### PR TITLE
Ignore new weights in fitting

### DIFF
--- a/beast/examples/phat_small/regress_check.py
+++ b/beast/examples/phat_small/regress_check.py
@@ -52,7 +52,6 @@ def hdf5diff(fname1, fname2):
                             hd.add_nonzero_match(sname)
                 else:
                     for cname in all_names:
-                        print(cname)
                         if cname in all_namesb:
                             if np.sum(hdfa[sname][cname]
                                       - hdfb[sname][cname]) != 0:

--- a/beast/physicsmodel/models.py
+++ b/beast/physicsmodel/models.py
@@ -84,8 +84,8 @@ def make_iso_table(outname, logtmin=6.0, logtmax=10.13, dlogt=0.05,
         can handle)
     """
     if oiso is None: 
-        #oiso = isochrone.PadovaWeb()
-        oiso = isochrone.PadovaWeb(modeltype='parsec12s')
+        oiso = isochrone.PadovaWeb()
+        #oiso = isochrone.PadovaWeb(modeltype='parsec12s')
         #oiso = isochrone.MISTWeb()
         
     t = oiso._get_t_isochrones(max(6.0, logtmin), min(10.13, logtmax), dlogt, z)

--- a/beast/plotting/plot_indiv_fit.py
+++ b/beast/plotting/plot_indiv_fit.py
@@ -24,7 +24,7 @@ from astropy.io import fits
 from astropy import units as ap_units
 from astropy.coordinates import SkyCoord as ap_SkyCoord
 
-from .beastplotlib import initialize_parser
+from beastplotlib import initialize_parser
 
 def disp_str(stats, k, keyname):
     dvals = [stats[keyname+'_p50'][k],


### PR DESCRIPTION
Needed to ignore the new grid_weight and prior_weight columns in the BEAST model grid.
Also minor changes to get regress_check.py and plot_indiv_fit.py to work.