### PR TITLE
Updated beast_dev doc /wrt setting upstream on new fork

### DIFF
--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -60,7 +60,7 @@ Fork the BEAST distro
 
   .. code:: shell
 	    
-     $ git remote set-url --add upstream https://github.com/karllark/beast.git
+     $ git remote add upstream https://github.com/karllark/beast.git
  
    
 Adding Branches


### PR DESCRIPTION
The correct command is -
git remote add upstream https://github.com/karllark/beast.git