### PR TITLE
Code Corrections: SMC ExtCurve, Isochrone Min logAge

### DIFF
--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -406,9 +406,10 @@ class Gordon03_SMCBar(ExtinctionLaw):
                      ( ((xspluv) ** 2 - (x0 ** 2)) ** 2 + (gamma ** 2) *
                        ((xspluv) ** 2 ))
             
-            # FUV portion  
+        # FUV portion  
+        ind = np.where(x >= 5.9)
+        if np.size(ind) > 0:
             if draine_extend:
-                ind = np.where(x >= 5.9)
                 dfname = libdir+'SMC_Rv2.74_norm.txt'
                 l_draine, k_draine = np.loadtxt(dfname,usecols=(0,1),unpack=True)
                 dind = np.where((1./l_draine) >= 5.9)

--- a/beast/physicsmodel/models.py
+++ b/beast/physicsmodel/models.py
@@ -86,7 +86,7 @@ def make_iso_table(outname, oiso=None, logtmin=6.0, logtmax=10.13, dlogt=0.05,
     if oiso is None: 
         oiso = isochrone.PadovaWeb()
         
-    t = oiso._get_t_isochrones(max(6.0, logtmin), min(10.13, logtmax), dlogt, z)
+    t = oiso._get_t_isochrones(max(5.0, logtmin), min(10.13, logtmax), dlogt, z)
     t.header['NAME'] = '{0} Isochrones'.format('_'.join(outname.split('_')[:-1]))
 
     t.write(outname)

--- a/beast/physicsmodel/stars/isochrone.py
+++ b/beast/physicsmodel/stars/isochrone.py
@@ -656,7 +656,7 @@ class MISTWeb(Isochrone):
         """
 
         if not hasattr(Z, '__iter__'):
-            iso_table = mist.get_t_isochrones(max(6.0, logtmin), min(10.13, logtmax), dlogt,
+            iso_table = mist.get_t_isochrones(max(5.0, logtmin), min(10.13, logtmax), dlogt,
                                               v_div_vcrit=self.rotation,
                                               FeH_value=np.log10(Z/self.Zref))
             iso_table.header['NAME'] = 'MESA/MIST Isochrones'


### PR DESCRIPTION
Two Edits:

1) SMC extinction curve (`Gordon03_SMCBar()`) -- and therefore `Gordon16_RvFALaw()` suffered from an implementation error concerning the application of C_4*F(x) term of the extinction curve.  When `draine_extend=False`, code was applying term to full UV portion of curve at lam < 2700 Ang (x > 3.7 um^-1) rather than only at x > 5.9 um^-1.  This error is caused by the `ind` index selection not being properly redefined for the `else` block. This plot to shows the effect of bug to the SMC curve, and the corrected version:
![edit_smccurvecorrection](https://user-images.githubusercontent.com/2006101/27242521-7e418894-5292-11e7-84d3-14e575c4d4ce.png)

2) Minor edits to enable logA values down to 5.0 as allowed by MIST isochrones.
