### PR TITLE
update URL in ezpadova parsec.py

### DIFF
--- a/beast/physicsmodel/stars/ezpadova/parsec.py
+++ b/beast/physicsmodel/stars/ezpadova/parsec.py
@@ -248,7 +248,7 @@ def __query_website(d):
     aa = re.compile('output\d+')
     fname = aa.findall(c)
     if len(fname) > 0:
-        url = '{0}/~lgirardi/tmp/{1}.dat'.format(webserver, fname[0])
+        url = '{0}/tmp/{1}.dat'.format(webserver, fname[0])
         print('Downloading data...{0}'.format(url))
         bf = urlopen(url)
         r = bf.read()


### PR DESCRIPTION
The URL for the padova isochrones on Leo Girardi's website changed, so this fixes parsec.py (in the ezpadova package) to go to the correct place.