### PR TITLE
Fix: mass_prior_weights uninitialized

### DIFF
--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -80,6 +80,7 @@ def compute_age_mass_metallicity_weights(_tgrid, **kwargs):
                 # must be a single mass for this age,z combination
                 # set mass weight to zero to remove this point from the grid
                 mass_grid_weights = np.zeros(1)
+                mass_prior_weights = np.zeros(1)
 
             # apply both the mass and age weights  
             for i, k in enumerate(aindxs):


### PR DESCRIPTION
I was playing around a bit and came across this bug.

mass_prior_weights is not initialized in the 'else' section of the 'if' block. It is then used in the for loop below it. If the 'else' section is entered the first time the 'if' block is evaluated, this leaves mass_prior_weights uninitialized, crashing the program with an error.

Fix suggested: Set to np.zeros(1), just like mass_grid_weights. Would this produce correct behaviour?
