### PR TITLE
Add optional redshift parameter

### DIFF
--- a/beast/examples/metal_production/datamodel.py
+++ b/beast/examples/metal_production/datamodel.py
@@ -127,6 +127,9 @@ absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 # distance modulus to the galaxy
 distanceModulus = 18.5 * units.mag
 
+# redshift of galaxy
+redshift = 0.000875 # LMC redshift from SIMBAD
+
 ################
 
 ### Stellar grid definition

--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -110,12 +110,18 @@ if __name__ == '__main__':
         else:
             extra_kwargs = None
 
+        if hasattr(datamodel, 'redshift'):
+            redshift = datamodel.redshift
+        else:
+            redshift = 0
+
         # generate the spectral library (no dust extinction)
         (spec_fname, g_spec) = make_spectral_grid(
             datamodel.project,
             oiso,
             osl=datamodel.osl,
             distance=distance,
+            redshift=redshift,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights

--- a/beast/examples/phat_small/datamodel.py
+++ b/beast/examples/phat_small/datamodel.py
@@ -121,6 +121,9 @@ absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 # distance modulus to the galaxy
 distanceModulus = 24.47 * units.mag
 
+# redshift of galaxy
+redshift = -0.001 # M31 blueshift from SIMBAD
+
 ################
 
 ### Stellar grid definition

--- a/beast/examples/phat_small/run_beast.py
+++ b/beast/examples/phat_small/run_beast.py
@@ -84,12 +84,18 @@ if __name__ == '__main__':
         else:
             extra_kwargs = None
 
+        if hasattr(datamodel, 'redshift'):
+            redshift = datamodel.redshift
+        else:
+            redshift = 0
+
         # generate the spectral library (no dust extinction)
         (spec_fname, g_spec) = make_spectral_grid(
             datamodel.project,
             oiso,
             osl=datamodel.osl,
             distance=distance,
+            redshift=redshift,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights

--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -69,6 +69,7 @@ def make_iso_table(project, oiso=None, logtmin=6.0, logtmax=10.13, dlogt=0.05,
 
 def make_spectral_grid(project, oiso, osl=None, bounds={}, distance=None,
                        verbose=True, spec_fname=None, filterLib=None,
+                       redshift=0,
                        add_spectral_properties_kwargs=None, **kwargs):
     """
     The spectral grid is generated using the stellar parameters by
@@ -90,6 +91,10 @@ def make_spectral_grid(project, oiso, osl=None, bounds={}, distance=None,
         Distance at which models should be shifted
         0 means absolute magnitude.
         Expecting pc units
+
+    redshift: float
+        Redshift to which wavelengths should be shifted
+        Default is 0 (rest frame)
 
     spec_fname: str
         full filename to save the spectral grid into
@@ -145,6 +150,7 @@ def make_spectral_grid(project, oiso, osl=None, bounds={}, distance=None,
         # seds already at 10 pc, need multiplcation by the square of the ratio
         # to this distance
         if hasattr(g, 'writeHDF'):
+            g.lamb = g.lamb * (1. + redshift)
             if distance is not None:
                 g.seds = g.seds / (0.1 * _distance) ** 2
             if add_spectral_properties_kwargs is not None:
@@ -155,8 +161,9 @@ def make_spectral_grid(project, oiso, osl=None, bounds={}, distance=None,
             g.writeHDF(spec_fname)
         else:
             for gk in g:
+                gk.lamb = gk.lamb * (1. + redshift)
                 if distance is not None:
-                    gk.seds = gk.seds / (0.1 * _distance) ** 2
+                   gk.seds = gk.seds / (0.1 * _distance) ** 2
                 if add_spectral_properties_kwargs is not None:
                     gk = creategrid.add_spectral_properties(gk,
                                             nameformat=nameformat,

--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -163,7 +163,7 @@ def make_spectral_grid(project, oiso, osl=None, bounds={}, distance=None,
             for gk in g:
                 gk.lamb = gk.lamb * (1. + redshift)
                 if distance is not None:
-                   gk.seds = gk.seds / (0.1 * _distance) ** 2
+                    gk.seds = gk.seds / (0.1 * _distance) ** 2
                 if add_spectral_properties_kwargs is not None:
                     gk = creategrid.add_spectral_properties(gk,
                                             nameformat=nameformat,


### PR DESCRIPTION
This pull request implements redshift as an optional parameter in `datamodel.py`. The wavelength array in `make_spectral_grid` is simply multiplied by (1 + redshift), with a default redshift of 0. I've tested it on both current examples.

If there is a better way to implement this, or if keeping the rest frame wavelengths somewhere in the spectral grid is important, please let me know!