### PR TITLE
WIP: First step: Make run_beast.py runnable from another directory

### DIFF
--- a/beast/examples/phat_small/run_beast.py
+++ b/beast/examples/phat_small/run_beast.py
@@ -33,7 +33,23 @@ from beast.physicsmodel.grid import FileSEDGrid
 from beast.tools import verify_params
 
 
-import datamodel
+# import datamodel
+# print("Import statement gets datamodel from {}.".format(datamodel.__file__))
+# print("Distances are {}".format(datamodel.distances))
+
+# import runpy, os
+
+# print("runpy.run_path runs code from {}.".format(datamodelfile))
+# datamodel_globals = runpy.run_path(datamodelfile)
+# print("Distances are {}".format(datamodel_globals['distances']))
+
+# https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
+import importlib.util, os
+datamodelfile = os.path.join(os.getcwd(), 'datamodel.py')
+spec = importlib.util.spec_from_file_location("datamodel", datamodelfile)
+datamodel = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(datamodel)
+print("Project name: {}".format(datamodel.project))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some example code showing how a module can be imported from an absolute
path, in this case the current working directory.

There is another way commented out which uses runpy, which returns the datamodel namespace as a dictionary.

This PR can be considered merge-ready once it has addressed all the issues mentioned in #187.