### PR TITLE
Pip installable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,6 @@ matrix:
         - os: osx
           env: SETUP_CMD='test --remote-data'
 
-        # Do a coverage test. with python version 3.5
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12 SETUP_CMD='test --remote-data --coverage'
-
         # Do a coverage test.
         - os: linux
           env: SETUP_CMD='test --remote-data --coverage'
@@ -118,10 +114,6 @@ matrix:
         # Try MacOS X including the remote data tests
         - os: osx
           env: SETUP_CMD='test --remote-data'
-
-        # Do a coverage test.
-        - os: linux
-          env: SETUP_CMD='test --remote-data --coverage'
 
         - os: linux
           env: ASTROPY_VERSION=development

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 1.1 (unreleased)
 ================
 
-- no changes yet
+- pip installable version
+- library files in BEAST_PATH, ~/.beast, or in src directory beast/beast/libs
+- automated regression testing
 
 1.0 (2017-12-29)
 ================

--- a/beast/config.py
+++ b/beast/config.py
@@ -1,42 +1,46 @@
 from __future__ import print_function
 import os
+from os.path import expanduser
 import inspect
 
 # Set to use some C code instead of pure python to speed up the computations.
 # If False, only numpy and python code are used.
-#__WITH_C_LIBS__ = True
+# __WITH_C_LIBS__ = True
 __WITH_C_LIBS__ = False
 
-#numexpr -- optimized multi-threaded numpy evaluations
+# numexpr -- optimized multi-threaded numpy evaluations
 __USE_NUMEXPR__ = True
 
 # Default number of threads to use when parallel computing
-#__NTHREADS__ = 6
+# __NTHREADS__ = 6
 __NTHREADS__ = 1
 
-#directories
-__ROOT__ = '/'.join(os.path.abspath(inspect.getfile(inspect.currentframe())).split('/')[:-1])
-libsdir = __ROOT__ + '/libs/'
+# library directory
+beast_envvar = "BEAST_LIBS"
+userhome = expanduser("~")
+ploc = userhome + "/.beast/"
+if beast_envvar in os.environ:
+    __ROOT__ = os.environ[beast_envvar]
+elif os.path.isdir(ploc):
+    __ROOT__ = ploc
+else:
+    __ROOT__ = '/'.join(os.path.abspath(inspect.getfile(inspect.currentframe())).split('/')[:-1])
+    __ROOT__ += '/libs/'
 
 # Online libraries
 # will be replaced by a more flexible support (JSON is easy!)
-libs_server = 'http://chex.astro.washington.edu:7777/beastlibs/'
+libs_server = 'http://www.stsci.edu/~kgordon/beast/'
 libs = dict(
-    vega     = 'vega.hd5',
-    filters  = 'filters.hd5',
-    #basel22p = 'BaSeL_v2.2.pegase.grid.fits',
-    #elodie31 = 'Elodie_v3.1.grid.fits',
-    kurucz04 = 'kurucz2004.grid.fits',
-    tlusty09 = 'tlusty.lowres.grid.fits',
-    hstcovar = 'hst_whitedwarf_frac_covar.fits'
-    #specgrid = 'basel_padova2010.spectralgrid.fits',
-    #sedgrid  = 'PHATSEDs_basel_padovaiso.fits'
-    #kuruczgrid = 'kurucz2004.grid.fits',
-    #padovaiso='padova2010.iso.fits',
-    #kuruczisog  = 'stellib_kurucz2004_padovaiso.spectralgrid.fits'
+    vega='vega.hd5',
+    filters='filters.hd5',
+    kurucz04='kurucz2004.grid.fits',
+    tlusty09='tlusty.lowres.grid.fits',
+    hstcovar='hst_whitedwarf_frac_covar.fits'
+    # basel22p = 'BaSeL_v2.2.pegase.grid.fits',
+    # elodie31 = 'Elodie_v3.1.grid.fits'
 )
 
-#Make sure the configuration is coherent for the python installation
+# Make sure the configuration is coherent for the python installation
 try:
     import numexpr
     if not __USE_NUMEXPR__:
@@ -54,10 +58,11 @@ try:
     tables.parameters.MAX_BLOSC_THREADS = __NTHREADS__
     tables.set_blosc_max_threads(__NTHREADS__)
 except ImportError:
-    pass 
+    pass
+
 
 def printConfig():
-    print(""" ============ pyPEGASE defaut configuration ===========
+    print(""" ============ BEAST defaut configuration ===========
     * Including C-code during computations: %s
     * Parallel processing using %d threads
     """ % (__WITH_C_LIBS__, __NTHREADS__))

--- a/beast/observationmodel/noisemodel/absflux_covmat.py
+++ b/beast/observationmodel/noisemodel/absflux_covmat.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from astropy.io.fits import getdata    
+from astropy.io.fits import getdata
 
 from .. import phot
 from ...config import __ROOT__
@@ -51,7 +51,7 @@ def hst_frac_matrix(filters, spectrum=None, progress=True,
 
     # get the HST fractional covariance matrix at spectroscopic resolution
     if hst_fname is None:
-        hst_fname = __ROOT__+'/libs/hst_whitedwarf_frac_covar.fits'
+        hst_fname = __ROOT__+'/hst_whitedwarf_frac_covar.fits'
 
     hst_data = getdata(hst_fname,1)
 
@@ -76,7 +76,7 @@ def hst_frac_matrix(filters, spectrum=None, progress=True,
 
     for i in range(n_filters):
         mult_image[:,:,i] = image_ones*flist[i].transmit
-        
+
     # handle single spectrum or many spectra
     if len(spectrum[1].shape) > 1:
         n_models = spectrum[1].shape[0]
@@ -99,7 +99,7 @@ def hst_frac_matrix(filters, spectrum=None, progress=True,
         else:
             interp_spectrum = np.interp(waves, spectrum[0], spectrum[1][k,:])
 
-    
+
         for i in range(n_filters):
             mult_image_spec[:,:,i] = mult_image[:,:,i]*interp_spectrum
 
@@ -115,7 +115,7 @@ def hst_frac_matrix(filters, spectrum=None, progress=True,
         for i in range(n_filters):
             for j in range(0,i):
                 frac_covar_bands[i,j] = frac_covar_bands[j,i]
-                
+
         # add the term accounting for the uncertainty in the overall
         #  zero point of the flux scale
         #  (e.g., uncertainty in Vega at 5555 A)

--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -26,8 +26,8 @@ from scipy.integrate import trapz
 from ..tools.decorators import timeit
 from ..config import __ROOT__
 
-__default__      = __ROOT__ + '/libs/filters.hd5'
-__default_vega__ = __ROOT__ + '/libs/vega.hd5'
+__default__      = __ROOT__ + '/filters.hd5'
+__default_vega__ = __ROOT__ + '/vega.hd5'
 
 # this is used to convert from bolometric luminosities to abs fluxes
 # object to 10parsecs -- abs mag.
@@ -695,23 +695,3 @@ def appendVegaFilter(filtInst, VegaLib=__default_vega__):
     sedTab.flush()
     vtab.close()
     print('% {0}: Filter {1} added to {2}'.format(sys.argv[0], filtInst.name, VegaLib))
-
-
-def xxtest(absFlux=True):
-    """ Test units """
-    gridfile = 'libs/stellib_kurucz2004_padovaiso.spectralgrid.fits'
-    filter_names = 'hst_wfc3_f275w hst_wfc3_f336w hst_acs_wfc_f475w hst_acs_wfc_f814w hst_wfc3_f110w hst_wfc3_f160w'.upper().split()
-
-    from . import grid
-
-    #Load the initial model grid
-    with timeit('Loading Grid, %s' % gridfile):
-        g0   = grid.FileSpectralGrid(gridfile)
-        lamb = g0.lamb
-
-    # Load the filters
-    with timeit('Loading Filters (with interpolation)'):
-        flist = load_filters(filter_names, interp=True, lamb=lamb)
-
-    with timeit('SED integrations over %d ' % g0.grid.nrows):
-        return extractSEDs(g0, flist, absFlux=absFlux)

--- a/beast/observationmodel/vega.py
+++ b/beast/observationmodel/vega.py
@@ -16,7 +16,7 @@ class Vega(object):
     """ Class that handles vega spectrum and references.
     This class know where to find the Vega synthetic spectrum (Bohlin 2007) in
     order to compute fluxes and magnitudes in given filters
-    
+
     An instance can be used as a context manager as::
 
         filters = ['HST_WFC3_F275W', 'HST_WFC3_F336W', 'HST_WFC3_F475W', \
@@ -30,7 +30,7 @@ class Vega(object):
     def __init__(self, source=None):
         """ Constructor """
         if source is None:
-            source = '{0}/libs/vega.hd5'.format(__ROOT__)
+            source = '{0}/vega.hd5'.format(__ROOT__)
         self.source = source
         self.hdf = None
 

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -15,7 +15,7 @@ from ...config import __ROOT__
 __all__ = ['ExtinctionLaw', 'Cardelli89', 'Fitzpatrick99',
            'Gordon03_SMCBar', 'Gordon16_RvFALaw']
 
-libdir = __ROOT__ + '/libs/'
+libdir = __ROOT__
 
 class ExtinctionLaw(object):
     """
@@ -23,7 +23,7 @@ class ExtinctionLaw(object):
 
     Parameters
     ----------
-    
+
     Attributes
     ----------
     name : 'string'
@@ -33,7 +33,7 @@ class ExtinctionLaw(object):
         self.name = 'None'
 
     def function(self, lamb, *arg, **kwargs):
-        """ 
+        """
         function to provide extinction curve given wavelength(s)
         """
         raise NotImplementedError
@@ -88,7 +88,7 @@ class ExtinctionLaw(object):
         return self.function(*args, **kwargs)
 
     def isvalid(self, *args, **kwargs):
-        """ 
+        """
         Check if the current arguments are in the validity domain of the law
         Must be redefined if any restriction applies to the law
         """
@@ -101,7 +101,7 @@ class Cardelli89(ExtinctionLaw):
     From Cardelli, Clayton, and Mathis (1989, ApJ, 345, 245).
 
     Fitzpatrick99 should be used instead except for historical puposes
-    as this newer law is based on 10x more observations and a better 
+    as this newer law is based on 10x more observations and a better
     treatment of the optical/NIR photometry based portion of the curves.
     """
     def __init__(self):
@@ -315,7 +315,7 @@ class Fitzpatrick99(ExtinctionLaw):
                 dfname = libdir+'MW_Rv%s_ext.txt' % ("{0:.1f}".format(Rv))
                 l_draine, k_draine = np.loadtxt(dfname, usecols=(0,1),
                                                 unpack=True)
-            else: 
+            else:
                 add, = np.where(diffRv < 0.)
                 Rv1 = tmprvs[add[0]-1]
                 Rv2 = tmprvs[add[0]]
@@ -325,9 +325,9 @@ class Fitzpatrick99(ExtinctionLaw):
                 dfname = libdir+'MW_Rv%s_ext.txt' % ("{0:.1f}".format(Rv2))
                 l_draine, k_draine2 = np.loadtxt(dfname, usecols=(0,1),
                                                  unpack=True)
-                frac = diffRv[add[0]-1]/(Rv2-Rv1) 
+                frac = diffRv[add[0]-1]/(Rv2-Rv1)
                 k_draine = (1. - frac)*k_draine1 + frac*k_draine2
-            
+
             dind = np.where((1./l_draine) >= 5.9)
             k[fuvind] = interp(x[fuvind],1./l_draine[dind][::-1],
                                k_draine[dind][::-1])
@@ -340,10 +340,10 @@ class Fitzpatrick99(ExtinctionLaw):
 
 
 class Gordon03_SMCBar(ExtinctionLaw):
-    """ 
+    """
     Gordon03 SMCBar extinction curve
 
-    Average of 4 SMCBar extinction curves from 
+    Average of 4 SMCBar extinction curves from
     Gordon et al. 2003 (ApJ, 594, 279).
 
     Note that Rv has no impact on this law: according to Gordon et al (2003),
@@ -389,7 +389,7 @@ class Gordon03_SMCBar(ExtinctionLaw):
 
         # set Rv explicitly to the fixed value
         Rv = self.Rv
-            
+
         c1 = -4.959 / Rv
         c2 = 2.264 / Rv
         c3 = 0.389 / Rv
@@ -412,8 +412,8 @@ class Gordon03_SMCBar(ExtinctionLaw):
             yspluv = 1.0 + c1 + (c2 * xspluv) + c3 * ((xspluv) ** 2) / \
                      ( ((xspluv) ** 2 - (x0 ** 2)) ** 2 + (gamma ** 2) *
                        ((xspluv) ** 2 ))
-            
-        # FUV portion  
+
+        # FUV portion
         ind = np.where(x >= 5.9)
         if np.size(ind) > 0:
             if draine_extend:
@@ -453,13 +453,13 @@ class Gordon03_SMCBar(ExtinctionLaw):
 
 
 class Gordon16_RvFALaw(ExtinctionLaw):
-    """ 
+    """
     Gordon16 RvFA extinction law
 
-    Mixture of Milky Way R(V) dependent extinction law and 
+    Mixture of Milky Way R(V) dependent extinction law and
     Gordon et al. (2003) SMCBar average extinction curve.
 
-    This extinction curve model encompasses the average behavior of 
+    This extinction curve model encompasses the average behavior of
     measured extinction curves in the Milky Way, LMC, and SMC.
 
     Implemented as a mixture between Fitzpatrick99 and Gordon03_SMCBar
@@ -512,13 +512,13 @@ class Gordon16_RvFALaw(ExtinctionLaw):
         return f_A*k_A + (1. - f_A)*k_B
 
     def get_Rv_A(self, Rv, f_A=0.5):
-        """ 
+        """
         Calculate the R(V) of the A component given the R(V) of the mixture
 
         Rv_A is such that:
 
                 1 / Rv = f_A / Rv_A + (1 - f_A) / Rv_B
-        
+
                 Rv_A = 1. / (1. / (Rv * f_A) - (1. - f_A) / (f_A * Rv_B))
 
                 where Rv_B = 2.74 by definition (see Gordon03_SMCBar)
@@ -541,13 +541,13 @@ class Gordon16_RvFALaw(ExtinctionLaw):
         return 1. / (1. / (Rv * f_A) - (1. - f_A) / (f_A * Rv_B))
 
     def get_Rv(self, Rv_A, f_A=0.5):
-        """ 
+        """
         Calculate the Rv of the mixture law given R(V) of the A component
 
         Rv_A is such that:
 
                 1 / Rv = f_A / Rv_A + (1 - f_A) / Rv_B
-        
+
                 where Rv_B = 2.74 by definition (see Gordon03_SMCBar)
 
         Parameters

--- a/beast/physicsmodel/stars/isochrone.py
+++ b/beast/physicsmodel/stars/isochrone.py
@@ -42,7 +42,7 @@ class Isochrone(object):
         return numpy.log10(metal / 0.02)
 
     def FeHtometal(self, feh):
-        """ 
+        """
         Convert Z to [Fe/H] values
         """
         return 10 ** feh * 0.02
@@ -119,7 +119,7 @@ class Isochrone(object):
 class padova2010(Isochrone):
     def __init__(self):
         self.name = 'Padova 2010 (Marigo 2008 + Girardi 2010)'
-        self.source = __ROOT__ + '/libs/padova2010.iso.fits'
+        self.source = __ROOT__ + '/padova2010.iso.fits'
         self._load_table_(self.source)
         self.ages = 10 ** numpy.unique(self.data['logA'])
         self.Z    = numpy.unique(self.data['Z'])
@@ -156,7 +156,7 @@ class padova2010(Isochrone):
         #    _age = int(age.to('yr').magnitude)
         #else:
         #    _age = int(age * inputUnit.to('yr').magnitude)
-            
+
         assert ((metal is not None) | (FeH is not None)), "Need a chemical par. value."
 
         if (metal is not None) & (FeH is not None):
@@ -213,7 +213,7 @@ class padova2010(Isochrone):
 class pegase(Isochrone):
     def __init__(self):
         self.name   = 'Pegase.2 (Fioc+1997)'
-        self.source = __ROOT__ + '/libs/pegase.iso.hd5'
+        self.source = __ROOT__ + '/pegase.iso.hd5'
         self.data   = tables.openFile(self.source)
         self.ages   = numpy.sort(numpy.asarray([k.attrs.time for k in self.data.root.Z02]) * 1e6)
         self.Z      = numpy.asarray([ float('0.' + k[1:]) for k in self.data.root._g_listGroup(self.data.getNode('/'))[0]])
@@ -438,7 +438,7 @@ class PadovaWeb(Isochrone):
 #            _age = int(age.to('yr').magnitude)
 #        else:
 #            _age = int(age * inputUnit.to('yr').magnitude)
-            
+
         assert ((metal is not None) | (FeH is not None)), "Need a chemical par. value."
 
         if (metal is not None) & (FeH is not None):
@@ -467,7 +467,7 @@ class PadovaWeb(Isochrone):
             iso_table.remove_columns(['Age', 'logTe', 'Mini', 'Mass', 'label'])
             # Remove age-specific Z, rename Zini as Z
             iso_table.remove_columns(['Z'])
-            iso_table.add_column('Z', iso_table['Zini'][:]) 
+            iso_table.add_column('Z', iso_table['Zini'][:])
             iso_table.remove_columns(['Zini'])
 
         else:
@@ -477,7 +477,7 @@ class PadovaWeb(Isochrone):
             iso_table.add_column('logT', iso_table['logTe'][:])
             iso_table.add_column('logg', iso_table['logG'][:])
             iso_table.remove_columns(['logageyr', 'logLLo', 'logTe', 'logG'])
-            
+
         # Remove phot columns and unnecessary properties
         filternames = "U UX B BX V R I J H K L M".split()
         theorycols = ['C/O', 'M_hec', 'int_IMF', 'period', 'pmode',
@@ -523,7 +523,7 @@ class PadovaWeb(Isochrone):
                 iso_table = iso_table.selectWhere('*', cond)
             else:
                 print("No bad point filtering for PARSEC models.")
-        
+
         return iso_table
 
     def _get_t_isochrones(self, logtmin, logtmax, dlogt, Z=0.0152):
@@ -542,7 +542,7 @@ class PadovaWeb(Isochrone):
 
         Z: float or sequence
             single value of list of values of metalicity Z
- 
+
         returns
         -------
         tab: eztable.Table
@@ -557,7 +557,7 @@ class PadovaWeb(Isochrone):
 
             # rename cols, remove phot and other unnecessary cols
             iso_table = self._clean_cols(iso_table)
-            
+
             # filter iso data: pre-ms and bad points
             iso_table = self._filter_iso_points(iso_table,
                                                 filterPMS=self.filterPMS, filterBad=self.filterBad)
@@ -579,7 +579,7 @@ class MISTWeb(Isochrone):
         self.Zref = Zref
         self.rotation = rotation
 
-    def _get_isochrone(self, age, metal=None, FeH=None, 
+    def _get_isochrone(self, age, metal=None, FeH=None,
                        *args, **kwargs):
         """ Retrieve isochrone from the original source
             internal use to adapt any library
@@ -618,7 +618,7 @@ class MISTWeb(Isochrone):
         iso_table.add_column('stage', iso_table['phase'][:])
         iso_table.remove_columns(['log10_isochrone_age_yr', 'log_Teff', 'log_L', 'log_g',
                                   'initial_mass', 'star_mass', 'stage'])
-        
+
         # Remove phot columns and unnecessary properties
         extracol1="star_mdot he_core_mass c_core_mass log_LH log_LHe log_R".split()
         extracol2="log_center_T log_center_Rho center_gamma center_h1 center_he4 center_c12".split()
@@ -662,7 +662,7 @@ class MISTWeb(Isochrone):
 
         Z: float or sequence
             single value of list of values of metalicity Z
- 
+
         returns
         -------
         tab: eztable.Table
@@ -679,10 +679,10 @@ class MISTWeb(Isochrone):
 
             # rename cols, remove phot and other unnecessary cols
             iso_table = self._clean_cols(iso_table)
-            
+
         else:
             iso_table = self._get_t_isochrones(logtmin, logtmax, dlogt, Z[0])
-            iso_table.header['NAME'] = 'MESA/MIST Isochrones'            
+            iso_table.header['NAME'] = 'MESA/MIST Isochrones'
 
             if len(Z) > 1:
                 more = [ self._get_t_isochrones(logtmin, logtmax, dlogt, Zk).data for Zk in Z[1:] ]

--- a/beast/physicsmodel/stars/stellib.py
+++ b/beast/physicsmodel/stars/stellib.py
@@ -31,13 +31,13 @@ sig_stefan = constants.sigma_sb.value
 rsun = constants.R_sun.value
 
 config = {
-    'basel_2.2_pegase': __ROOT__ + '/libs/BaSeL_v2.2.pegase.grid.fits',
-    'elodie_3.1': __ROOT__ + '/libs/Elodie_v3.1.grid.fits',
-    'kurucz': __ROOT__ + '/libs/kurucz2004.grid.fits',
-    'tlusty': __ROOT__ + '/libs/tlusty.lowres.grid.fits',
-    'btsettl': __ROOT__ + '/libs/bt-settl.lowres.grid.fits',
-    'btsettl_medres': __ROOT__ + '/libs/bt-settl.medres.grid.fits',
-    'munari': __ROOT__ + '/libs/atlas9-munari.hires.grid.fits'
+    'basel_2.2_pegase': __ROOT__ + '/BaSeL_v2.2.pegase.grid.fits',
+    'elodie_3.1': __ROOT__ + '/Elodie_v3.1.grid.fits',
+    'kurucz': __ROOT__ + '/kurucz2004.grid.fits',
+    'tlusty': __ROOT__ + '/tlusty.lowres.grid.fits',
+    'btsettl': __ROOT__ + '/bt-settl.lowres.grid.fits',
+    'btsettl_medres': __ROOT__ + '/bt-settl.medres.grid.fits',
+    'munari': __ROOT__ + '/atlas9-munari.hires.grid.fits'
 }
 
 __all__ = ['Stellib', 'CompositeStellib', 'Kurucz', 'Tlusty',
@@ -514,7 +514,7 @@ class Stellib(object):
 
     def gen_spectral_grid_from_given_points(self, pts, bounds=dict(dlogT=0.1,
                                                                    dlogg=0.3)):
-        """ 
+        """
         Reinterpolate a given stellar spectral library on to an Isochrone grid
 
         Parameters
@@ -534,7 +534,7 @@ class Stellib(object):
         Returns
         -------
         g: SpectralGrid
-            Spectral grid (in memory) containing the requested list of 
+            Spectral grid (in memory) containing the requested list of
             stars and associated spectra
         """
         # Step 0: prepare outputs
@@ -557,12 +557,12 @@ class Stellib(object):
         # stores the grid weights separately (initialize to 1)
         #   these weights alone provide flat priors on all fit parameters
         _grid['grid_weight'] = np.full(ndata, 1.0, dtype=float)
-        
+
         # index to the grid
         # useful to setup here as it will then be cleanly propagated
         #   to the SED grid
         _grid['specgrid_indx'] = np.full(ndata, 0.0, dtype=float)
-                    
+
         specs = np.empty( (ndata, len(self.wavelength)), dtype=float )
 
         # copy meta data of pts into the resulting structure
@@ -618,7 +618,7 @@ class Stellib(object):
         # populate the specgrid index
         _grid['specgrid_indx'] = np.arange(len(_grid['specgrid_indx']),
                                            dtype=np.int64)
-        
+
         # ship
         g = SpectralGrid(lamb, seds=specs, grid=Table(_grid), header=header, backend='memory')
 
@@ -731,7 +731,7 @@ class CompositeStellib(Stellib):
             * second, if points are not found in strict mode, the boundary is
               relaxed and a new search is made.
 
-        Each point is associated to the first library matching the above 
+        Each point is associated to the first library matching the above
             conditions.
 
         Parameters
@@ -748,7 +748,7 @@ class CompositeStellib(Stellib):
         returns
         -------
         res: ndarray(dtype=int)
-            a ndarray, 0 meaning no library covers the point, and 1, ... n, 
+            a ndarray, 0 meaning no library covers the point, and 1, ... n,
                for the n-th library
         """
         xy = np.asarray(xypoints)
@@ -828,7 +828,7 @@ class CompositeStellib(Stellib):
         returns
         -------
         b: ndarray[float, ndim=2]
-            (closed) boundary points: [logg, Teff] (or [Teff, logg] is swap 
+            (closed) boundary points: [logg, Teff] (or [Teff, logg] is swap
             is True)
 
         .. note::
@@ -884,7 +884,7 @@ class CompositeStellib(Stellib):
         -------
         (osl, r): tuple
             osl: is the library index starting from 1. 0 means no coverage.
-            r: is the result from interp call on the corresponding library. 
+            r: is the result from interp call on the corresponding library.
             a 3 to 12 star indexes and associated weights
         """
         dlogT = bounds.get('dlogT', 0.1)
@@ -951,7 +951,7 @@ class CompositeStellib(Stellib):
         -------
         (osl, r): tuple
             osl is the library index starting from 1. 0 means no coverage.
-            r is the result from interp call on the corresponding library. 
+            r is the result from interp call on the corresponding library.
             a 3 to 12 star indexes and associated weights
         """
         dlogT = bounds.get('dlogT', 0.1)
@@ -1023,7 +1023,7 @@ class CompositeStellib(Stellib):
         returns
         -------
         s: ndarray
-            an array containing the composite spectrum reinterpolated onto 
+            an array containing the composite spectrum reinterpolated onto
             self.wavelength
 
         .. note::
@@ -1051,7 +1051,7 @@ class CompositeStellib(Stellib):
 
     def gen_spectral_grid_from_given_points(self, pts,
                                             bounds=dict(dlogT=0.1, dlogg=0.3)):
-        """ 
+        """
         Reinterpolate a given stellar spectral library on to an Isochrone grid
 
         Parameters
@@ -1071,7 +1071,7 @@ class CompositeStellib(Stellib):
         Returns
         -------
         g: SpectralGrid
-            Spectral grid (in memory) containing the requested list of stars 
+            Spectral grid (in memory) containing the requested list of stars
             and associated spectra
         """
         dlogT = bounds.get('dlogT', 0.1)
@@ -1573,7 +1573,7 @@ class BTSettl(Stellib):
                 (3.60206 + dlogT, 5.5 + dlogg),
                 (3.60206 + dlogT, 6.0 + dlogg),
                 (3.41497 - dlogT, 6.0 + dlogg)]
-            
+
         return np.array(bbox)
 
     @property
@@ -1647,7 +1647,7 @@ class Munari(Stellib):
                 (3.98900 + dlogT, 2.0 - dlogg),
                 (3.98900 + dlogT, 5.0 + dlogg),
                 (3.54407 - dlogT, 5.0 + dlogg)]
-            
+
         return np.array(bbox)
 
     @property

--- a/beast/tools/get_libfile.py
+++ b/beast/tools/get_libfile.py
@@ -1,0 +1,20 @@
+# script to download the BEAST library files
+from shutil import copyfile
+
+from astropy.utils.data import download_file
+
+from beast.config import libs_server, libs, __ROOT__
+
+
+def _download_rename(filename, url_loc, local_loc):
+    """
+    Download a file and rename it to have correct name and location
+    """
+    fname_dld = download_file('%s%s' % (url_loc, filename))
+    copyfile(fname_dld, local_loc+filename)
+    return filename
+
+
+if __name__ == '__main__':
+    for ckey, clib in libs.items():
+        nfilename = _download_rename(clib, libs_server, __ROOT__)

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -1,3 +1,5 @@
+.. _beast_development:
+
 #################
 BEAST Development
 #################

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,8 +7,8 @@ Requirements
 
 Running the BEAST requires:
 
-- Python 2.7 or >=3.4
-- Astropy 1.3
+- Python >=3.4 (recommended) or 2.7 (still possible)
+- Astropy >=1.3
 
 In turn, Astropy depends on
 `other packages <http://docs.astropy.org/en/latest/install.html>`_ for
@@ -27,101 +27,131 @@ One easy way to obtain the above is through the AstroConda Python stack:
   you can use the `conda` command to install any other packages and create
   environments, etc.
 
-- Setup the AstroConda Channel:
+- Setup the AstroConda Channel::
 
-``$ conda config --add channels http://ssb.stsci.edu/astroconda``
+    $ conda config --add channels http://ssb.stsci.edu/astroconda
 
-- Install AstroConda with Python 3 (recommended):
+- Install AstroConda with Python 3 (recommended)::
 
-``$conda create -n astroconda stsci``
+    $conda create -n astroconda stsci
 
-- Install AstroConda with Python 2.7 (still possible):
+- Install AstroConda with Python 2.7 (still possible)::
 
-``$ conda create -n iraf27 python=2.7 stsci pyraf iraf``
+    $ conda create -n iraf27 python=2.7 stsci pyraf iraf
 
 - Make sure that the ``PyTables`` and ``hdf5`` packages are installed:
 
-``$ conda install -n astroconda (or iraf27) pytables``
-
-``$ conda install -n astroconda (or iraf27) hdf5``
+    $ conda install -n astroconda (or iraf27) pytables
+    $ conda install -n astroconda (or iraf27) hdf5
 
 
 Installing the BEAST
 ====================
 
-For the BEAST to work properly, you need to place a 'libs' directory containing
-files related to filters, photometry, stellar atmospheres, and in the future,
-stellar evolution models. See **Obtaining BEAST libraries** below.
+In addition to installing the code, library files also need to be installed.
+See :ref:`library-files`.
 
-Option 1
---------
+Using pip
+---------
 
-The following is the recommended option which will allow you to easily keep up
-with code updates. If additionally you would like to contribute to code
-enhancements, see Option 3 below.
+``beast`` can also be installed using pip::
 
-Places BEAST on your local computer as a clone of the
-`BEAST GitHub repository <https://github.com/BEAST-Fitting/beast>`_. To do this, go
-to the directory where you want to place the BEAST and type the following:
+    # from PyPI
+    $ pip install beast
 
-``$ git clone https://github.com/BEAST-Fitting/beast.git``
+    # if you already have an older version installed
+    $ pip install --upgrade beast
 
-This will create a directory named 'beast' containing the BEAST.
+    # from the master trunk on the repository, considered developmental code
+    $ pip install git+https://github.com/BEAST-Fitting/beast.git
 
-Option 2
---------
+From source
+-----------
 
-This option places BEAST in its current version on your local computer. One
-disadvantage is that you will have to manually obtain BEAST updates from the
-GitHub repository if you use this option.
+``beast`` can be installed from the source code in the normal
+python fashion after downloading it from the git repo::
 
-On the `BEAST GitHub homepage <https://github.com/BEAST-Fitting/beast>`_ click on
-the 'Clone or Download' button, then select 'Download ZIP'. Unzip the
-file in the desired directory.
+     $ python setup.py install
 
-Option 3
---------
+For developers
+--------------
 
 This option is suitable if you *plan to make code contributions* to the BEAST.
-See the :ref:'beast_development' for details.
+See the :ref:`beast_development` for details.
+
+.. _library-files:
 
 BEAST Library Files
 ===================
 
-For the BEAST to work properly, you need to place a 'libs' directory containing
-files related to filters, photometry, stellar atmospheres, and in the future
-stellar evolution models in the 'beast/beast' directory. Follow this link to
-download the 'libs' files.
+For the BEAST to work properly, you need to place a set of files in a
+directory.  These files contain information related to filters,
+stellar atmospheres, and in the future stellar evolution models.
+
+.. _library_loc:
+
+Location
+--------
+
+There are 3 possible locations for these files (in the order the code
+will search for them):
+
+1. in a directory designated by the BEAST_LIBS environment variable
+2. in the '.beast' directory in the home directory of the current user
+3. in the source code in 'beast/beast/libs'
+
+Manual download
+---------------
 
 <https://stsci.box.com/v/beastlibs>
+
+Script download
+---------------
+
+After installing the `beast`, run the following script and the library files
+will be downloaded into the location specified in :ref:`library_loc`::
+
+     $ beast/tools/get_libfiles.py
 
 
 Running Example
 ===============
 
-There is a small sample script named 'run_beast.py' located in
-'beast/beast/examples/phat_small' as a quick check to confirm that BEAST
-installation is working.
+You can find examples of BEAST runs in the
+<https://github.com/BEAST-Fitting/beast-examples>
+repository.
 
-In 'beast/beast/examples/phat_small', place a soft link named 'beast'
-pointing two levels up:
+Inside each example, there is a run_beast*.py script.
 
-``$ cd beast/beast/examples/phat_small``
+phat_small example
+------------------
 
-``$ ln -s ../../ beast``
+This example is based on a *very* small amount of PHAT old data.
+
+If the beast has not been installed (only downloaded from github), then
+In the 'phat_small' directory, place a soft link named 'beast' to where the
+beast code is located.  Specifically::
+
+    $ cd beast-examples/phat_small
+
+    $ ln -s beast_code_loc/beast/beast beast
 
 If you installed Python through AstroConda, first activate the correct
-AstroConda environment:
+AstroConda environment::
 
-``$ source activate astroconda``
+    $ source activate astroconda
 
-Verify that the current default Python is version 3:
+Verify that the current default Python is version 3::
 
-``$ python --version``
+    $ python --version
 
-Now try a sample BEAST run:
+Now try a sample BEAST run::
 
-``$ ./run_beast.py`` or ``$ python run_beast.py``
+    $ ./run_beast.py
+
+or::
+
+    $ python run_beast.py::
 
 Optionally, you can run BEAST with one, or a combination, of these arguments
 
@@ -136,9 +166,9 @@ For example: ``$ ./run_beast.py -h`` or ``$ ./run_beast.py -potf``
 
 If the BEAST is running correctly the second command should run without errors
 and should have written the output files into 'beast_example_phat/'. The result
-can be plotted using
+can be plotted using::
 
-``$ python beast/plotting/plot_indiv_fit.py beast_example_phat/beast_example_phat``
+    $ python beast/plotting/plot_indiv_fit.py beast_example_phat/beast_example_phat
 
 The argument for this script is the prefix of the output files. The output
 should look like this:

--- a/license/LICENSE.rst
+++ b/license/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016, Karl D. Gordon
+Copyright (c) 2015-2018, Karl D. Gordon
 
 All rights reserved.
 
@@ -10,8 +10,8 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
-* Neither the name of the copyright holder nor the names of its contributors may 
-  be used to endorse or promote products derived from this software without 
+* Neither the name of the copyright holder nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = False
 github_project = BEAST-Fitting/beast
 install_requires = astropy scipy tables
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.0.dev
+version = 1.1.dev
 
 [entry_points]
 astropy-package-template-example = beast.example_mod:main


### PR DESCRIPTION
Update the beast so it can be installed via pip. Locations for library files other than in the src directory now possible (see docs).
Useful in general and needed for megabeast work (testing, docs, etc.).

Example beast run files moved to new repository in BEAST-Fitting.
https://github.com/BEAST-Fitting/beast-examples

Addresses issue #155.

Using atom editor, so some PEP8 changes for extra characters automatically done.