### PR TITLE
batch script setup codes: use command line or functions

### DIFF
--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -187,5 +187,8 @@ if __name__ == '__main__':
                         help="number of fitting runs per core")
     args = parser.parse_args()
 
+    project = args.projectname
+    datafile = args.datafile
+    n_pernode_files = args.num_percore
 
-    setup_batch_beast_fit(args.projectname, args.datafile, args.num_percore=5)
+    setup_batch_beast_fit(project, datafile, n_pernode_files=5)

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -15,25 +15,34 @@ from astropy.table import Table
 from astropy.io import fits
 #####
 
-if __name__ == '__main__':
 
-    # commandline parser
-    parser = argparse.ArgumentParser()
-    parser.add_argument("projectname",
-                        help="project name to use (basename for files)")
-    parser.add_argument("datafile",
-                        help="file with the observed data (FITS file)")
-    parser.add_argument("--num_percore", default=5, type=int,
-                        help="number of fitting runs per core")
-    args = parser.parse_args()
+def setup_batch_beast_fit(projectname,
+                              datafile,
+                              num_percore=5):
+    """
+    Sets up batch files for submission to the 'at' queue on linux (or similar) systems
 
-    project = args.projectname
-    datafile = args.datafile
+
+    Parameters
+    ----------
+    project : string
+        project name to use (basename for files)
+
+    datafile : string
+        file with the observed data (FITS file) - the observed photometry, not the sub-files
+
+    num_percore : int (default = 5)
+        number of fitting runs per core
+
+    """
+    
+
+    project = projectname
 
     cat_files = np.array(glob.glob(datafile.replace('.fits','*_sub*.fits')))
 
     n_cat_files = len(cat_files)
-    n_pernode_files = args.num_percore
+    n_pernode_files = num_percore
 
     # setup the subdirectory for the batch and log files
     job_path = project+'/fit_batch_jobs/'
@@ -162,3 +171,21 @@ if __name__ == '__main__':
 
     if pf_open:
         pf.close()
+
+
+
+
+if __name__ == '__main__':
+
+    # commandline parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument("projectname",
+                        help="project name to use (basename for files)")
+    parser.add_argument("datafile",
+                        help="file with the observed data (FITS file)")
+    parser.add_argument("--num_percore", default=5, type=int,
+                        help="number of fitting runs per core")
+    args = parser.parse_args()
+
+
+    setup_batch_beast_fit(args.projectname, args.datafile, args.num_percore=5)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -12,30 +12,42 @@ import argparse
 
 import numpy as np
 
-if __name__ == '__main__':
 
-    # commandline parser
-    parser = argparse.ArgumentParser()
-    parser.add_argument("projectname",
-                        help="project name to use (basename for files)")
-    parser.add_argument("datafile",
-                        help="file with the observed data (FITS file)")
-    parser.add_argument("astfile",
-                        help="file with ASTs")
-    parser.add_argument("--num_subtrim", default=5, type=int,
-                        help="number of trim batch jobs")
-    args = parser.parse_args()
+def setup_batch_beast_trim(project,
+                               datafile,
+                               astfile,
+                               num_subtrim=5):
+    """
+    Sets up batch files for submission to the 'at' queue on linux (or similar) systems
 
-    project = args.projectname
-    datafile = args.datafile
-    ast_file = args.astfile
+
+    Parameters
+    ----------
+    project : string
+        project name to use (basename for files)
+
+    datafile : string
+        file with the observed data (FITS file) - the observed photometry, not the sub-files
+
+    astfile : string
+        file with ASTs
+
+    num_subtrim : int (default = 5)
+        number of trim batch jobs
+
+    """
+
+    # keep input variable names consistent with original command-line input method
+    ast_file = astfile
+    n_subtrim_files = num_subtrim
+
+    
     
     full_model_filename = "%s/%s_seds.grid.hd5"%(project,project)
 
     cat_files = np.array(glob.glob(datafile.replace('.fits','*_sub*.fits')))
 
     n_cat_files = len(cat_files)
-    n_subtrim_files = args.num_subtrim
     n_per_subtrim = int(n_cat_files/n_subtrim_files) + 1
 
     print('# trim files per process = ',n_per_subtrim)
@@ -94,3 +106,22 @@ if __name__ == '__main__':
 
     for i in range(n_subtrim_files):
         bt_f[i].close()
+
+
+
+if __name__ == '__main__':
+
+    # commandline parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument("projectname",
+                        help="project name to use (basename for files)")
+    parser.add_argument("datafile",
+                        help="file with the observed data (FITS file)")
+    parser.add_argument("astfile",
+                        help="file with ASTs")
+    parser.add_argument("--num_subtrim", default=5, type=int,
+                        help="number of trim batch jobs")
+    args = parser.parse_args()
+
+
+    setup_batch_beast_trim(args.projectname, args.datafile, args.astfile, args.num_subtrim=5)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -122,5 +122,9 @@ if __name__ == '__main__':
                         help="number of trim batch jobs")
     args = parser.parse_args()
 
+    project = args.projectname
+    datafile = args.datafile
+    ast_file = args.astfile
+    n_subtrim_files = args.num_subtrim
 
-    setup_batch_beast_trim(args.projectname, args.datafile, args.astfile, args.num_subtrim=5)
+    setup_batch_beast_trim(project, datafile, astfile, n_subtrim_files=5)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -127,4 +127,4 @@ if __name__ == '__main__':
     ast_file = args.astfile
     n_subtrim_files = args.num_subtrim
 
-    setup_batch_beast_trim(project, datafile, astfile, n_subtrim_files=5)
+    setup_batch_beast_trim(project, datafile, ast_file, n_subtrim_files=5)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -37,7 +37,6 @@ def setup_batch_beast_trim(project,
 
     """
 
-    # keep input variable names consistent with original command-line input method
     ast_file = astfile
     n_subtrim_files = num_subtrim
 


### PR DESCRIPTION
The `setup_batch_beast_trim.py` and `setup_batch_beast_fit.py` codes were both formatted to be called from the command line.  I wanted to be able to call them from within other python code, so I rearranged them to also be callable as functions.