### PR TITLE
Plot indiv fit: skip values that have only one bin

### DIFF
--- a/beast/plotting/plot_indiv_fit.py
+++ b/beast/plotting/plot_indiv_fit.py
@@ -55,6 +55,13 @@ def plot_1dpdf(ax, pdf1d_hdu, tagname, xlabel, starnum,
     n_objects, n_bins = pdf.shape
     n_objects -= 1
 
+    ax.text(0.95, 0.95, xlabel, transform=ax.transAxes,
+            va='top', ha='right')
+
+    if n_bins == 1:
+        ax.text(0.5, 0.5, 'unused', transform=ax.transAxes, va='center', ha='center')
+        return
+
     xvals = pdf[n_objects, :]
     if logx:
         xvals = np.log10(xvals)
@@ -74,9 +81,6 @@ def plot_1dpdf(ax, pdf1d_hdu, tagname, xlabel, starnum,
     ax.set_xlim(xlim[0] - 0.05 * xlim_delta, xlim[1] + 0.05 * xlim_delta)
     # ax.set_ylim(0.0,1.1*pdf[starnum,:].max())
     ax.set_ylim(0.0, 1.1)
-
-    ax.text(0.95, 0.95, xlabel, transform=ax.transAxes,
-            va='top', ha='right')
 
     if stats is not None:
         ylim = ax.get_ylim()


### PR DESCRIPTION
The plot_indiv_fit script was crashing because the 1d pdfs end up having a Nan in them when there is only one bin. 

I suspect there are also other ways the plotting script might crash when
trying to plot a 1d pdf with only one bin. This fix just skips those
quantities, and puts 'unused' on the plot area.