### PR TITLE
minor fixes for setup_batch_beast_trim.py

### DIFF
--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -84,7 +84,7 @@ def setup_batch_beast_trim(project,
         bt_f.append(open(trimfile,'w'))
         bt_f[-1].write(project + '\n')
         #bt_f[-1].write(full_model_filename + '\n')
-        pf.write('./beast/tools/trim_many_via_obsdata.py '+trimfile+' > '
+        pf.write('python -m beast.tools.trim_many_via_obsdata.py '+trimfile+' > '
                  +log_path+'beast_trim_tr'+str(i+1)+'.log\n')
     pf.close()
     

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -41,12 +41,16 @@ def setup_batch_beast_trim(project,
     n_subtrim_files = num_subtrim
 
     
-    
     full_model_filename = "%s/%s_seds.grid.hd5"%(project,project)
 
     cat_files = np.array(glob.glob(datafile.replace('.fits','*_sub*.fits')))
 
     n_cat_files = len(cat_files)
+
+    # make sure n_subtrim_files isn't larger than the number of catalog sub-files
+    if n_subtrim_files > n_cat_files:
+        n_subtrim_files = n_cat_files
+
     n_per_subtrim = int(n_cat_files/n_subtrim_files) + 1
 
     print('# trim files per process = ',n_per_subtrim)


### PR DESCRIPTION
Fixes two problems:
* making empty job files when `num_subtrim` is larger than the number of catalog files (#207)
* the resulting script breaks because of issues with relative imports