### PR TITLE
Ast fixes

### DIFF
--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -137,7 +137,6 @@ if __name__ == '__main__':
         # get the modesedgrid on which to grab input AST
         modelsedgridfile = datamodel.project + '/' + datamodel.project + \
                        '_seds.grid.hd5'
-        modelsedgrid = FileSEDGrid(modelsedgridfile)
 
         N_models = datamodel.ast_models_selected_per_age
         Nfilters = datamodel.ast_bands_above_maglimit
@@ -159,7 +158,7 @@ if __name__ == '__main__':
             mag_cuts = min_mags + tmp_cuts
 
         outfile = './' + datamodel.project + '/' + datamodel.project + '_inputAST.txt'
-        pick_models(modelsedgrid, datamodel.filters, mag_cuts, Nfilter=Nfilters,
+        pick_models(modelsedgridfile, datamodel.filters, mag_cuts, Nfilter=Nfilters,
                     N_stars=N_models, Nrealize=Nrealize, outfile=outfile)
 
         if datamodel.ast_with_positions == True:

--- a/beast/examples/phat_small/run_beast.py
+++ b/beast/examples/phat_small/run_beast.py
@@ -111,7 +111,6 @@ if __name__ == '__main__':
         # get the modesedgrid on which to grab input AST
         modelsedgridfile = datamodel.project + '/' + datamodel.project + \
             '_seds.grid.hd5'
-        modelsedgrid = FileSEDGrid(modelsedgridfile)
 
         N_models = datamodel.ast_models_selected_per_age
         Nfilters = datamodel.ast_bands_above_maglimit
@@ -134,7 +133,7 @@ if __name__ == '__main__':
             mag_cuts = min_mags + tmp_cuts
 
         outfile = './' + datamodel.project + '/' + datamodel.project + '_inputAST.txt'
-        pick_models(modelsedgrid, datamodel.filters, mag_cuts, Nfilter=Nfilters,
+        pick_models(modelsedgridfile, datamodel.filters, mag_cuts, Nfilter=Nfilters,
                     N_stars=N_models, Nrealize=Nrealize, outfile=outfile)
 
         if datamodel.ast_with_positions == True:

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -258,7 +258,7 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
 
     # Select the models above the magnitude limits in N filters
     idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter)
-    grid_cut = gridf['grid'][idxs]
+    grid_cut = gridf['grid'][list(idxs)]
 
     # Sample the model grid uniformly
     prime_params = np.column_stack(

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -162,7 +162,7 @@ def pick_positions_per_background(chosen_seds, bg_map, N_bg_bins,
 
     # Write out the table in ascii
     if outfile:
-        formats = {k: '%.5f' for k in out_table.colnames}
+        formats = {k: '%.5f' for k in out_table.colnames[2:]}
         ascii.write(out_table, outfile, overwrite=True, formats=formats)
 
     return out_table


### PR DESCRIPTION
- pass filename instead of grid object to pick_models
- h5py doesn't like arrays of indices. Fix this by making them into a list first.
- Do not format 'ones' and 'zeros' columns as '%.5f'