### PR TITLE
typing issue during resume fitting

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -455,7 +455,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
 
     it = Pbar(len(obs)-start_pos,
               desc='Calculating Lnp/Stats').iterover(islice(obs.enumobs(),
-                                                            start_pos,None))
+                                                            int(start_pos),None))
     for e, obj in it:
         # calculate the full nD posterior
         (sed) = obj


### PR DESCRIPTION
When resuming a fit, the input for one of the iterating functions needed to be an `int`, but it was `numpy.int64`, so I fixed it.