### PR TITLE
dealing with PDFs for negative fluxes

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -201,7 +201,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
     ast: beast noisemodel instance
         noise model data
 
-    qnames: list of quantities or expresions
+    qnames: list of quantities or expressions
 
     p: array-like
         list of percentile values

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -316,16 +316,10 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
         qnames.append('log'+cfilter+'_wd_bias')
 
     # create the full model fluxes for later use
-    #   save on log format like the other fluxes
+    #   save as symmetric log, since the fluxes can be negative
     full_model_flux = _seds + ast_bias
     logtempseds = np.array(full_model_flux)
-    indxs = np.where(full_model_flux > 0)
-    if len(indxs) > 0:
-        logtempseds[indxs] = np.log10(full_model_flux[indxs])
-    indxs = np.where(full_model_flux <= 0)
-    if len(indxs) > 0:
-        logtempseds[indxs] = -100.
-    full_model_flux = logtempseds
+    full_model_flux = np.sign(logtempseds) * np.log10(1 + np.abs(logtempseds * math.log(10)))
 
     # setup the arrays to temp store the results
     n_qnames = len(qnames)

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -369,12 +369,6 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
 
         # setup the fast 1d pdf
 
-        # need to know so 'zeros' (defined at -100) are ignored
-        if '_bias' in qname:
-            ignorebelow = -99.99
-        else:
-            ignorebelow = None
-
         # needed for mass parameters as they are stored as linear values
         # computationally, less bins needed if 1D PDFs done as log spacing
         if qname in set(['M_ini', 'M_act','radius']):
@@ -390,7 +384,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
             maxval = None
 
         # generate the fast 1d pdf mapping
-        _tpdf1d = pdf1d(q, nbins, ignorebelow=ignorebelow,
+        _tpdf1d = pdf1d(q, nbins,
                         logspacing=logspacing, minval=minval,
                         maxval=maxval)
         fast_pdf1d_objs.append(_tpdf1d)

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -320,7 +320,8 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
     #   save as symmetric log, since the fluxes can be negative
     full_model_flux = _seds + ast_bias
     logtempseds = np.array(full_model_flux)
-    full_model_flux = np.sign(logtempseds) * np.log10(1 + np.abs(logtempseds * math.log(10)))
+    #full_model_flux = np.sign(logtempseds) * np.log10(1 + np.abs(logtempseds * math.log(10)))
+    full_model_flux = np.sign(logtempseds) * np.log1p(np.abs(logtempseds * math.log(10)))/math.log(10)
 
     # setup the arrays to temp store the results
     n_qnames = len(qnames)

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -314,7 +314,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
     qnames = qnames_in
     filters = sedgrid.filters
     for i, cfilter in enumerate(filters):
-        qnames.append('log'+cfilter+'_wd_bias')
+        qnames.append('symlog'+cfilter+'_wd_bias')
 
     # create the full model fluxes for later use
     #   save as symmetric log, since the fluxes can be negative
@@ -346,7 +346,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
     for qname in qnames:
         #q = g0[qname][g0_indxs]
         if '_bias' in qname:
-            fname = (qname.replace('_wd_bias','')).replace('log','')
+            fname = (qname.replace('_wd_bias','')).replace('symlog','')
             q = full_model_flux[:,filters.index(fname)]
         else:
             q = g0[qname]
@@ -531,7 +531,7 @@ def Q_all_memory(prev_result, obs, sedgrid, ast, qnames_in, p=[16., 50., 84.],
 
         for k, qname in enumerate(qnames):
             if '_bias' in qname:
-                fname = (qname.replace('_wd_bias','')).replace('log','')
+                fname = (qname.replace('_wd_bias','')).replace('symlog','')
                 q = full_model_flux[:,filters.index(fname)]
             else:
                 q = g0[qname]

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -26,6 +26,7 @@ import os
 import sys
 import time
 import numpy as np
+import math
 import tables
 import string
 from itertools import islice

--- a/beast/fitting/pdf1d.py
+++ b/beast/fitting/pdf1d.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 
 class pdf1d():
-    def __init__(self, gridvals, nbins, ignorebelow=None, logspacing=False, minval=None, maxval=None):
+    def __init__(self, gridvals, nbins, logspacing=False, minval=None, maxval=None):
         """
         Create an object which can be used to efficiently generate a 1D pdf for an observed object
 
@@ -20,10 +20,6 @@ class pdf1d():
         nbins: int
             number of bins to use for the 1D pdf
 
-        ignorebelow: float
-            ignore the grid points for which the quantity falls below
-            this threshold
-
         logspacing: bool
             whether to use logarithmic spacing for the bins
 
@@ -35,12 +31,7 @@ class pdf1d():
         self.n_gridvals = len(gridvals)
         self.logspacing = logspacing
 
-        # useful when very low values need to be ignored
-        # (mainly log values that have zeros set to a low value)
-        if ignorebelow is not None:
-            indxs, = np.where(gridvals > ignorebelow)
-        else:
-            indxs = np.arange(self.n_gridvals)
+        indxs = np.arange(self.n_gridvals)
         self.n_indxs = len(indxs)
             
         # storage of the grid values to consider


### PR DESCRIPTION
Addresses #120:
* for the fluxes that might be negative, does the symmetric log, rather than log10 (which meant removing negative fluxes from consideration - bad!)
* the `ignorebelow` option in `pdf1d.py` only existed to ignore the negative fluxes, so it has been removed (as well as references to it in `fit.py`)

A paper about the symmetric log is [here](https://pdfs.semanticscholar.org/70d5/3d9f448e6f2c10bd87a4a058be64f5af7dbc.pdf).  The formula is
`y = sign(x) * log10(1 + |x/C|)`
where `C=1/log(10)` ensures a smooth function.

Here's a plot: orange is a standard log10(x), which drops to -infinity at x=0, and blue is the symlog, which deals nicely with x <= 0.
<img width="559" alt="screenshot" src="https://user-images.githubusercontent.com/32465297/40860433-55cfceb8-65b3-11e8-82be-21aee6faf709.png">



