### PR TITLE
Adding Docs for Grid Inputs: isochrones, speclibs

### DIFF
--- a/beast/physicsmodel/stars/ezmist/mist.json
+++ b/beast/physicsmodel/stars/ezmist/mist.json
@@ -1,5 +1,5 @@
 {
-	"version": [1.0],
+	"version": [1.2],
 	"url": "http://waps.cfa.harvard.edu/MIST/interp_isos.html",
 	"request_url": "http://waps.cfa.harvard.edu/MIST/iso_form.php",
 	"download_url": "http://waps.cfa.harvard.edu/MIST/",
@@ -37,7 +37,7 @@
 		],
 	"Av_value": 0,
 	"defaults": {
-		"version": 1.0,
+		"version": 1.2,
 		"v_div_vcrit": "vvcrit0.0",
 		"age_scale": "log10",
 		"age_type": "standard",

--- a/beast/physicsmodel/stars/isochrone.py
+++ b/beast/physicsmodel/stars/isochrone.py
@@ -617,7 +617,7 @@ class MISTWeb(Isochrone):
         iso_table.add_column('logg', iso_table['log_g'][:])
         iso_table.add_column('stage', iso_table['phase'][:])
         iso_table.remove_columns(['log10_isochrone_age_yr', 'log_Teff', 'log_L', 'log_g',
-                                  'initial_mass', 'star_mass', 'stage'])
+                                  'initial_mass', 'star_mass', 'phase'])
 
         # Remove phot columns and unnecessary properties
         extracol1="star_mdot he_core_mass c_core_mass log_LH log_LHe log_R".split()

--- a/beast/physicsmodel/stars/stellib.py
+++ b/beast/physicsmodel/stars/stellib.py
@@ -31,13 +31,13 @@ sig_stefan = constants.sigma_sb.value
 rsun = constants.R_sun.value
 
 config = {
-    'basel_2.2_pegase': __ROOT__ + '/BaSeL_v2.2.pegase.grid.fits',
-    'elodie_3.1': __ROOT__ + '/Elodie_v3.1.grid.fits',
-    'kurucz': __ROOT__ + '/kurucz2004.grid.fits',
-    'tlusty': __ROOT__ + '/tlusty.lowres.grid.fits',
-    'btsettl': __ROOT__ + '/bt-settl.lowres.grid.fits',
-    'btsettl_medres': __ROOT__ + '/bt-settl.medres.grid.fits',
-    'munari': __ROOT__ + '/atlas9-munari.hires.grid.fits'
+    'basel_2.2_pegase': __ROOT__ + 'BaSeL_v2.2.pegase.grid.fits',
+    'elodie_3.1': __ROOT__ + 'Elodie_v3.1.grid.fits',
+    'kurucz': __ROOT__ + 'kurucz2004.grid.fits',
+    'tlusty': __ROOT__ + 'tlusty.lowres.grid.fits',
+    'btsettl': __ROOT__ + 'bt-settl.lowres.grid.fits',
+    'btsettl_medres': __ROOT__ + 'bt-settl.medres.grid.fits',
+    'munari': __ROOT__ + 'atlas9-munari.hires.grid.fits'
 }
 
 __all__ = ['Stellib', 'CompositeStellib', 'Kurucz', 'Tlusty',

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -1,0 +1,115 @@
+#################
+BEAST Grid Inputs
+#################
+
+Below are details regarding grid choices for stellar evolution models,
+spectral libraries, and dust extinction laws.
+
+Stellar Evolution Models
+========================
+
+Stellar evolution models provide the BEAST model grid with stellar parameters
+(L, Teff, log g) as a function of age, metallicity, and stellar mass.  The
+BEAST is currently implemented to obtain this information from stellar
+isochrone sets.  These isochrones are obtained at run-time via webforms that
+yield interpolated data products and stored as CSV files.
+
+Choices:
+
+* Padova/PARSEC
+   * The Padova family of stellar evolution models spans multiple generations
+     of  work (Bertelli+94, Girardi+00, Girardi+02; Marigo+08, Girardi+10),
+     including the most recent set of PARSEC and COLIBRI models (Bressan+12,
+     Marigo+17). 
+   * PARSEC models accessed via
+     `webform <http://stev.oapd.inaf.it/cgi-bin/cmd>`_ by ``ezpadova`` module.
+   * Options = ``modeltype`` (default='parsec12s_r14' for PARSEC+COLIBRI):
+     isochrone model set - alternate choices=['parsec12s' for PARSEC 1.2S,
+     '2010' for Marigo08+Girardi10]; ``filterPMS`` (default=False): remove
+     pre-main sequence stars (M < 12 Msun).
+   * Details = age: 0 to 13.5 Gyr; metallicity: [M/H] from -2.2 to +0.5
+     (0.0001≤Z≤0.02; 122 pts), also super-solar available (Z = 0.03,0.04,0.06);
+     solar abundance: Caffau+11 (Z_photo=0.0153), initial by calibration
+     (Z_initial=0.0177)
+    
+* MIST
+   * The MIST models (Choi+16) are computed using MESA (Paxton+11,13,15).
+   * MIST Isochrone Interpolator accessed via
+     `webform <http://waps.cfa.harvard.edu/MIST/interp_isos.html>`_ by
+     ``ezmist`` module.
+   * Options = ``rotation`` (default='vvcrit0.0'): select rotating or
+     non-rotating models - alternate choice=['vvcrit0.4' for initial rotation
+     of 0.4 x critical rotation].
+   * Details = age: log(Age) from 5.0 to 10.3 (default sample = 0.05 dex);
+     metallicity: [Fe/H] from -4 to +0.5 (default sample = 0.25 dex), all
+     solar scaled in Version 1.2; solar abundance: Asplund+09 (Z_proto=0.0142,
+     Z_photo=0.0134)
+
+Spectral Models
+===============
+
+Stellar atmosphere models provide the BEAST model grid with stellar spectra
+(surface flux as function of wavelength) as a function of Teff, log g, and
+metallicity.  The BEAST currently uses theoretical spectral libraries stored
+as static libraries.  Model files store spectra in flux format with units of
+erg/s/cm2/AA.
+
+Choices:
+
+* `Kurucz/CK04`_
+   * ATLAS9 model atmospheres by Castelli & Kurucz (2004), the industry
+     standard for LTE stellar atmospheres that spans a wide range of L and
+     Teff parameter space and a broad range of wavelenghts (XXX) at low
+     spectral resolution (20 Ang/pix; 2x sampling of R~100 at 4000 Ang).
+     Z grid spans -2.5 to +0.5 at 0.5 dex sampling. Models are computed using
+     solar abundances from Grevesse & Sauval (1998; Z=0.0169).
+ 
+* `Tlusty`_
+   * Non-LTE hot star (Teff > 15,000 K) atmosphere models (OSTAR and BSTAR) by
+     Lanz & Hubeny (2003, 2007), using spectra computed for
+     `Cloudy <http://nova.astro.umd.edu/Tlusty2002/tlusty-frames-cloudy.html>`_
+     by Peter van Hoof at R~900 (sampled at R~1800). Z grid spans 5 pts from
+     1/10-2x Solar, plus additional 4 pts from 1/1000-1/30x Solar for OSTAR
+     grid.  Models are computed using solar abundances from Grevesse & Sauval
+     (1998; Z=0.0169).
+ 
+* `BTSettl`_
+   * PHOENIX model atmospheres by Allard et al., specializing in cool star
+     atmospheres (Teff < 6000 K). Intrinsically high-res, resampled to
+     2 Ang/pix grid (medres) and to match CK04 grid (lores). Models are
+     computed using solar abundances from Asplund+09 (Z=0.0134).
+   * Adjustable Parameter = ``medres`` (default=True): 2 Ang/pix resolution,
+     or False for CK04 matched wavelength grid.
+  
+* `BOSZ`_
+   * Future Addition -- ATLAS9 model atmospheres computed by Bohlin+17
+     providing enhancement to CK04 in terms of spectral resolution, wavelength
+     coverage, grid density.
+ 
+* `Munari`_
+   * ATLAS9 model atmospheres available at higher spectral resolution than
+     CK04, but over limited wavelength range.
+
+Dust Extinction
+=================
+
+Dust extinction is applied to model spectra before bandpass convolution,
+providing fully self-consistent treatment of reddening.
+
+Choices:
+
+* Gordon+16
+   * ``extinction.Gordon16_RvFALaw()``: Mixture model of MW (Type A;
+     Fitzpatrick 99) and SMC (Type B; Gordon+03) extinction curves.
+   * Adjustable parameters include: A_V, R_V, and f_A.
+
+* Gordon+03
+   * ``extinction.Gordon03_SMCBar()``: Empirically-derived SMC Bar dust
+     extinction curve.
+   * Adjustable A_V, R_V fixed at 2.74
+
+ .. _BTSettl: https://phoenix.ens-lyon.fr/Grids/BT-Settl/
+ .. _TLusty: http://nova.astro.umd.edu/Tlusty2002/database/
+ .. _Munari: http://cdsarc.u-strasbg.fr/viz-bin/Cat?cat=J%2FA%2BA%2F442%2F1127
+ .. _Kurucz/CK04: http://www.stsci.edu/hst/observatory/crds/castelli_kurucz_atlas.html
+ .. _BOSZ: https://archive.stsci.edu/prepds/bosz/

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -56,8 +56,8 @@ erg/s/cm2/AA.
 
 Choices:
 
-* `Kurucz/CK04`_
-   * ATLAS9 model atmospheres by Castelli & Kurucz (2004), the industry
+* `Kurucz`_
+   * ATLAS9 model atmospheres by Castelli & Kurucz (2004; CK04), the industry
      standard for LTE stellar atmospheres that spans a wide range of L and
      Teff parameter space and a broad range of wavelenghts (XXX) at low
      spectral resolution (20 Ang/pix; 2x sampling of R~100 at 4000 Ang).
@@ -90,6 +90,11 @@ Choices:
    * ATLAS9 model atmospheres available at higher spectral resolution than
      CK04, but over limited wavelength range.
 
+Recommendations: Tlusty+Kurucz as default, providing non-LTE models at high
+temperatures and standard ATLAS9 models elsewhere.  BTSettl library provides
+improvement at low temperatures, while BOSZ (coming soon) or Munari provide
+higher spectral resolution if required.
+
 Dust Extinction
 =================
 
@@ -111,5 +116,5 @@ Choices:
  .. _BTSettl: https://phoenix.ens-lyon.fr/Grids/BT-Settl/
  .. _TLusty: http://nova.astro.umd.edu/Tlusty2002/database/
  .. _Munari: http://cdsarc.u-strasbg.fr/viz-bin/Cat?cat=J%2FA%2BA%2F442%2F1127
- .. _Kurucz/CK04: http://www.stsci.edu/hst/observatory/crds/castelli_kurucz_atlas.html
+ .. _Kurucz: http://www.stsci.edu/hst/observatory/crds/castelli_kurucz_atlas.html
  .. _BOSZ: https://archive.stsci.edu/prepds/bosz/

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -47,14 +47,14 @@ Grid Definition Parameters
 --------------------------
 
 The BEAST generates a grid of stellar models based on aditional input parameters
-from datamodel.py.
+from datamodel.py. See <beast_grid_inputs.rst> for details on model libraries.
 
 * ``distances``: distance grid range parameters. ``[min, max, step]``, or ``[fixed number]``.
 * ``distance_unit``: specify magnitude (``units.mag``) or a length unit
 * ``logt``: age grid range parameters (min, max, step).
 * ``z``: metallicity grid points.
-* ``oiso``: isochrone model grid. Current choices: Padova or MIST. Default: PARSEC+CALIBRI: ``oiso = isochrone.PadovaWeb(modeltype='parsec12s', filterPMS=True)``
-* ``osl``: stellar library definition. Options include Kurucz, `Tlusty`_, `BTSettl`_, Munari, Elodie and BaSel. You can also generate an object from the union of multiple individual libraries: ``osl = stellib.Tlusty() + stellib.Kurucz()``
+* ``oiso``: isochrone model grid. Current choices: Padova or MIST. Default: PARSEC+CALIBRI: ``oiso = isochrone.PadovaWeb()``
+* ``osl``: stellar library definition. Options include Kurucz, Tlusty, BTSettl, Munari, Elodie and BaSel. You can also generate an object from the union of multiple individual libraries: ``osl = stellib.Tlusty() + stellib.Kurucz()``
 
 * ``extLaw``: extinction law definition.
 
@@ -503,9 +503,3 @@ The filters currently included in the BEAST filter library are as follows.
 +--------------------------+
 | GROUND_SDSS_Z            |
 +--------------------------+
-
-
-.. _BTSettl:  https://phoenix.ens-lyon.fr/Grids/BT-Settl/
-.. _TLusty:  http://nova.astro.umd.edu/Tlusty2002/database/
-.. _Munari:  http://archives.pd.astro.it/2500-10500/
-.. _BaSel:  http://www.astro.unibas.ch/BaSeL_files/BaSeL2_2.tar.gz


### PR DESCRIPTION
Added documentation page for grid inputs.  Also made minor corrections to iso and stellib code and documentation.

Closes https://github.com/BEAST-Fitting/beast/issues/205, https://github.com/BEAST-Fitting/beast/issues/158, and possibly https://github.com/BEAST-Fitting/beast/issues/71.