### PR TITLE
Subgridding tweaks

### DIFF
--- a/beast/examples/subgridding/run_beast_subgrids.py
+++ b/beast/examples/subgridding/run_beast_subgrids.py
@@ -30,8 +30,19 @@ from beast.physicsmodel.grid import FileSEDGrid
 from beast.tools import verify_params
 from beast.tools import subgridding_tools
 
-# I'm using this to import the datamodel module, so that this script can
-# be run via a symlink
+import pickle
+
+
+# import datamodel
+# print("Import statement gets datamodel from {}.".format(datamodel.__file__))
+# print("Distances are {}".format(datamodel.distances))
+
+# import runpy, os
+
+# print("runpy.run_path runs code from {}.".format(datamodelfile))
+# datamodel_globals = runpy.run_path(datamodelfile)
+# print("Distances are {}".format(datamodel_globals['distances']))
+
 # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
 import importlib.util
 import os
@@ -39,38 +50,63 @@ datamodelfile = os.path.join(os.getcwd(), 'datamodel.py')
 spec = importlib.util.spec_from_file_location('datamodel', datamodelfile)
 datamodel = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(datamodel)
+print("Project name: {}".format(datamodel.project))
 
+outdir = os.path.join('.', datamodel.project)
+subgrid_names_file = os.path.join(outdir, 'subgrid_fnames.txt')
 
 if __name__ == '__main__':
     # commandline parser
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--physicsmodel',
-                        help='Generate the physics model grid',
-                        action='store_true')
-    parser.add_argument('-a', '--ast', help='Generate an input AST file',
-                        action='store_true')
-    parser.add_argument('-o', '--observationmodel',
-                        help='Calculate the observation model (bias and noise)',
-                        action='store_true')
-    parser.add_argument('-t', '--trim',
-                        help='Trim the physics and observation model grids',
-                        action='store_true')
-    parser.add_argument('-f', '--fit', help='Fit the observed data',
-                        action='store_true')
-    parser.add_argument('-r', '--resume', help='Resume a fitting run',
-                        action='store_true')
-    parser.add_argument('--nprocs', type=int, default=1,
-                        help='Number of processes to use to process the subgrids')
-    parser.add_argument('--nsubs', type=int, default=1,
-                        help='Number of subgrids to split the physics model into')
-    parser.add_argument('--subset', type=int, nargs=2, default=[None, None],
-                        metavar=('START', 'STOP'),
-                        help='Only process subgrids in the range [START, STOP[ '
-                             '(o, t and f steps only)')
-    parser.add_argument('-m', '--merge', action='store_true',
-                        help='Merge the subgrid results (pdf1d and stats)')
+    parser.add_argument("-p", "--physicsmodel",
+                        help="Generate the physics model grid",
+                        action="store_true")
+    parser.add_argument("-a", "--ast", help="Generate an input AST file",
+                        action="store_true")
+    parser.add_argument("-o", "--observationmodel",
+                        help="Calculate the observation model (bias and noise)",
+                        action="store_true")
+    parser.add_argument("-t", "--trim",
+                        help="Trim the physics and observation model grids",
+                        action="store_true")
+    parser.add_argument("-f", "--fit", help="Fit the observed data",
+                        action="store_true")
+    parser.add_argument("-r", "--resume", help="Resume a fitting run",
+                        action="store_true")
+    parser.add_argument("--nprocs", type=int, default=1,
+                        help='''Number of processes to use to process
+                        the subgrids''')
+    parser.add_argument("--nsubs", type=int, default=1,
+                        help='''Number of subgrids to split the physics
+                        model into''')
+    parser.add_argument("--subset", type=int, nargs=2, default=[None, None],
+                        help='''Only process subgrids in the range
+                        [start, stop[. Should work for the o, t and f
+                        steps''')
+    parser.add_argument("-m", "--merge", action="store_true",
+                        help="Merge the subgrid results")
+    parser.add_argument("--ignore-missing-subresults", action="store_true",
+                        help='''In some cases, it might not be possible
+                        to perform the fit step for some subgrids, for
+                        example because the trimmed grids are empty or
+                        only have zero/negative weight points. In that
+                        case, this option can be used to perform the
+                        merge anyway. Just make sure that any missing
+                        grids are missing for the right reasons.''')
+    parser.add_argument("--dens_bin", type=int, default=None,
+                        help='''Run for a certain source/background
+                        density bin. Use the split_catalog_using_map `
+                        tool to generate the right files for this
+                        option.''')
 
     args = parser.parse_args()
+
+    if args.dens_bin is not None:
+        bin_subfolder = 'bin{}'.format(args.dens_bin)
+        pdir = create_project_dir(bin_subfolder)
+
+    def subcatalog_fname(full_cat_fname, dens_bin):
+        return full_cat_fname.replace('.fits', '_bin{}.fits'.format(dens_bin))
 
     # check input parameters, print what is the problem, stop run_beast
     verify_params.verify_input_format(datamodel)
@@ -79,13 +115,13 @@ if __name__ == '__main__':
         parallel = args.nprocs > 1
         if (parallel):
             p = Pool(args.nprocs)
-            p.map(function, argument)
+            for r in p.imap_unordered(function, argument):
+                print(r)
+
         else:
             for a in argument:
-                function(a)
-
-    outdir = os.path.join('.', datamodel.project)
-    subgrid_names_file = os.path.join(outdir, 'subgrid_fnames.txt')
+                r = function(a)
+                print(r)
 
     def get_modelsubgridfiles():
         with open(subgrid_names_file, 'r') as f:
@@ -172,25 +208,27 @@ if __name__ == '__main__':
         subgridding_tools.merge_grids(seds_fname, final_sub_names)
 
     if args.ast:
-        # This ast section should be replaced by a more general implementation
-
         # Determine magnitude range for ASTs
         mag_cuts = datamodel.ast_maglimit
+        bright_cuts = None
         if len(mag_cuts) == 1:
             tmp_cuts = mag_cuts
             obsdata = datamodel.get_obscat(datamodel.obsfile,
                                            datamodel.filters)
 
-            min_mags = np.zeros(len(datamodel.filters))
+            faintest_mags = np.zeros(len(datamodel.filters))
+            brightest_mags = np.zeros(len(datamodel.filters))
             for k, filtername in enumerate(obsdata.filters):
                 sfiltername = obsdata.data.resolve_alias(filtername)
                 sfiltername = sfiltername.replace('rate', 'vega')
                 sfiltername = sfiltername.replace('RATE', 'VEGA')
                 keep, = np.where(obsdata[sfiltername] < 99.)
-                min_mags[k] = np.percentile(obsdata[keep][sfiltername], 90.)
+                faintest_mags[k] = np.percentile(obsdata[keep][sfiltername], 90.)
+                brightest_mags[k] = np.amin(obsdata[keep][sfiltername])
 
             # max. mags from the gst observation cat.
-            mag_cuts = min_mags + tmp_cuts
+            mag_cuts = faintest_mags + tmp_cuts # this many mags fainter thant the 90th percentile
+            bright_cuts = brightest_mags - tmp_cuts # this many mags brighter than the brightest source
 
         # Choose seds for ASTs
         modelsedgridfile = os.path.join(
@@ -216,7 +254,7 @@ if __name__ == '__main__':
                                                                 min_N_per_flux,
                                                                 outfile_chosenSEDs,
                                                                 bins_outfile,
-                                                                mag_pad=0)
+                                                                bright_cut=bright_cuts)
         else:
             chosen_seds = make_ast_input_list.pick_models(modelsedgridfile,
                                                           datamodel.filters,
@@ -228,13 +266,14 @@ if __name__ == '__main__':
 
         # Assign positions for ASTs
         outfile_inputAST = os.path.join(
-            outdir, datamodel.project + '_inputAST.txt')
-        make_ast_xy_list.pick_positions_per_background(chosen_seds,
-                                                       bg_map=datamodel.ast_bg_map_file,
-                                                       N_bg_bins=datamodel.ast_bg_nbins,
-                                                       outfile=outfile_inputAST,
-                                                       refimage=datamodel.ast_reference_image,
-                                                       Nrealize=10)
+           outdir, datamodel.project + '_inputAST.txt')
+        make_ast_xy_list.pick_positions_from_map(chosen_seds,
+                                                 input_map=datamodel.ast_bg_map_file,
+                                                 N_bins=datamodel.ast_bg_nbins,
+                                                 Npermodel=10,
+                                                 outfile=outfile_inputAST,
+                                                 refimage=datamodel.ast_reference_image,
+                                                 Nrealize=1)
 
     if args.observationmodel:
         print('Generating noise model from ASTs and absflux A matrix')
@@ -247,11 +286,23 @@ if __name__ == '__main__':
 
             # generate the AST noise model
             noisefile = modelsedgridfile.replace('seds', 'noisemodel')
-            noisemodel.make_toothpick_noise_model(
+            astfile = datamodel.astfile
+
+            # If we are treating regions with different
+            # backgrounds/source densities separately, pick one of the
+            # split ast files, and put the results in a subfolder.
+            if args.dens_bin is not None:
+                noisefile = os.path.join(bin_subfolder, noisefile)
+                create_project_dir(os.path.dirname(noisefile))
+                astfile = subcatalog_fname(astfile, args.dens_bin)
+
+            outname = noisemodel.make_toothpick_noise_model(
                 noisefile,
-                datamodel.astfile,
+                astfile,
                 modelsedgrid,
                 absflux_a_matrix=datamodel.absflux_a_matrix)
+
+            return outname
 
         parallel_wrapper(gen_subobsmodel, modelsedgridfiles)
 
@@ -259,8 +310,10 @@ if __name__ == '__main__':
         print('Trimming the model and noise grids')
 
         # read in the observed data
-        obsdata = datamodel.get_obscat(datamodel.obsfile,
-                                       datamodel.filters)
+        obsfile = datamodel.obsfile
+        if args.dens_bin is not None:
+            obsfile = subcatalog_fname(obsfile, args.dens_bin)
+        obsdata = datamodel.get_obscat(obsfile, datamodel.filters)
 
         modelsedgridfiles = get_modelsubgridfiles()[subset_slice]
 
@@ -268,14 +321,20 @@ if __name__ == '__main__':
         def trim_submodel(modelsedgridfile):
             modelsedgrid = FileSEDGrid(modelsedgridfile)
 
-            # read in the noise model just created
+
             noisefile = modelsedgridfile.replace('seds', 'noisemodel')
+            sed_trimname = modelsedgridfile.replace('seds', 'seds_trim')
+            noisemodel_trimname = sed_trimname.replace('seds', 'noisemodel')
+            # When working with density bins, we nees to work in a subfolder
+            if args.dens_bin is not None:
+                noisefile = os.path.join(bin_subfolder, noisefile)
+                sed_trimname = os.path.join(bin_subfolder, sed_trimname)
+                noisemodel_trimname = os.path.join(bin_subfolder, noisemodel_trimname)
+
+            # read in the noise model just created
             noisemodel_vals = noisemodel.get_noisemodelcat(noisefile)
 
             # trim the model sedgrid
-            sed_trimname = modelsedgridfile.replace('seds', 'seds_trim')
-            noisemodel_trimname = sed_trimname.replace('seds', 'noisemodel')
-
             trim_grid.trim_models(modelsedgrid, noisemodel_vals, obsdata,
                                   sed_trimname, noisemodel_trimname, sigma_fac=3.)
 
@@ -285,18 +344,38 @@ if __name__ == '__main__':
         start_time = time.clock()
 
         # read in the observed data
-        obsdata = datamodel.get_obscat(datamodel.obsfile,
-                                       datamodel.filters)
+        obsfile = datamodel.obsfile
+        if args.dens_bin is not None:
+            obsfile = subcatalog_fname(obsfile, args.dens_bin)
 
-        modelsedgridfiles = get_modelsubgridfiles()[subset_slice]
+        obsdata = datamodel.get_obscat(obsfile, datamodel.filters)
 
+        modelsedgridfiles = get_modelsubgridfiles()
         trimmed_modelsedgridfiles = [
             s.replace('seds', 'seds_trim') for s in modelsedgridfiles]
         trimmed_noisemodelfiles = [
             s.replace('seds', 'noisemodel') for s in trimmed_modelsedgridfiles]
-        grid_info_dict = subgridding_tools.reduce_grid_info(
-            trimmed_modelsedgridfiles,
-            trimmed_noisemodelfiles, nprocs=args.nprocs)
+
+        if args.dens_bin is not None:
+            # Use the right subfolder
+            trimmed_modelsedgridfiles, trimmed_noisemodelfiles = [
+                [os.path.join(bin_subfolder, f) for f in l]
+                for l in [trimmed_modelsedgridfiles, trimmed_noisemodelfiles]
+            ]
+
+        grid_info_pkl = 'grid_info_dict.pkl'
+        if not os.path.isfile(grid_info_pkl):
+            grid_info_dict = subgridding_tools.reduce_grid_info(
+                trimmed_modelsedgridfiles,
+                trimmed_noisemodelfiles, nprocs=4)
+
+            with open(grid_info_pkl, 'wb') as p:
+                pickle.dump(grid_info_dict, p)
+            print('wrote grid_info_dict to ' + grid_info_pkl)
+        else:
+            print('loading grid_info_dict from ' + grid_info_pkl)
+            with open(grid_info_pkl, 'rb') as p:
+                grid_info_dict = pickle.loads(p.read())
 
         # perform fits for the subgrids individually
         def fit_submodel(modelsedgridfile):
@@ -312,23 +391,36 @@ if __name__ == '__main__':
             statsfile = statsfile.replace('.hd5', '.fits')
             pdf1dfile = statsfile.replace('stats', 'pdf1d')
 
+            if args.dens_bin is not None:
+                # Put everything in the right subfolder
+                trimmed_modelsedgridfile, trimmed_noisemodelfile, lnpfile, statsfile, pdf1dfile = [
+                    os.path.join(bin_subfolder, f)
+                    for f in [trimmed_modelsedgridfile, trimmed_noisemodelfile, lnpfile, statsfile,
+                              pdf1dfile]
+                ]
+
+
             # load the subgrid seds and subgrid noisemodel
             modelsedgrid = FileSEDGrid(trimmed_modelsedgridfile)
             noisemodel_vals = noisemodel.get_noisemodelcat(
                 trimmed_noisemodelfile)
 
-            fit.summary_table_memory(obsdata, noisemodel_vals,
-                                     modelsedgrid, resume=args.resume,
-                                     threshold=-10.,
-                                     save_every_npts=100, lnp_npts=60,
-                                     stats_outname=statsfile,
-                                     pdf1d_outname=pdf1dfile,
-                                     grid_info_dict=grid_info_dict,
-                                     lnp_outname=lnpfile,
-                                     do_not_normalize=True)
-            print('Done fitting on grid ' + trimmed_modelsedgridfile)
+            try:
+                fit.summary_table_memory(obsdata, noisemodel_vals,
+                                         modelsedgrid, resume=args.resume,
+                                         threshold=-10.,
+                                         save_every_npts=100, lnp_npts=60,
+                                         stats_outname=statsfile,
+                                         pdf1d_outname=pdf1dfile,
+                                         grid_info_dict=grid_info_dict,
+                                         lnp_outname=lnpfile,
+                                         do_not_normalize=True)
+                print("Done fitting on grid " + trimmed_modelsedgridfile)
+            except Exception as e:
+                if not args.ignore_missing_subresults:
+                    raise e
 
-        parallel_wrapper(fit_submodel, modelsedgridfiles)
+        parallel_wrapper(fit_submodel, modelsedgridfiles[subset_slice])
 
         new_time = time.clock()
         print('time to fit: ', (new_time - start_time) / 60., ' min')
@@ -338,9 +430,24 @@ if __name__ == '__main__':
         with_fits = [s.replace('.hd5', '.fits') for s in modelsedgridfiles]
         pdf1dfiles = [s.replace('seds', 'pdf1d') for s in with_fits]
         statsfiles = [s.replace('seds', 'stats') for s in with_fits]
-        print('Merging')
+        output_fname_base = os.path.join(datamodel.project, 'combined')
+        if args.dens_bin is not None:
+            pdf1dfiles, statsfiles = [[os.path.join(bin_subfolder, f) for f in l]
+                                      for l in [pdf1dfiles, statsfiles]]
+            output_fname_base = os.path.join(bin_subfolder, output_fname_base)
+
+        if args.ignore_missing_subresults:
+            # remove any missing filenames from the lists, and hope for the best
+            def only_existing_files(file_list):
+                return [f for f in file_list if os.path.isfile(f)]
+            pdf1dfiles = only_existing_files(pdf1dfiles)
+            statsfiles = only_existing_files(statsfiles)
+
+        print("Merging")
         print(list(zip(pdf1dfiles, statsfiles)))
-        subgridding_tools.merge_pdf1d_stats(pdf1dfiles, statsfiles)
+
+        subgridding_tools.merge_pdf1d_stats(pdf1dfiles, statsfiles,
+                                            output_fname_base=output_fname_base)
 
     # print help if no arguments
     if not any(vars(args).values()):

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -140,7 +140,8 @@ def subgrid_info(grid_fname, noise_fname=None):
         # ranges for these values.
         full_model_flux = seds[:] + noisemodel.root.bias[:]
         logtempseds = np.array(full_model_flux)
-        full_model_flux = np.sign(logtempseds) * np.log1p(np.abs(logtempseds * math.log(10)))/math.log(10)
+        full_model_flux = np.sign(logtempseds)\
+            * np.log1p(np.abs(logtempseds * math.log(10)))/math.log(10)
 
         filters = sedgrid.filters
         for i, f in enumerate(filters):
@@ -366,7 +367,7 @@ def merge_pdf1d_stats(subgrid_pdf1d_fnames, subgrid_stats_fnames, output_fname_b
     # Grid with highest Pmax, for each star
     pmaxes = np.zeros((nobs, nsubgrids))
     for gridnr in range(nsubgrids):
-        pmaxes[:,gridnr] = stats[gridnr]['Pmax']
+        pmaxes[:, gridnr] = stats[gridnr]['Pmax']
     max_pmax_index_per_star = pmaxes.argmax(axis=1)
 
     # Rebuild the stats

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -22,7 +22,7 @@ def split_and_check(grid_fname, num_subgrids):
         sub_grids.append(sub_g.grid.data)
 
         np.testing.assert_equal(complete_g.lamb, sub_g.lamb)
-        np.testing.assert_equal(complete_g.grid.columns, sub_g.grid.columns)
+        assert complete_g.grid.columns.items() == sub_g.grid.columns.items()
 
     sub_seds_reconstructed = np.concatenate(sub_seds)
     np.testing.assert_equal(sub_seds_reconstructed, complete_g.seds)

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -48,4 +48,22 @@ def test_split_grid():
 
 @remote_data
 def test_reduce_grid_info():
-    pass
+    seds_trim_fname = download_rename('beast_example_phat_seds_trim.grid.hd5')
+    sub_fnames = subgridding_tools.split_grid(seds_trim_fname, 3)
+
+    complete_g_info = subgridding_tools.subgrid_info(seds_trim_fname)
+    cap_unique = 50
+    sub_g_info = subgridding_tools.reduce_grid_info(
+        sub_fnames, nprocs=3, cap_unique=cap_unique)
+
+    for q in complete_g_info:
+        assert q in sub_g_info
+        assert complete_g_info[q]['min'] == sub_g_info[q]['min']
+        assert complete_g_info[q]['max'] == sub_g_info[q]['max']
+        num_unique = len(complete_g_info[q]['unique'])
+        if num_unique > cap_unique:
+            # Cpan still be larger if one of the sub results during the
+            # reduction is larger. This is as intended.
+            assert sub_g_info[q]['num_unique'] >= cap_unique
+        else:
+            assert sub_g_info[q]['num_unique'] == num_unique

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from astropy.tests.helper import remote_data
+
+from beast.tools import subgridding_tools
+from beast.tests.helpers import download_rename
+from beast.physicsmodel.grid import FileSEDGrid
+
+def split_and_check(grid_fname, num_subgrids):
+    sub_fnames = subgridding_tools.split_grid(grid_fname, num_subgrids)
+
+    complete_g = FileSEDGrid(grid_fname)
+
+    # count the number of grid cells
+    sub_seds = []
+    sub_grids = []
+
+    for sub_fname in sub_fnames:
+        sub_g = FileSEDGrid(sub_fname)
+
+        sub_seds.append(sub_g.seds)
+        sub_grids.append(sub_g.grid.data)
+
+        np.testing.assert_equal(complete_g.lamb, sub_g.lamb)
+        np.testing.assert_equal(complete_g.grid.columns, sub_g.grid.columns)
+
+    sub_seds_reconstructed = np.concatenate(sub_seds)
+    np.testing.assert_equal(sub_seds_reconstructed, complete_g.seds)
+
+    sub_grids_reconstructed = np.concatenate(sub_grids)
+    np.testing.assert_equal(sub_grids_reconstructed, complete_g.grid.data)
+
+@remote_data
+def test_split_grid():
+    seds_trim_fname = download_rename('beast_example_phat_seds_trim.grid.hd5')
+    split_and_check(seds_trim_fname, 4) # an even number
+    split_and_check(seds_trim_fname, 3) # an odd numer
+    split_and_check(seds_trim_fname, 1) # an edge case
+
+@remote_data
+def test_reduct_grid_info():
+    pass

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -1,5 +1,6 @@
-import numpy as np
+import os
 
+import numpy as np
 from astropy.tests.helper import remote_data
 
 from beast.tools import subgridding_tools
@@ -30,13 +31,19 @@ def split_and_check(grid_fname, num_subgrids):
     sub_grids_reconstructed = np.concatenate(sub_grids)
     np.testing.assert_equal(sub_grids_reconstructed, complete_g.grid.data)
 
+    # the split method skips anything that already exists, so if we
+    # want to use this function multiple times for the same test
+    # grid, we need to do this.
+    for f in sub_fnames:
+        os.remove(f)
+
 @remote_data
 def test_split_grid():
     seds_trim_fname = download_rename('beast_example_phat_seds_trim.grid.hd5')
-    split_and_check(seds_trim_fname, 4) # an even number
-    split_and_check(seds_trim_fname, 3) # an odd numer
-    split_and_check(seds_trim_fname, 1) # an edge case
+    sub_fnames = split_and_check(seds_trim_fname, 1) # an edge case
+    sub_fnames = split_and_check(seds_trim_fname, 3) # an odd numer
+    sub_fnames = split_and_check(seds_trim_fname, 4) # an even number
 
 @remote_data
-def test_reduct_grid_info():
+def test_reduce_grid_info():
     pass

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -7,10 +7,10 @@ from beast.tools import subgridding_tools
 from beast.tests.helpers import download_rename
 from beast.physicsmodel.grid import FileSEDGrid
 
-def split_and_check(grid_fname, num_subgrids):
-    sub_fnames = subgridding_tools.split_grid(grid_fname, num_subgrids)
 
+def split_and_check(grid_fname, num_subgrids):
     complete_g = FileSEDGrid(grid_fname)
+    sub_fnames = subgridding_tools.split_grid(grid_fname, num_subgrids)
 
     # count the number of grid cells
     sub_seds = []
@@ -37,12 +37,14 @@ def split_and_check(grid_fname, num_subgrids):
     for f in sub_fnames:
         os.remove(f)
 
+
 @remote_data
 def test_split_grid():
     seds_trim_fname = download_rename('beast_example_phat_seds_trim.grid.hd5')
-    sub_fnames = split_and_check(seds_trim_fname, 1) # an edge case
-    sub_fnames = split_and_check(seds_trim_fname, 3) # an odd numer
-    sub_fnames = split_and_check(seds_trim_fname, 4) # an even number
+    split_and_check(seds_trim_fname, 1)  # an edge case
+    split_and_check(seds_trim_fname, 3)  # an odd numer
+    split_and_check(seds_trim_fname, 4)  # an even number
+
 
 @remote_data
 def test_reduce_grid_info():


### PR DESCRIPTION
- New options for the subgridding run script. See the help strings. The script has had a general rework, too.

- The `reduce_grid_info` tool in `subgridding_tools` has a new option to reduce the memory usage. The original method tries to count how many unique values a quantity has in the total grid. If the grid is very large, this can cause too much memory usage. The `cap_unique` option simply cuts of the calculation when a certain number of unique values (default 1000) has been counted. As long as the maximum number of bins for the 1d pPDFs in fit.py (default 50) is smaller than this number, this option should be safe to use.