### PR TITLE
Encode the filter name before retrieving vega mags

### DIFF
--- a/beast/observationmodel/vega.py
+++ b/beast/observationmodel/vega.py
@@ -63,7 +63,8 @@ class Vega(object):
             FNAME  = s.hdf.root.sed.cols.FNAME[:]
             MAG    = s.hdf.root.sed.cols.MAG[:]
             CWAVE  = s.hdf.root.sed.cols.CWAVE[:]
-        idx = numpy.asarray([ numpy.where( FNAME == k) for k in filters ])
+        idx = numpy.asarray([ numpy.where( FNAME == k.encode('utf-8') )
+                              for k in filters ])
         return numpy.ravel(FNAME[idx]), numpy.ravel(MAG[idx]), numpy.ravel(CWAVE[idx])
 
 


### PR DESCRIPTION
I just ran into this, and noticed that the fix was already there for getFlux. This is the same fix, but for getMag.

Without this, the numpy.where will fail, as the strings in the loaded file are stored in byte format, not UTF-8.