### PR TITLE
save physical parameters associated with ASTs

### DIFF
--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -163,8 +163,10 @@ def run_beast_production(basename,
             mag_cuts = min_mags + tmp_cuts
 
         outfile = './' + datamodel.project + '/' + datamodel.project + '_inputAST.txt'
-        pick_models(modelsedgridfile, datamodel.filters, mag_cuts, Nfilter=Nfilters,
-                    N_stars=N_models, Nrealize=Nrealize, outfile=outfile)
+        outfile_params = './' + datamodel.project + '/' + datamodel.project + '_ASTparams.fits'
+        chosen_seds = pick_models(modelsedgridfile, datamodel.filters,
+                                  mag_cuts, Nfilter=Nfilters, N_stars=N_models, Nrealize=Nrealize,
+                                  outfile=outfile, outfile_params=outfile_params)
 
         if datamodel.ast_with_positions == True:
             separation = datamodel.ast_pixel_distribution

--- a/beast/examples/phat_small/run_beast.py
+++ b/beast/examples/phat_small/run_beast.py
@@ -142,9 +142,10 @@ if __name__ == '__main__':
             mag_cuts = min_mags + tmp_cuts
         print(modelsedgrid)
         outfile = './' + datamodel.project + '/' + datamodel.project + '_inputAST.txt'
+        outfile_params = './' + datamodel.project + '/' + datamodel.project + '_ASTparams.fits'
         chosen_seds = pick_models(modelsedgridfile, datamodel.filters,
                                   mag_cuts, Nfilter=Nfilters, N_stars=N_models, Nrealize=Nrealize,
-                                  outfile=outfile)
+                                  outfile=outfile, outfile_params=outfile_params)
 
         if datamodel.ast_with_positions == True:
             separation = datamodel.ast_pixel_distribution

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -11,6 +11,7 @@ from astropy.table import Column
 
 from ..vega import Vega
 
+import pdb
 
 def mag_limits(seds, faint_cut, Nfilter=1, bright_cut=None):
     """
@@ -267,6 +268,10 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
 
     # Convert to Vega mags
     sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
+
+    # make sure Nfilters isn't larger than the total number of filters
+    if Nfilters > len(filters):
+        Nfilters = len(filters)
 
     # Select the models above the magnitude limits in N filters
     idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -10,6 +10,7 @@ from astropy.table import Table
 from astropy.table import Column
 
 from ..vega import Vega
+from beast.physicsmodel.grid import FileSEDGrid
 
 import pdb
 
@@ -264,10 +265,12 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
     with Vega() as v:               # Get the vega fluxes
         vega_f, vega_flux, lamb = v.getFlux(filters)
 
-    gridf = h5py.File(sedgrid_fname)
+    #gridf = h5py.File(sedgrid_fname)
+    modelsedgrid = FileSEDGrid(sedgrid_fname)
 
     # Convert to Vega mags
-    sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
+    #sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
+    sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
 
     # make sure Nfilters isn't larger than the total number of filters
     if Nfilter > len(filters):
@@ -275,7 +278,11 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
 
     # Select the models above the magnitude limits in N filters
     idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)
-    grid_cut = gridf['grid'][list(idxs)]
+    #grid_cut = gridf['grid'][list(idxs)]
+    cols = {}
+    for key in list(modelsedgrid.grid.keys()):
+        cols[key] = modelsedgrid.grid[key][idxs]
+    grid_cut = Table(cols)
 
     # Sample the model grid uniformly
     prime_params = np.column_stack(

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -270,8 +270,8 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
     sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
 
     # make sure Nfilters isn't larger than the total number of filters
-    if Nfilters > len(filters):
-        Nfilters = len(filters)
+    if Nfilter > len(filters):
+        Nfilter = len(filters)
 
     # Select the models above the magnitude limits in N filters
     idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -12,7 +12,6 @@ from astropy.table import Column
 from ..vega import Vega
 from beast.physicsmodel.grid import FileSEDGrid
 
-import pdb
 
 def mag_limits(seds, faint_cut, Nfilter=1, bright_cut=None):
     """
@@ -223,7 +222,7 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
 
 
 def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealize=20,
-                outfile=None, bright_cut=None):
+                outfile=None, outfile_params=None, bright_cut=None):
     """Creates a fake star catalog from a BEAST model grid
 
     Parameters
@@ -252,6 +251,10 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
         If a file name is given, the selected models will be written to
         disk
 
+    outfile_params: str
+        If a file name is given, the physical parameters associated with
+        each model will be written to disk
+
     bright_cut: list of float
         Same as mag_cuts, but for the bright end
 
@@ -260,6 +263,7 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
     astropy Table of selected models
     - and optionally -
     ascii file: A list of selected models, written to 'outfile'
+    fits file: the corresponding physical parameters, written to 'outfile_params'
     """
 
     with Vega() as v:               # Get the vega fluxes
@@ -290,16 +294,22 @@ def pick_models(sedgrid_fname, filters, mag_cuts, Nfilter=3, N_stars=70, Nrealiz
     search_age = np.unique(prime_params[:, 0])
 
     N_sample = N_stars
-    models = []
+    model_ind = [] # indices for the model grid
+    ast_params = grid_cut[[]] # the corresponding model parameters
     for iage in search_age:
         tmp, = np.where(prime_params[:, 0] == iage)
-        models.append(np.random.choice(tmp, N_sample))
+        new_ind = np.random.choice(tmp, N_sample)
+        model_ind.append(new_ind)
+        [ast_params.add_row(grid_cut[new_ind[i]]) for i in range(len(new_ind))]
 
-    index = np.repeat(idxs[np.array(models).reshape((-1))], Nrealize)
+    index = np.repeat(idxs[np.array(model_ind).reshape((-1))], Nrealize)
     sedsMags = Table(sedsMags[index, :], names=filters)
 
     if outfile is not None:
         ascii.write(sedsMags, outfile, overwrite=True,
                     formats={k: '%.5f' for k in sedsMags.colnames})
+
+    if outfile_params is not None:
+        ast_params.write(outfile_params, overwrite=True)
 
     return sedsMags

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -105,3 +105,8 @@ DOLPHOT to define the input star position.
 
 In case the new method is used, which samples by background density, this number
 will be multiplied by the number of background density bins chosen.
+
+The code will also optionally output a fits file, `[project]/[project]_ASTparams.fits`,
+which has the physical parameters associated with each of the artificial stars.  It
+has `<number of ages> * ast_models_selected_per_age` lines, and has the same
+columns as the main SED grid file.


### PR DESCRIPTION
Addresses #159 by saving the physical parameters associated with each artificial star.  The example files and documentation are also updated.

An issue that came up during this processes was the way the SED grid was being read in and processed: it was taking absurdly long to extract the grid information for a given set of indices.  I updated that part of the code to use the same procedure as the grid trimming in [trim_grid.py](https://github.com/BEAST-Fitting/beast/blob/master/beast/fitting/trim_grid.py).