### PR TITLE
small updates to background maps

### DIFF
--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -85,11 +85,12 @@ def create_background_density_map(catfile, npix=10, reference=None, nointeract=T
     _, ax = plt.subplots(1, 2)
     figs = []
     figs.append(ax[0].imshow(bg_map))
-    ax[0].set_title('density_estimate')
+    ax[0].set_title('bg_density_estimate')
     figs.append(ax[1].imshow(n_map))
     ax[1].set_title('number of sources')
     for f, a in zip(figs, ax):
         plt.colorbar(f, ax=a)
+    plt.tight_layout()
     plt.savefig(catfile.replace('.fits','_'+ref_base+'-maps.png'))
 
     # Overplot the map on the image used for the calculation

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -107,7 +107,8 @@ Data
 
 The data need to have source density information added as it is common
 for the observation model (scatter and bias) to be strongly dependent
-on source density due to crowding/confusion noise.
+on source density due to crowding/confusion noise.  The background may
+also be important in some situations, so there is code to calculate it as well.
 
 Adding source density to observations
 =====================================
@@ -149,6 +150,25 @@ Command to create the the source density split files
 
     $ ./beast/tools/subdivide_obscat_by_source_density.py --n_per_file 6250 \
              --sort_col F475W_RATE datafile_with_sourceden.fits
+
+
+
+Adding background to observations
+=================================
+
+Create a new version of the observations that includes a column with the
+background level.  This is done by calculating the median background for
+stars that fall in each spatial bin.  The code will output a new catalog, an
+hdf5 file with the background maps and grid information, and some
+diagnostic plots. 
+
+Command to create the observed catalog with background column with a 15x15 pixel array using the 'datafile.fits' catalog and the 'image.fits' reference image.
+
+  .. code:: shell
+
+     $ ./beast/tools/create_background_density_map.py --npix 15 \
+             --reference image.fits --nointeract True datafile.fits
+
 
 *****
 Model


### PR DESCRIPTION
This changes how files are named, so it's easier to keep track of multiple fields.  The default is to use the full name of the reference image in the file names, and it adds an optional keyword to change the naming system to another string (which could be just the filter name).  It also saves everything into the same folder as the input catalog.  

I also made some minor changes to the plots (one of the titles, and using `plt.tight_layout`), and added a bit of documentation about the background maps.