### PR TITLE
minor bug in subdivide_obscat_by_source_density.py

### DIFF
--- a/beast/tools/subdivide_obscat_by_source_density.py
+++ b/beast/tools/subdivide_obscat_by_source_density.py
@@ -52,8 +52,8 @@ def split_obs_by_source_density(catfile, bin_width=1, sort_col='F475W_RATE',
     for ek, ok in enumerate(uinds):
         ii, = np.where(inds == ok)
         cc = SD_cut[ii]
-        print(ok,ok+1, cc.min(), cc.max())
-        assert((cc.min() >= ok) & (cc.max() < ok+1))   # checking we are in the right bin
+        print(bins[ok], bins[ok]+bin_width, cc.min(), cc.max())
+        assert((cc.min() >= bins[ok]) & (cc.max() < bins[ok]+bin_width))   # checking we are in the right bin
         aa = np.str(bins[ok])                          # lower value in bin (string naming purpose)
         bb = np.str(bins[ok] + bin_width)              # higher value in bin (string naming purpose)
         print('SD ' + aa + '-' + bb + ' # sources = ' + str(len(ii)))


### PR DESCRIPTION
The code `subdivide_obscat_by_source_density.py` prints the current bin and checks that it's the right one.  However, it was using the bin index rather than the bin itself.  I stumbled upon a case where these aren't identical, so the `assert` was failing even though the bins were fine.