### PR TITLE
allow one SED grid file for multiple fields

### DIFF
--- a/beast/examples/metal_production/beast_production_wrapper.py
+++ b/beast/examples/metal_production/beast_production_wrapper.py
@@ -168,7 +168,8 @@ def beast_production_wrapper():
         print('')
 
         # the file name for the model grid
-        physics_model_file = './' + field_names[b] + '_beast/' + field_names[b] + '_beast_seds.grid.hd5'
+        #physics_model_file = './' + field_names[b] + '_beast/' + field_names[b] + '_beast_seds.grid.hd5'
+        physics_model_file = 'METAL_seds.grid.hd5'
 
         # only make the physics model if it doesn't already exist
         if not os.path.isfile(physics_model_file):

--- a/beast/examples/metal_production/beast_production_wrapper.py
+++ b/beast/examples/metal_production/beast_production_wrapper.py
@@ -230,7 +230,8 @@ def beast_production_wrapper():
 
             setup_batch_beast_trim.setup_batch_beast_trim(field_names[b] + '_beast',
                                                             gst_file, ast_file,
-                                                            num_subtrim=1, nice=19)
+                                                            num_subtrim=1, nice=19,
+                                                            seds_fname=physics_model_file)
 
             print('\n**** go run trimming code for '+field_names[b]+'! ****')
             print('Here is the command to run:')

--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -72,8 +72,9 @@ def run_beast_production(basename,
     # - trimmed noise model
     noisemodel_trimname = stats_filebase + '_noisemodel_trim.hd5'
     # - SED grid
-    modelsedgrid_filename = "%s/%s_seds.grid.hd5"%(datamodel.project,
-                                                   datamodel.project)
+    #modelsedgrid_filename = "%s/%s_seds.grid.hd5"%(datamodel.project,
+    #                                               datamodel.project)
+    modelsedgrid_filename = "METAL_seds.grid.hd5"
 
     print("***run information***")
     print("  project = " + datamodel.project)
@@ -84,10 +85,10 @@ def run_beast_production(basename,
     print("trimmed noisefiles = " + noisemodel_trimname)
     print("    stats filebase = " + stats_filebase)
 
-    if physicsmodel:
+    # make sure the project directory exists
+    pdir = create_project_dir(datamodel.project)
 
-        # make sure the project directory exists
-        pdir = create_project_dir(datamodel.project)
+    if physicsmodel:
 
         # download and load the isochrones
         (iso_fname, oiso) = make_iso_table(datamodel.project,
@@ -115,6 +116,7 @@ def run_beast_production(basename,
             redshift=redshift,
             distance=datamodel.distances,
             distance_unit=datamodel.distance_unit,
+            spec_fname=modelsedgrid_filename,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights
@@ -136,6 +138,7 @@ def run_beast_production(basename,
             rv_prior_model=datamodel.rv_prior_model,
             av_prior_model=datamodel.av_prior_model,
             fA_prior_model=datamodel.fA_prior_model,
+            spec_fname=modelsedgrid_filename,
             add_spectral_properties_kwargs=extra_kwargs)
 
     if ast:

--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -61,9 +61,9 @@ def run_beast_production(basename,
 
     # update the filenames as needed for production
     # - photometry sub-file
-    datamodel.obsfile = 'data/' + basename + '_with_sourceden' \
-                        + '_SD_' + source_density.replace('_','-') \
-                        + '_sub' + sub_source_density + '.fits'
+    datamodel.obsfile = basename.replace('.fits','_with_sourceden'
+                        + '_SD_' + source_density.replace('_','-')
+                        + '_sub' + sub_source_density + '.fits')
     # - stats files
     stats_filebase = "%s/%s"%(datamodel.project,datamodel.project) \
                      + '_sd' + source_density.replace('_','-') \
@@ -147,7 +147,7 @@ def run_beast_production(basename,
         Nfilters = datamodel.ast_bands_above_maglimit
         Nrealize = datamodel.ast_realization_per_model
         mag_cuts = datamodel.ast_maglimit
-        obsdata = datamodel.get_obscat(datamodel.obsfile, datamodel.filters)
+        obsdata = datamodel.get_obscat(basename, datamodel.filters)
 
         if len(mag_cuts) == 1:
             tmp_cuts = mag_cuts
@@ -227,7 +227,7 @@ def run_beast_production(basename,
         print('Trimming the model and noise grids')
 
         # read in the observed data
-        obsdata = datamodel.get_obscat(datamodel.obsfile,
+        obsdata = datamodel.get_obscat(basename,
                                        datamodel.filters)
 
         # get the modesedgrid on which to generate the noisemodel

--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -116,7 +116,6 @@ def run_beast_production(basename,
             redshift=redshift,
             distance=datamodel.distances,
             distance_unit=datamodel.distance_unit,
-            spec_fname=modelsedgrid_filename,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -55,6 +55,8 @@ def setup_batch_beast_fit(projectname,
 
     cat_files = np.array(sorted(glob.glob(datafile.replace('.fits','*_sub*.fits'))))
 
+    datafile_basename = datafile.split('/')[-1].replace('.fits','')
+
     n_cat_files = len(cat_files)
     n_pernode_files = num_percore
 
@@ -191,7 +193,7 @@ def setup_batch_beast_fit(projectname,
                 pipe_str = ' >> '
 
             job_command = nice_str + 'python run_beast_production.py -f ' + ext_str + ' ' + \
-                          datafile + ' ' + sd_num + ' '+sub_num + pipe_str \
+                          datafile_basename + ' ' + sd_num + ' '+sub_num + pipe_str \
                           + log_path+'beast_fit' + \
                           '_sd'+sd_num+'_sub'+sub_num+'.log'
 

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -55,8 +55,6 @@ def setup_batch_beast_fit(projectname,
 
     cat_files = np.array(sorted(glob.glob(datafile.replace('.fits','*_sub*.fits'))))
 
-    datafile_basename = datafile.split('/')[-1].replace('.fits','')
-
     n_cat_files = len(cat_files)
     n_pernode_files = num_percore
 
@@ -193,7 +191,7 @@ def setup_batch_beast_fit(projectname,
                 pipe_str = ' >> '
 
             job_command = nice_str + 'python run_beast_production.py -f ' + ext_str + ' ' + \
-                          datafile_basename + ' ' + sd_num + ' '+sub_num + pipe_str \
+                          datafile + ' ' + sd_num + ' '+sub_num + pipe_str \
                           + log_path+'beast_fit' + \
                           '_sd'+sd_num+'_sub'+sub_num+'.log'
 

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -17,7 +17,8 @@ def setup_batch_beast_trim(project,
                                datafile,
                                astfile,
                                num_subtrim=5,
-                               nice=None):
+                               nice=None,
+                               seds_fname=None):
     """
     Sets up batch files for submission to the 'at' queue on linux (or similar) systems
 
@@ -38,14 +39,19 @@ def setup_batch_beast_trim(project,
 
     nice : int (default = None)
         set this to an integer (-20 to 20) to prepend a "nice" level to the trimming command
+
+    seds_fname : string (default = None)
+        full filename to the SED grid
   
     """
 
     ast_file = astfile
     n_subtrim_files = num_subtrim
 
-    
-    full_model_filename = "%s/%s_seds.grid.hd5"%(project,project)
+    if seds_fname is None:
+        full_model_filename = "%s/%s_seds.grid.hd5"%(project,project)
+    else:
+        full_model_filename = seds_fname
 
     cat_files = np.array(glob.glob(datafile.replace('.fits','*_sub*.fits')))
 
@@ -97,6 +103,7 @@ def setup_batch_beast_trim(project,
         trimfile = job_path+'BEAST_' + str(i+1)
         bt_f.append(open(trimfile,'w'))
         bt_f[-1].write(project + '\n')
+        bt_f[-1].write(full_model_filename + '\n')
         #bt_f[-1].write(full_model_filename + '\n')
         pf.write(nice_str + 'python -m beast.tools.trim_many_via_obsdata '+trimfile+' > '
                  +log_path+'beast_trim_tr'+str(i+1)+'.log\n')

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 
     project = file_lines[0].rstrip()
     
-    modelfile = "%s/%s_seds.grid.hd5"%(project,project)
+    modelfile = file_lines[1].rstrip()
 
     print('Reading the model grid files = ', modelfile)
 
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     ext_brick = ''
     
     old_noisefile = ''
-    for k in range(1,len(file_lines)):
+    for k in range(2,len(file_lines)):
         line = file_lines[k]
         line_bits = line.split()
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -274,9 +274,12 @@ trimming.
 This code sets up batch files for submission to the 'at' queue on linux
 (or similar) systems.  The projectname (e.g., 'PHAT') provides a portion
 of the batch file names.  The datafile and astfile are the observed photometry
-file (not sub files) and file with the ASTs in them.  A subdirectory in the
-project directory is created with a joblist file for submission to the batch
-queue and smaller files used by the trimming code.
+file (not sub files) and file with the ASTs in them.  The optional input
+seds_fname can be used to specify the file with the physics model grid,
+which overrides the default filename when you wish to use one model grid
+for multiple fields. A subdirectory in the project directory is created with
+a joblist file for submission to the batch queue and smaller files used by
+the trimming code.
 
 The joblist file can be split into smaller files if submission to multiple
 cores is desired.  Use the 'split' commandline tool.  The optional 'nice'


### PR DESCRIPTION
This makes it possible to use one SED grid for multiple fields.  Edited files are:
* `setup_batch_beast_trim.py`: adds optional input for SED filename (otherwise, use standard one constructed from project name) and includes filename in output file
* `trim_many_via_obsdata.py`: read in filename from the above output file
* workflow documentation: added sentence about the optional input
* updated METAL production example (`run_beast_production.py` and `beast_production_wrapper.py`) to show how to use one SED file

Addresses #283.