### PR TITLE
Set bin_delta to 1 if there is only 1 bin

### DIFF
--- a/beast/fitting/pdf1d.py
+++ b/beast/fitting/pdf1d.py
@@ -53,8 +53,11 @@ class pdf1d():
                 self.min_val = math.log10(self.min_val)
                 self.max_val = math.log10(self.max_val)
                 tgridvals = np.log10(tgridvals)
-        
-            self.bin_delta = (self.max_val - self.min_val)/(self.nbins-1)
+
+            if (self.nbins > 1):
+                self.bin_delta = (self.max_val - self.min_val)/(self.nbins-1)
+            else:
+                self.bin_delta = 1
             self.bin_vals = self.min_val + np.arange(self.nbins)*self.bin_delta
             self.bin_edges = self.min_val + \
                              (np.arange(self.nbins+1) - 0.5)*self.bin_delta


### PR DESCRIPTION
Adresses #223 

This just needs a new version of `beast_example_phat_stats.fits` for the remote data. Only the distance_p16 column is different:

```
E               AssertionError: 
E               Not equal to tolerance rtol=1e-07, atol=0
E               distance_p16 columns not equal
E               (mismatch 100.0%)
E                x: Column([783429.642766, 783429.642766, 783429.642766, 783429.642766,
E                       783429.642766, 783429.642766, 783429.642766, 783429.642766,
E                       783429.642766, 783429.642766, 783429.642766, 783429.642766,...
E                y: Column([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
E                       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
E                       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,...
```

Which makes sense.