### PR TITLE
ezpadova: freeze webform version for stability

### DIFF
--- a/beast/physicsmodel/stars/ezpadova/parsec.py
+++ b/beast/physicsmodel/stars/ezpadova/parsec.py
@@ -236,8 +236,12 @@ def __query_website(d):
     """ Communicate with the CMD website """
     webserver = 'http://stev.oapd.inaf.it'
     print('Interrogating {0}...'.format(webserver))
-    # url = webserver + '/cgi-bin/cmd_2.8'
-    url = webserver + '/cgi-bin/cmd'
+
+    # OPTION: Use fixed version for stability (CURRENT CHOICE)
+    url = webserver + '/cgi-bin/cmd_3.1'
+    # OPTION: Use current version for most recent models
+    # url = webserver + '/cgi-bin/cmd'
+
     q = urlencode(d)
     # print('Query content: {0}'.format(q))
     if py3k:


### PR DESCRIPTION
The Padova group appears to be updating their webform used to select and download PARSEC isochrones.  While the work is on-going, and until we can update the ezpadova package to match the latest webform version, I explicitly link requests to query the "cmd_3.1" form.

The frozen version will allow things to work, but we will need to follow-up on this to keep up-to-date with the latest Padova/PARSEC libraries -- see this issue for that future work: https://github.com/BEAST-Fitting/beast/issues/296