### PR TITLE
some updates for PHAT production runs

### DIFF
--- a/beast/examples/phat_small/datamodel.py
+++ b/beast/examples/phat_small/datamodel.py
@@ -31,6 +31,10 @@ from beast.observationmodel.noisemodel import absflux_covmat
 #   the name of the output results directory
 project = 'beast_example_phat'
 
+# name of the survey
+#  used for the creation of the unique name for each source
+surveyname = 'PHAT'
+
 # filters : list of strings
 #   full filter names in BEAST filter database
 filters = ['HST_WFC3_F275W','HST_WFC3_F336W','HST_ACS_WFC_F475W',

--- a/beast/examples/phat_small_multidistance/datamodel.py
+++ b/beast/examples/phat_small_multidistance/datamodel.py
@@ -31,6 +31,10 @@ from beast.observationmodel.noisemodel import absflux_covmat
 #   the name of the output results directory
 project = 'multidistance'
 
+# name of the survey
+#  used for the creation of the unique name for each source
+surveyname = 'PHAT'
+
 # filters : list of strings
 #   full filter names in BEAST filter database
 filters = ['HST_WFC3_F275W','HST_WFC3_F336W','HST_ACS_WFC_F475W',

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -20,7 +20,8 @@ def setup_batch_beast_fit(projectname,
                               datafile,
                               num_percore=5,
                               nice=None,
-                              overwrite_logfile=True):
+                              overwrite_logfile=True,
+                              prefix=None):
     """
     Sets up batch files for submission to the 'at' queue on linux (or similar) systems
 
@@ -41,6 +42,10 @@ def setup_batch_beast_fit(projectname,
 
     overwrite_logfile : boolean (default = True)
         if True, will overwrite the log file; if False, will append to existing log file
+
+    prefix : string (default=None)
+        Set this to a string (such as 'source activate astroconda') to prepend
+        to each batch file (use '\n's to make multiple lines)
 
     Returns
     -------
@@ -172,6 +177,10 @@ def setup_batch_beast_fit(projectname,
                 pf = open(joblist_file,'w')
                 run_info_dict['files_to_run'].append(joblist_file)
                 
+
+            # write out anything at the beginning of the file
+            if prefix is not None:
+                pf.write(prefix+'\n')
 
             ext_str = ''
             if reg_run:

--- a/beast/tools/split_ast_input_file.py
+++ b/beast/tools/split_ast_input_file.py
@@ -1,0 +1,72 @@
+import numpy as np
+import subprocess
+
+def split_asts(project, giant_ast_file, n_per_file):
+    """
+    Divide the list of ASTs into sub-files, to make it easier to process them
+    with Ben's pipeline.  The sub-files will be placed in the project folder,
+    and also put into a tar file.
+
+    Parameters
+    ----------
+    project : string
+        name of the project from datamodel.project, which defines the folder name
+
+    giant_ast_file : string
+        Name of the AST file created by AST section of run_beast.py
+
+    n_per_file : integer
+        number of lines per output file
+
+    """
+
+    with open(giant_ast_file,'r') as f:
+
+        ast_data = f.readlines()
+
+        # remove the first line
+        del ast_data[0]
+ 
+        # length of file
+        n_lines = len(ast_data)
+        print('AST file contains '+str(n_lines)+' lines')
+    
+        # number of new files
+        n_file = n_lines // n_per_file
+            
+        # check if there are extras
+        if n_lines % n_per_file != 0:
+            n_file += 1
+
+        print('Splitting AST file into '+str(n_file)+' sub-files')
+
+        # loop across files
+        for i in range(n_file):
+
+            #print('writing file ', i+1, ' of ', n_file)
+
+            with open('./'+project+'/fake_'+str(i+1)+'.lst','w') as f_out:
+
+                # write n_per_file lines from large file
+                for j in range(i*n_per_file, (i+1)*n_per_file):
+
+                    # make sure we don't go over for the last file
+                    if j > n_lines-1:
+                        break
+                
+                    f_out.write(ast_data[j])
+            
+
+
+    # combine AST files into a tar file
+
+    file_list = ['./'+project+'/fake_'+str(i+1)+'.lst' for i in range(n_file)]
+
+    cmd = 'tar -cf ' + './'+project+'/'+project + '_ASTs.tar ' + ' '.join(file_list)
+
+    subprocess.run(cmd, shell=True)
+
+    # remove the individual files to avoid clutter
+
+    cmd = 'rm '+' '.join(file_list)
+    subprocess.run(cmd, shell=True)

--- a/beast/tools/split_asts_by_source_density.py
+++ b/beast/tools/split_asts_by_source_density.py
@@ -1,0 +1,65 @@
+from __future__ import print_function
+
+import numpy as np
+from astropy.table import Table
+
+def split_asts(ast_file, sd_map_file):
+    """
+    Split the ASTs into sub-files for each source density bin.
+
+    Parameters
+    ----------
+    ast_file : string
+        Name of the file that contains the AST results (mag_in and mag_out)
+
+    sd_map_file : string
+        Name of the fits file that contains the source densities
+
+    """
+
+    # read in the AST file
+    ast_data = Table.read(ast_file)
+
+    # read in the source density file
+    sd_data = Table.read(sd_map_file)
+
+    # define SD bins
+    sd_bins = np.arange(np.floor(np.min(sd_data['sourcedens'])),
+                            np.ceil(np.max(sd_data['sourcedens']))+1,
+                            dtype=int)
+
+
+    # go through each source density bin
+    for i in range(len(sd_bins)-1):
+
+        print('getting ASTs in SD bin '+str(sd_bins[i])+'-'+str(sd_bins[i+1]) )
+
+        # list to hold all of the indices
+        ast_all_ind = []
+
+        # indices for this bin
+        sd_ind = np.where((sd_data['sourcedens'] >= sd_bins[i]) &
+                              (sd_data['sourcedens'] < sd_bins[i+1]))[0]
+
+        # for each index, grab the ASTs within that RA/Dec box
+        for j,ind in enumerate(sd_ind):
+
+            ast_ind = np.where((ast_data['RA_J2000'] > sd_data['min_ra'][ind]) &
+                                   (ast_data['RA_J2000'] < sd_data['max_ra'][ind]) &
+                                   (ast_data['DEC_J2000'] > sd_data['min_dec'][ind]) & 
+                                   (ast_data['DEC_J2000'] < sd_data['max_dec'][ind]) )[0]
+
+            # append indices to master list
+            if len(ast_ind) > 0:
+                ast_all_ind += ast_ind.tolist()
+
+
+        # make a new table out of the indices
+        print('   found '+str(len(ast_all_ind))+' ASTs')
+        if len(ast_all_ind) > 0:
+            print('   writing new table')
+            ast_table = ast_data[ast_all_ind]
+            new_filename = ast_file.replace('.fits','_SD_'+str(sd_bins[i])+'-'+str(sd_bins[i+1])+'.fits')
+            ast_table.write(new_filename, overwrite=True)
+        
+

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -58,6 +58,9 @@ if __name__ == '__main__':
         astfile = line_bits[3]
     
         noisefile = "%s/%s_noisemodel.hd5"%(project,project)
+        # if the noisefile doesn't exist, it's because it's divided into source density bins
+        if not os.path.isfile(noisefile):
+            noisefile = "%s/%s_noisemodel_SD_%s.hd5"%(project,project,source_density)
 
         stats_filebase = "%s/%s_sd%s_sub%s"%(project,
                                              project,


### PR DESCRIPTION
In preparing/doing PHAT production runs, I've added some code and made a few changes.
* `split_ast_input_file.py`: new code to split the AST input stars into sub-files (to make it logistically easier for @benw1 to run them)
* `split_asts_by_source_density.py`: new code to split the ASTs into sub-files for each source density bin, which can then be used for a SD-specific noise model
* `trim_many_via_obsdata.py`: if it doesn't find the standard noise model file, it looks for a noise model file with the source density in the file name
* `setup_batch_beast_fit.py` has optional input `prefix` for adding things to the beginning of the file
* PHAT datamodel examples were missing the `surveyname` parameter, so it's added back in