### PR TITLE
AST selection update, and catalog histogram plotting code

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -132,7 +132,8 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
 
-    idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)
+    #idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)
+    idxs = np.where(modelsedgrid.grid['logL'] > -9)[0]
     sedsMags_cut = sedsMags[idxs]
 
     # Note that i speak of fluxes, but I've recently modified this to

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -62,7 +62,8 @@ def mag_limits(seds, faint_cut, Nfilter=1, bright_cut=None):
 
 def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
                                 N_fluxes, min_N_per_flux,
-                                outfile=None, bins_outfile=None, bright_cut=None):
+                                outfile=None, outfile_params=None,
+                                bins_outfile=None, bright_cut=None):
     """
     Creates a fake star catalog from a BEAST model grid. The chosen seds
     are optimized for the toothpick model, by working with a given
@@ -96,6 +97,10 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
         Output path for the models (optional). If this file already
         exists, the chosen seds are loaded from this file instead.
 
+    outfile_params: string (default=None)
+        If a file name is given, the physical parameters associated with
+        each model will be written to disk
+
     bins_outfile: string
         Output path for a file containing the flux bin limits for each
         filter, and the number of samples for each (optional)
@@ -120,9 +125,11 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
     with Vega() as v:
         vega_f, vega_flux, lambd = v.getFlux(filters)
 
-    gridf = h5py.File(sedgrid_fname)
+    #gridf = h5py.File(sedgrid_fname)
+    modelsedgrid = FileSEDGrid(sedgrid_fname)
 
-    sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
+    #sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
+    sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
 
     idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)
@@ -207,6 +214,14 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
     if outfile is not None:
         ascii.write(sedsMags, outfile, overwrite=True,
                     formats={k: '%.5f' for k in sedsMags.colnames})
+
+    # if chosen, save the corresponding model parameters
+    if outfile_params is not None:
+        grid_dict = {}
+        for key in list(modelsedgrid.grid.keys()):
+            grid_dict[key] = modelsedgrid.grid[key][chosen_idxs]
+        ast_params = Table(grid_dict)
+        ast_params.write(outfile_params, overwrite=True)
 
     if bins_outfile is not None:
         bin_info_table = Table()

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 
-import h5py
 import numpy as np
 from astropy.io import ascii
 from astropy.table import Table
@@ -125,10 +124,8 @@ def pick_models_toothpick_style(sedgrid_fname, filters, mag_cuts, Nfilter,
     with Vega() as v:
         vega_f, vega_flux, lambd = v.getFlux(filters)
 
-    #gridf = h5py.File(sedgrid_fname)
     modelsedgrid = FileSEDGrid(sedgrid_fname)
 
-    #sedsMags = -2.5 * np.log10(gridf['seds'][:] / vega_flux)
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
 

--- a/beast/plotting/plot_mag_hist.py
+++ b/beast/plotting/plot_mag_hist.py
@@ -1,0 +1,77 @@
+from __future__ import print_function, division
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+
+def plot_mag_hist(data_file, n_bins=50):
+    """
+    Make histograms of magnitudes.  This only uses the [filter]_VEGA, so
+    sources removed with quality cuts are not included.
+
+    Parameters
+    ----------
+    data_file : str
+        path+file for the stellar photometry
+
+    n_bins : int (default=50)
+        number of bins to use in the histogram
+
+    """
+
+    # read in data
+    with fits.open(data_file) as hdu:
+        data_table = hdu[1].data
+    filter_list = [col[:-5] for col in data_table.columns.names if 'VEGA' in col]
+    n_filter = len(filter_list)
+
+    
+    # figure
+    fig = plt.figure(figsize=(5,4*n_filter))
+
+    
+    # make histograms
+    for f,filt in enumerate(filter_list):
+
+        # subplot region
+        ax = plt.subplot(n_filter, 1, f+1)
+
+        # histogram
+        plot_this = data_table[filt+'_VEGA'][np.where(data_table[filt+'_VEGA'] < 90)]
+        
+        hist = plt.hist(plot_this, bins=n_bins,
+                        facecolor='grey', linewidth=0.25, edgecolor='grey')
+
+        # peak magnitude
+        mag_peak = hist[1][np.where(hist[0] == np.max(hist[0]))][0] + (hist[1][1]-hist[1][0])/2
+        hist_ylim = ax.get_ylim()
+        
+        plt.plot([mag_peak, mag_peak], [-100,1.2*hist_ylim[1]],
+                    linestyle='--', linewidth=2, color='black', alpha=0.75)
+        ax.set_ylim(hist_ylim)
+
+        # label peak mag and total number of stars
+        plt.text(0.65, 0.93, r'N$_{\mathrm{tot}}$: '+'{}'.format(len(plot_this)),
+                     ha='left', va='center', transform=ax.transAxes, fontsize=12)
+        plt.text(0.65, 0.85, r'M$_{\mathrm{peak}}$: '+'{:.2f}'.format(mag_peak),
+                     ha='left', va='center', transform=ax.transAxes, fontsize=12)
+
+
+        
+        #pdb.set_trace()
+
+        # axis labels
+        ax.tick_params(axis='both', which='major', labelsize=13)
+        ax.set_xlim(ax.get_xlim()[::-1])
+        plt.xlabel(filt+' (Vega mag)', fontsize=14)
+        plt.ylabel('N', fontsize=14)
+
+
+    plt.tight_layout()
+
+    fig.savefig(data_file.replace('.fits', '_fluxhist.pdf'))
+    plt.close(fig)
+

--- a/beast/plotting/plot_mag_hist.py
+++ b/beast/plotting/plot_mag_hist.py
@@ -1,10 +1,7 @@
 from __future__ import print_function, division
 import numpy as np
 import matplotlib.pyplot as plt
-import argparse
 from astropy.io import fits
-from astropy.coordinates import SkyCoord
-from astropy import units as u
 
 
 def plot_mag_hist(data_file, n_bins=50):
@@ -72,6 +69,6 @@ def plot_mag_hist(data_file, n_bins=50):
 
     plt.tight_layout()
 
-    fig.savefig(data_file.replace('.fits', '_fluxhist.pdf'))
+    fig.savefig(data_file.replace('.fits', '_maghist.pdf'))
     plt.close(fig)
 

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -8,5 +8,6 @@ There are `several scripts
   * `plot_cmd.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd.py>`_: Make a color-magnitude diagram of the observations.  Inputs are the photometry file (which can be a `simulation <https://beast.readthedocs.io/en/latest/simulations.html#plotting>`_) and the three filters.
   * `plot_cmd_with_fits.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd_with_fits.py>`_: Similar to above, but color-coding the data points using one of the parameters from the BEAST fitting.  Takes three additional inputs: a BEAST stats file, the parameter to use, and whether to apply color after taking the log10 of the parameter.
   * `plot_indiv_fit.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_indiv_fit.py>`_: For a given star, makes a multi-panel plot that shows the PDFs and best fits of each parameter, as well as an SED (similar to Figure 14 in `Gordon+16 <http://adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
+  * `plot_mag_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_mag_hist.py>`_: Make histograms of the magnitudes for each band in the photometry catalog.
 
 


### PR DESCRIPTION
Two unrelated (but temporally coincident) changes.
* AST code for selecting on flux bins (`pick_models_toothpick_style` in `make_ast_input_list.py`) now draws from the whole flux range of the model grid, rather than limiting it to the magnitudes present in the catalog.  It cuts out any grid points with SEDs that have `logL = -9.999` (see discussion in #308 and #309).  I also added the option to save the SED parameters into a file for future reference.
* The new plotting code `plot_mag_hist.py` makes histograms of the magnitudes in the photometry catalog, and notes the number of good (mag != 99) sources and the peak of the histogram.  I added a line about it in the documentation.