### PR TITLE
more code (generalizing and new) for v1.3 production runs

### DIFF
--- a/beast/observationmodel/noisemodel/generic_noisemodel.py
+++ b/beast/observationmodel/noisemodel/generic_noisemodel.py
@@ -119,7 +119,7 @@ def make_toothpick_noise_model(outname, astfile, sedgrid,
         if len(indxs) > 0:
             noise[indxs, k] *= -1.0
 
-    print('Writting to disk into {0:s}'.format(outname))
+    print('Writing to disk into {0:s}'.format(outname))
     with tables.open_file(outname, 'w') as outfile:
         outfile.create_array(outfile.root, 'bias', bias)
         outfile.create_array(outfile.root, 'error', noise)

--- a/beast/plotting/plot_mag_hist.py
+++ b/beast/plotting/plot_mag_hist.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from astropy.io import fits
 
 
-def plot_mag_hist(data_file, n_bins=50):
+def plot_mag_hist(data_file, stars_per_bin=100, max_bins=75):
     """
     Make histograms of magnitudes.  This only uses the [filter]_VEGA, so
     sources removed with quality cuts are not included.
@@ -14,8 +14,19 @@ def plot_mag_hist(data_file, n_bins=50):
     data_file : str
         path+file for the stellar photometry
 
-    n_bins : int (default=50)
-        number of bins to use in the histogram
+    stars_per_bin : float (default=100)
+        This is the average number of stars per histogram bin. Calculate
+        the number of bins to use for each histogram by dividing the total
+        number of stars by this value (this ensures each histogram is
+        reasonably smooth).  The total number of bins is capped at max_bins.
+
+    max_bins : int (default=75)
+        maximum number of bins for each histogram.
+
+    Returns
+    -------
+    peak_mags : dict
+        dictionary with the peak magnitudes, for possible later use
 
     """
 
@@ -25,6 +36,8 @@ def plot_mag_hist(data_file, n_bins=50):
     filter_list = [col[:-5] for col in data_table.columns.names if 'VEGA' in col]
     n_filter = len(filter_list)
 
+    # save the peak mags
+    peak_mags = {}
     
     # figure
     fig = plt.figure(figsize=(5,4*n_filter))
@@ -38,22 +51,23 @@ def plot_mag_hist(data_file, n_bins=50):
 
         # histogram
         plot_this = data_table[filt+'_VEGA'][np.where(data_table[filt+'_VEGA'] < 90)]
+        n_bins = np.min([ int( len(plot_this) / stars_per_bin ), max_bins ])
         
         hist = plt.hist(plot_this, bins=n_bins,
                         facecolor='grey', linewidth=0.25, edgecolor='grey')
 
         # peak magnitude
-        mag_peak = hist[1][np.where(hist[0] == np.max(hist[0]))][0] + (hist[1][1]-hist[1][0])/2
+        peak_mags[filt] = hist[1][np.where(hist[0] == np.max(hist[0]))][0] + (hist[1][1]-hist[1][0])/2
         hist_ylim = ax.get_ylim()
         
-        plt.plot([mag_peak, mag_peak], [-100,1.2*hist_ylim[1]],
+        plt.plot([peak_mags[filt], peak_mags[filt]], [-100,1.2*hist_ylim[1]],
                     linestyle='--', linewidth=2, color='black', alpha=0.75)
         ax.set_ylim(hist_ylim)
 
         # label peak mag and total number of stars
         plt.text(0.65, 0.93, r'N$_{\mathrm{tot}}$: '+'{}'.format(len(plot_this)),
                      ha='left', va='center', transform=ax.transAxes, fontsize=12)
-        plt.text(0.65, 0.85, r'M$_{\mathrm{peak}}$: '+'{:.2f}'.format(mag_peak),
+        plt.text(0.65, 0.85, r'M$_{\mathrm{peak}}$: '+'{:.2f}'.format(peak_mags[filt]),
                      ha='left', va='center', transform=ax.transAxes, fontsize=12)
 
 
@@ -72,3 +86,6 @@ def plot_mag_hist(data_file, n_bins=50):
     fig.savefig(data_file.replace('.fits', '_maghist.pdf'))
     plt.close(fig)
 
+
+    # return peak magnitudes
+    return peak_mags

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -20,7 +20,7 @@ from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
 import numpy as np
 import photutils as pu
-from density_map import DensityMap
+from .density_map import DensityMap
 import itertools as it
 import os
 
@@ -104,7 +104,7 @@ def main_make_map(args):
         ra_grid = np.linspace(ra.min(), ra.max(), n_x + 1)
         dec_grid = np.linspace(dec.min(), dec.max(), n_y + 1)
 
-    output_base = os.path.basename(args.catfile).replace('.fits', '')
+    output_base = args.catfile.replace('.fits', '')
 
     if args.subcommand == 'sourceden':
         map_values_array = make_source_dens_map(cat, ra_grid, dec_grid,

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -484,7 +484,7 @@ def make_source_dens_map(cat,
                     npts_band_zero_map[i, j, k] = len(zindxs)
 
         # save the source density as an entry for each source
-        source_dens[indxs_for_SD] = npts_map[i, j]
+        source_dens[indxs] = npts_map[i, j]
 
     save_map_fits(npts_map, w, output_base + '_source_den_image.fits')
     save_map_fits(npts_zero_map, w, output_base + '_npts_zero_fluxes_image.fits')

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -446,8 +446,8 @@ def make_source_dens_map(cat,
     w = make_wcs_for_map(ra_grid, dec_grid)
     pix_x, pix_y = get_pix_coords(cat, w)
 
-    n_x = len(ra_grid) - 1
-    n_y = len(dec_grid) - 1
+    n_x = len(ra_grid)
+    n_y = len(dec_grid)
     npts_map = np.zeros([n_x, n_y], dtype=float)
     npts_zero_map = np.zeros([n_x, n_y], dtype=float)
     npts_band_zero_map = np.zeros([n_x, n_y, n_filters], dtype=float)

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -370,6 +370,9 @@ def measure_backgrounds(cat_table, ref_im, mask_radius, ann_width, cat_filter):
     # Threshold
     mask_union = mask_union > 0
 
+    # also mask NaNs
+    mask_union[np.isnan(ref_im.data)] = True
+
     # Save the masked reference image
     hdu = fits.PrimaryHDU(np.where(mask_union, 0, ref_im.data), header=ref_im.header)
     hdu.writeto('masked_reference_image.fits', overwrite=True)

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -606,7 +606,7 @@ def make_wcs_for_map(ra_grid, dec_grid):
     dec_delt = dec_grid[1] - dec_grid[0]
 
     w = wcs.WCS(naxis=2)
-    w.wcs.crpix = np.asarray([n_x, n_y], dtype=float) / 2.
+    w.wcs.crpix = np.asarray([n_x, n_y], dtype=float) / 2. + 1
     w.wcs.crval = np.array([center_ra, center_dec])
     w.wcs.cdelt = np.abs([-phys_ra_delt, dec_delt])
     w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
@@ -618,7 +618,7 @@ def get_pix_coords(cat, map_wcs):
        according to the given wcs"""
     world = np.column_stack((cat['RA'], cat['DEC']))
     print('working on converting ra, dec to pix x,y')
-    pixcrd = map_wcs.wcs_world2pix(world, 1)
+    pixcrd = map_wcs.wcs_world2pix(world, 1) - 0.5
     pix_x = pixcrd[:, 0]
     pix_y = pixcrd[:, 1]
     return pix_x, pix_y

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -1,0 +1,117 @@
+import numpy as np
+import os.path
+import os
+
+from astropy.io import fits
+from astropy.table import Table
+
+import pdb
+
+
+
+def cut_catalogs(input_file, output_file,
+                     partial_overlap=False,
+                     flagged=False, flag_filter=None,
+                     region_file=False):
+    """
+    Remove sources from the input catalog that are
+    - in regions without full imaging coverage
+    OR
+    - flagged as bad in flag_filter
+
+    The input catalog can either be photometry or ASTs
+
+    Parameters
+    ----------
+    input_file : string
+        file name of the input catalog (photometry or AST), where data is in
+        extension 1 of the fits file
+
+    output_file : string
+        file name for the output catalog
+
+    partial_overlap : boolean (default=False)
+        if True, remove sources in regions without full imaging coverage
+
+    flagged : boolean (default=False)
+        if True, remove sources with flag=99 in flag_filter
+
+    flag_filter : string (default=None)
+        if flagged is True, set this to the filter to use
+
+    region_file : boolean (default=False)
+        if True, create a ds9 region file where good sources are green and
+        removed sources are magenta
+
+    """
+
+
+    
+
+    # make sure something is chosen
+    if (partial_overlap == False) and (flagged == False):
+        print('must choose a criteria to cut catalogs')
+        return
+
+    
+    # read in the catalog
+    cat = Table.read(input_file)
+    filters = [c[0:-5] for c in cat.colnames if 'RATE' in c and 'RATERR' not in c]
+    n_stars = len(cat)
+    if 'RA' in cat.colnames:
+        ra_col = 'RA'
+        dec_col = 'DEC'
+    else:
+        ra_col = 'RA_J2000'
+        dec_col = 'DEC_J2000'
+
+    # array to keep track of which ones are good
+    # (1=good, 0=bad)
+    good_stars = np.ones(n_stars)
+
+
+    # partial overlap
+
+    if partial_overlap == True:
+
+        for filt in filters:
+            good_stars[cat[filt+'_RATE'] == 0] = 0
+    
+            
+    # flagged sources
+
+    if flagged == True:
+
+        good_stars[cat[flag_filter+'_FLAG'] >= 99] = 0
+        
+
+    # write out the sources as a ds9 region file
+    if region_file == True:
+        
+        with open(input_file+'.reg','w') as ds9_file:
+
+            # header
+            ds9_file.write('# Region file format: DS9 version 4.1\n')
+            ds9_file.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
+            ds9_file.write('fk5\n')
+
+            # stars
+            for i in range(n_stars):
+                if good_stars[i] == 0:
+                    ds9_file.write('circle('+str(cat[ra_col][i])+','
+                                       +str(cat[dec_col][i])+',0.1") # color=magenta\n')
+                if good_stars[i] == 1:
+                    ds9_file.write('circle('+str(cat[ra_col][i])+','
+                                       +str(cat[dec_col][i])+',0.1")\n')
+
+
+
+
+    # make a new file with the bad stars removed
+    new_cat = cat[good_stars == 1]
+
+    # save it
+    new_cat.write(output_file, format='fits', overwrite=True)
+    
+
+                    

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -1,11 +1,6 @@
 import numpy as np
-import os.path
-import os
 
-from astropy.io import fits
 from astropy.table import Table
-
-import pdb
 
 
 

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -18,7 +18,8 @@ def setup_batch_beast_trim(project,
                            astfile,
                            num_subtrim=5,
                            nice=None,
-                           seds_fname=None):
+                           seds_fname=None,
+                           prefix=None):
     """
     Sets up batch files for submission to the 'at' queue on
     linux (or similar) systems
@@ -45,6 +46,10 @@ def setup_batch_beast_trim(project,
 
     seds_fname : string (default = None)
         full filename to the SED grid
+
+    prefix : string (default=None)
+        Set this to a string (such as 'source activate astroconda') to prepend
+        to each batch file (use '\n's to make multiple lines)
 
     """
     ast_file = astfile
@@ -99,6 +104,11 @@ def setup_batch_beast_trim(project,
     joblist_file = job_path+'beast_batch_trim.joblist'
     pf = open(joblist_file, 'w')
 
+    # write out anything at the beginning of the file
+    if prefix is not None:
+        pf.write(prefix+'\n')
+
+    
     bt_f = []
     for i in range(n_subtrim_files):
         trimfile = job_path+'BEAST_' + str(i+1)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -53,7 +53,6 @@ def setup_batch_beast_trim(project,
 
     """
     ast_file = astfile
-    n_subtrim_files = num_subtrim
 
     if seds_fname is None:
         full_model_filename = "%s/%s_seds.grid.hd5" % (project, project)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -143,7 +143,139 @@ def setup_batch_beast_trim(project,
     for i in range(n_subtrim_files):
         bt_f[i].close()
 
+def generic_batch_trim(model_grid_file,
+                           noise_model_files,
+                           data_files,
+                           ast_files,
+                           trimmed_file_bases,
+                           job_path=None,
+                           file_prefix='BEAST',
+                           num_subtrim=5,
+                           nice=None,
+                           prefix=None):
+    """
+    Sets up batch files for submission to the 'at' queue on
+    linux (or similar) systems
 
+    This is a more generic version of the above code, in which all
+    files are specified at the input, rather than constructed.
+
+    The parameters that are lists of strings need to be the same length.
+
+    Parameters
+    ----------
+    model_grid_file : string
+        full filename to the SED grid (note that having the same model grid
+        file is what makes the batch trimming efficient)
+
+    noise_model_files : list of strings
+        full filename to the noise models
+
+    data_files : list of strings
+        file with the observed data (FITS file)
+
+    ast_files : list of strings
+        file with ASTs
+
+    trimmed_file_bases : string
+        prefix (path+name) for the eventual trimmed model grid and noise model
+
+    job_path : string (default=None)
+        path in which to store info about the jobs
+    
+    file_prefix : string (default='BEAST')
+        prefix for the name of the file in which to store the trimming commands
+
+    num_subtrim : int (default = 5)
+        number of trim batch jobs
+
+    nice : int (default = None)
+        set this to an integer (-20 to 20) to prepend a "nice" level
+        to the trimming command
+
+    prefix : string (default=None)
+        Set this to a string (such as 'source activate astroconda') to prepend
+        to each batch file (use '\n's to make multiple lines)
+
+    """
+
+
+    # check that everything is the same length that needs to be
+    keyword_list = [noise_model_files, data_files, ast_files, trimmed_file_bases]
+    length_array = np.array( [len(key) for key in keyword_list ] )
+    if len(np.unique(length_array)) != 1:
+        print('input lists are not the same length!')
+        return
+
+
+    # number of photometry catalog files
+    n_cat_files = len(data_files)
+
+    # make sure n_subtrim_files isn't larger than the number of
+    # catalog sub-files
+    if num_subtrim > n_cat_files:
+        num_subtrim = n_cat_files
+
+    # max number of files per process
+    n_per_subtrim = int(n_cat_files/num_subtrim)
+    if n_cat_files % num_subtrim != 0:
+        n_per_subtrim += 1
+
+    print('# trim files per process = ', n_per_subtrim)
+
+    # setup the subdirectory for the batch and log files
+    if job_path is None:
+        job_path = os.path.dirname(trimmed_file_bases[0])+'/trim_batch_jobs/'
+    if not os.path.isdir(job_path):
+        os.mkdir(job_path)
+
+    log_path = job_path+'logs/'
+    if not os.path.isdir(log_path):
+        os.mkdir(log_path)
+
+
+    # prepend nice
+    nice_str = ''
+    if nice is not None:
+        nice_str = 'nice -n' + str(int(nice)) + ' '
+
+    joblist_file = job_path+file_prefix+'_batch_trim.joblist'
+    pf = open(joblist_file, 'w')
+
+    # write out anything at the beginning of the file
+    if prefix is not None:
+        pf.write(prefix+'\n')
+
+    
+    bt_f = []
+    for i in range(num_subtrim):
+        trimfile = job_path+file_prefix+'_' + str(i+1)
+        bt_f.append(open(trimfile, 'w'))
+        bt_f[-1].write(model_grid_file + '\n')
+        pf.write(nice_str + 'python -m beast_lh.tools.trim_many_via_obsdata '
+                 + trimfile + ' > '
+                 + log_path + file_prefix+'_trim_tr'+str(i+1)+'.log\n')
+    pf.close()
+
+
+    k = 0
+    n_cur = 0
+    for i in range(n_cat_files):
+        bt_f[k].write(noise_model_files[i])
+        bt_f[k].write(' ' + data_files[i])
+        bt_f[k].write(' ' + ast_files[i])
+        bt_f[k].write(' ' + trimmed_file_bases[i])
+        bt_f[k].write('\n')
+        n_cur += 1
+        if n_cur >= n_per_subtrim:
+            n_cur = 0
+            k += 1
+
+    for i in range(num_subtrim):
+        bt_f[i].close()
+
+
+        
 if __name__ == '__main__':
 
     # commandline parser

--- a/beast/tools/split_asts_by_source_density.py
+++ b/beast/tools/split_asts_by_source_density.py
@@ -24,8 +24,8 @@ def split_asts(ast_file, sd_map_file):
     sd_data = Table.read(sd_map_file)
 
     # define SD bins
-    sd_bins = np.arange(np.floor(np.min(sd_data['sourcedens'])),
-                            np.ceil(np.max(sd_data['sourcedens']))+1,
+    sd_bins = np.arange(np.floor(np.min(sd_data['value'])),
+                            np.ceil(np.max(sd_data['value']))+1,
                             dtype=int)
 
 
@@ -38,8 +38,8 @@ def split_asts(ast_file, sd_map_file):
         ast_all_ind = []
 
         # indices for this bin
-        sd_ind = np.where((sd_data['sourcedens'] >= sd_bins[i]) &
-                              (sd_data['sourcedens'] < sd_bins[i+1]))[0]
+        sd_ind = np.where((sd_data['value'] >= sd_bins[i]) &
+                              (sd_data['value'] < sd_bins[i+1]))[0]
 
         # for each index, grab the ASTs within that RA/Dec box
         for j,ind in enumerate(sd_ind):

--- a/beast/tools/split_asts_by_source_density.py
+++ b/beast/tools/split_asts_by_source_density.py
@@ -63,7 +63,7 @@ def split_asts(ast_file, sd_map_file, bin_width=1.):
         if len(ast_all_ind) > 0:
             print('   writing new table')
             ast_table = ast_data[ast_all_ind]
-            new_filename = ast_file.replace('.fits','_SD_'+str(sd_bins[i])+'-'+str(sd_bins[i+1])+'.fits')
+            new_filename = ast_file.replace('.fits','_SD'+str(sd_bins[i])+'-'+str(sd_bins[i+1])+'.fits')
             ast_table.write(new_filename, overwrite=True)
         
 

--- a/beast/tools/split_asts_by_source_density.py
+++ b/beast/tools/split_asts_by_source_density.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import numpy as np
 from astropy.table import Table
 
-def split_asts(ast_file, sd_map_file):
+def split_asts(ast_file, sd_map_file, bin_width=1.):
     """
     Split the ASTs into sub-files for each source density bin.
 
@@ -14,6 +14,9 @@ def split_asts(ast_file, sd_map_file):
 
     sd_map_file : string
         Name of the fits file that contains the source densities
+
+    bin_width : float
+        Width of source density bin in star/arcsec
 
     """
 
@@ -26,6 +29,7 @@ def split_asts(ast_file, sd_map_file):
     # define SD bins
     sd_bins = np.arange(np.floor(np.min(sd_data['value'])),
                             np.ceil(np.max(sd_data['value']))+1,
+                            bin_width,
                             dtype=int)
 
 

--- a/beast/tools/subdivide_obscat_by_source_density.py
+++ b/beast/tools/subdivide_obscat_by_source_density.py
@@ -67,7 +67,7 @@ def split_obs_by_source_density(catfile, bin_width=1, sort_col='F475W_RATE',
         bb = np.str(bins[ok] + bin_width)
         print('SD ' + aa + '-' + bb + ' # sources = ' + str(len(ii)))
         sdobs = obs[ii]
-        sdfile = catfile.replace('.fits', '_SD_' + aa + '-' + bb + '.fits')
+        sdfile = catfile.replace('.fits', '_SD' + aa + '-' + bb + '.fits')
         sdobs.write(sdfile, overwrite=True)
 
         # Sort the stars

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -17,7 +17,6 @@ import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
 from beast.fitting import trim_grid
 from beast.physicsmodel.grid import FileSEDGrid
 
-from astropy.table import Table
 
 # datamodel only needed for the get_obscat function
 # would be good to remove this dependence

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -49,8 +49,14 @@ if __name__ == '__main__':
     old_noisefile = ''
     for k in range(1,len(file_lines)):
 
+        print('/n/n')
+
         # file names
         noisefile, obsfile, astfile, filebase = file_lines[k].split()
+
+        # make sure the proper directories exist
+        if not os.path.isdir(os.path.dirname(filebase)):
+            os.makedirs(os.path.dirname(filebase))
 
         # construct trimmed file names
         sed_trimname = filebase + '_sed_trim.grid.hd5'

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -15,7 +15,9 @@ import time
 # BEAST imports
 import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel 
 from beast.fitting import trim_grid
-from beast.physicsmodel.grid import FileSEDGrid  
+from beast.physicsmodel.grid import FileSEDGrid
+
+from astropy.table import Table
 
 # datamodel only needed for the get_obscat function
 # would be good to remove this dependence
@@ -30,44 +32,29 @@ if __name__ == '__main__':
 
     start_time = time.clock()
 
+    # read in trim file
     f = open(args.trimfile, 'r')
     file_lines = list(f)
 
-    project = file_lines[0].rstrip()
-    
-    modelfile = file_lines[1].rstrip()
-
-    print('Reading the model grid files = ', modelfile)
+    # physics model grid name
+    modelfile = file_lines[0].rstrip()
 
     # get the modesedgrid on which to generate the noisemodel  
-    modelsedgrid = FileSEDGrid(modelfile)  
+    print('Reading the model grid files = ', modelfile)
+    modelsedgrid = FileSEDGrid(modelfile)
 
     new_time = time.clock()
     print('time to read: ',(new_time - start_time)/60., ' min')
-
-    ext_brick = ''
     
     old_noisefile = ''
-    for k in range(2,len(file_lines)):
-        line = file_lines[k]
-        line_bits = line.split()
+    for k in range(1,len(file_lines)):
 
-        source_density = line_bits[0]
-        sub_source_density = line_bits[1]
-        obsfile = line_bits[2]
-        astfile = line_bits[3]
-    
-        noisefile = "%s/%s_noisemodel.hd5"%(project,project)
-        # if the noisefile doesn't exist, it's because it's divided into source density bins
-        if not os.path.isfile(noisefile):
-            noisefile = "%s/%s_noisemodel_SD_%s.hd5"%(project,project,source_density)
+        # file names
+        noisefile, obsfile, astfile, filebase = file_lines[k].split()
 
-        stats_filebase = "%s/%s_sd%s_sub%s"%(project,
-                                             project,
-                                             source_density,
-                                             sub_source_density)
-        sed_trimname = stats_filebase + '_sed_trim.grid.hd5'
-        noisemodel_trimname = stats_filebase + '_noisemodel_trim.hd5'
+        # construct trimmed file names
+        sed_trimname = filebase + '_sed_trim.grid.hd5'
+        noisemodel_trimname = filebase + '_noisemodel_trim.hd5'
 
         print('working on ' + sed_trimname)
         


### PR DESCRIPTION
This has a bunch of code updates in preparation for v1.3 production runs.  They're mostly related to things in #337 that still needed to be fully implemented, and generalizing some code for use with subgrids.  There are also a few bug fixes that I stumbled across.

* `create_background_density_map.py`
  * fix an import
  * fix some issues with WCS
  * background: new optional inputs (mask radius, annulus width, magnitude range for masked sources), mask any `NaN` pixels in ref image
  * source density: fix bug in assigning the source densities to stars in the catalog
* `cut_catalogs.py`: new code that will read in either a photometry or AST catalog and remove sources that are either (1) in regions without full imaging coverage, or (2) flagged as bad in the chosen filter
* `setup_batch_beast_trim.py`: generalized to take in all file names rather than creating them on the fly (though the old interface is still available for backwards compatibility), and puts all relevant file names in the output file
* `trim_many_via_obsdata.py`: changed to accept the new input file format (with all file names), rather than creating file names on the fly
* `split_asts_by_source_density.py`: added new optional input for the bin width
* `plot_mag_hist.py`: change how bins are chosen and output the magnitudes for the histogram maxima
* `generic_noisemodel.py`: fixing a typo in a print statement