### PR TITLE
Fix extinction/dust_extinction discrepancies

### DIFF
--- a/beast/examples/metal_production/run_beast_production.py
+++ b/beast/examples/metal_production/run_beast_production.py
@@ -113,6 +113,7 @@ def run_beast_production(basename,
             redshift=redshift,
             distance=datamodel.distances,
             distance_unit=datamodel.distance_unit,
+            extLaw=datamodel.extLaw,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights

--- a/beast/examples/phat_small/run_beast.py
+++ b/beast/examples/phat_small/run_beast.py
@@ -92,6 +92,7 @@ if __name__ == '__main__':
             redshift=redshift,
             distance=datamodel.distances,
             distance_unit=datamodel.distance_unit,
+            extLaw=datamodel.extLaw,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # add the stellar priors as weights

--- a/beast/examples/subgridding/run_beast_subgrids.py
+++ b/beast/examples/subgridding/run_beast_subgrids.py
@@ -155,6 +155,7 @@ if __name__ == '__main__':
             osl=datamodel.osl,
             distance=datamodel.distances,
             distance_unit=datamodel.distance_unit,
+            extLaw=datamodel.extLaw,
             add_spectral_properties_kwargs=extra_kwargs)
 
         # Work with the whole grid up to here (otherwise, priors need a

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -11,6 +11,7 @@ from astropy import units
 
 import dust_extinction.parameter_averages as dustext_par
 import dust_extinction.averages as dustext_avg
+from dust_extinction.helpers import _test_valid_x_range
 
 from ...observationmodel import phot
 from ...config import __ROOT__
@@ -113,6 +114,7 @@ class Cardelli89(ExtinctionLaw):
     """
     def __init__(self):
         self.name = 'Cardelli89'
+        self.x_range = [0.3, 10.0] # inverse microns
 
     def function(self, lamb, Av=1., Rv=3.1, Alambda=True, **kwargs):
         """
@@ -146,8 +148,15 @@ class Cardelli89(ExtinctionLaw):
         else:
             _lamb = lamb[:]
 
+
+        # convert to wavenumbers
+        x = 1.e4 / _lamb
+
+        # check that the wavenumbers are within the defined range
+        _test_valid_x_range(x, self.x_range, self.name)
+
+
         # init variables
-        x = 1.e4 / _lamb  # wavenumber in um^-1
         a = np.zeros(np.size(x))
         b = np.zeros(np.size(x))
         # Infrared (Eq 2a,2b)
@@ -212,6 +221,7 @@ class Fitzpatrick99(ExtinctionLaw):
     """
     def __init__(self):
         self.name = 'Fitzpatrick99'
+        self.x_range = [0.3, 10.0]
 
     def function(self, lamb, Av=1, Rv=3.1, Alambda=True,
                  draine_extend=False, **kwargs):
@@ -249,6 +259,13 @@ class Fitzpatrick99(ExtinctionLaw):
         else:
             _lamb = lamb[:]
 
+        # convert to wavenumbers
+        x = 1.e4 / _lamb
+
+        # check that the wavenumbers are within the defined range
+        _test_valid_x_range(x, self.x_range, self.name)
+
+        # initialize values
         c2 = -0.824 + 4.717 / Rv
         c1 = 2.030 - 3.007 * c2
         c3 = 3.23
@@ -256,7 +273,6 @@ class Fitzpatrick99(ExtinctionLaw):
         x0 = 4.596
         gamma = 0.99
 
-        x = 1.e4 / _lamb
         k = np.zeros(np.size(x))
 
         # compute the UV portion of A(lambda)/E(B-V)
@@ -357,6 +373,7 @@ class Gordon03_SMCBar(ExtinctionLaw):
     def __init__(self):
         self.name = 'Gordon03_SMCBar'
         self.Rv = 2.74
+        self.x_range = [0.3, 10.0]
 
     def function(self, lamb, Av=1, Rv=2.74, Alambda=True,
                  draine_extend=False,  **kwargs):
@@ -391,6 +408,12 @@ class Gordon03_SMCBar(ExtinctionLaw):
         else:
             _lamb = lamb[:]
 
+        # convert to wavenumbers
+        x = 1.e4 / _lamb
+
+        # check that the wavenumbers are within the defined range
+        _test_valid_x_range(x, self.x_range, self.name)
+
         # set Rv explicitly to the fixed value
         Rv = self.Rv
 
@@ -401,7 +424,6 @@ class Gordon03_SMCBar(ExtinctionLaw):
         x0 = 4.6
         gamma = 1.0
 
-        x = 1.e4 / _lamb
         k = np.zeros(np.size(x))
 
         # UV part

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -498,6 +498,9 @@ class Gordon16_RvFALaw(ExtinctionLaw):
         self.BLaw = Gordon03_SMCBar()
         self.name = 'Gordon16_RvFALaw'
 
+        self.x_range = [np.max([self.ALaw.x_range[0], self.BLaw.x_range[0]]),
+                        np.min([self.ALaw.x_range[1], self.BLaw.x_range[1]]) ]
+
     def function(self, lamb, Av=1, Rv=3.1, Alambda=True, f_A=0.5, **kwargs):
         """
         Gordon16_RvFALaw
@@ -613,6 +616,9 @@ class Generalized_RvFALaw(Gordon16_RvFALaw):
         self.BLaw = BLaw
         self.name = 'Generalized_RvFALaw:'+ALaw.name+'+'+BLaw.name
 
+        self.x_range = [np.max([self.ALaw.x_range[0], self.BLaw.x_range[0]]),
+                        np.min([self.ALaw.x_range[1], self.BLaw.x_range[1]]) ]
+
 
 class Generalized_DustExt(ExtinctionLaw):
     """
@@ -635,6 +641,8 @@ class Generalized_DustExt(ExtinctionLaw):
             raise ValueError(curve + ' class not found. \n' +
                              'Valid dust_extinction package classes: '+
                              ' '.join(dustext_par.__all__+dustext_avg.__all__))
+
+        self.x_range = self.extcurve_class.x_range
 
     def function(self, lamb, Av=1, Rv=3.1, Alambda=True,
                  **kwargs):

--- a/beast/physicsmodel/stars/tests/test_spectral_grid.py
+++ b/beast/physicsmodel/stars/tests/test_spectral_grid.py
@@ -4,6 +4,7 @@ from astropy import constants as const
 
 from ...stars import stellib
 from ...stars.isochrone import ezIsoch
+from ...dust import extinction
 from ... import grid
 from ...model_grid import (make_spectral_grid,
                            add_stellar_priors)
@@ -39,6 +40,10 @@ def test_make_kurucz_tlusty_spectral_grid():
     osl = stellib.Tlusty(filename=tlusty_fname) \
         + stellib.Kurucz(filename=kurucz_fname)
 
+    # define the extinction curve to use
+    extLaw = extinction.Gordon16_RvFALaw()
+
+
     filters = ['HST_WFC3_F275W', 'HST_WFC3_F336W', 'HST_ACS_WFC_F475W',
                'HST_ACS_WFC_F814W', 'HST_WFC3_F110W', 'HST_WFC3_F160W']
     add_spectral_properties_kwargs = dict(filternames=filters)
@@ -53,6 +58,7 @@ def test_make_kurucz_tlusty_spectral_grid():
         distance_unit=distance_unit,
         spec_fname=spec_fname,
         filterLib=filter_fname,
+        extLaw=extLaw,
         add_spectral_properties_kwargs=add_spectral_properties_kwargs)
 
     # compare the new to the cached version

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -207,7 +207,7 @@ def generic_batch_trim(model_grid_file,
         trimfile = job_path+file_prefix+'_' + str(i+1)
         bt_f.append(open(trimfile, 'w'))
         bt_f[-1].write(model_grid_file + '\n')
-        pf.write(nice_str + 'python -m beast_lh.tools.trim_many_via_obsdata '
+        pf.write(nice_str + 'python -m beast.tools.trim_many_via_obsdata '
                  + trimfile + ' > '
                  + log_path + file_prefix+'_trim_tr'+str(i+1)+'.log\n')
     pf.close()


### PR DESCRIPTION
Addresses #359:
* all BEAST extinction curve prescriptions have the attribute `x_range`, and if the input wavelength is outside of that range, it throws an error (conveniently using `_test_valid_x_range` from `dust_extinction`)
* In `beast.physicsmodel.model_grid`, `make_spectral_grid` takes the extinction curve (`datamodel.extLaw`) as an optional input.  If it's set, any parts of the spectra with wavelengths outside of `x_range` are discarded.