### PR TITLE
Remove extraneous space in `trim_grid.py`

### DIFF
--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -129,7 +129,7 @@ def trim_models(
 
     print("number of original models = ", len(sedgrid.seds[:, 0]))
     print("number of ast trimmed models = ", n_ast_indxs)
-    print(" number of trimmed models = ", len(indxs))
+    print("number of trimmed models = ", len(indxs))
 
     # Save the grid
     print("Writing trimmed sedgrid to disk into {0:s}".format(sed_outname))


### PR DESCRIPTION
Extra space at beginning of print statement has been removed.