### PR TITLE
Fix failing travis build

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -141,5 +141,5 @@ There are 2 possible locations for the required library files. The possible loca
 (in the order the code will search for them):
 
 1. In a directory designated by a BEAST_LIBS environment variable
-2. In the `.beast` directory in the home directory of the current user (ie, `~/.beast`);
+2. In the ``.beast`` directory in the home directory of the current user (ie, ``~/.beast``);
 this is usually the easiest and will be automatically created if it doesn't exist.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -142,4 +142,4 @@ There are 2 possible locations for the required library files. The possible loca
 
 1. In a directory designated by a BEAST_LIBS environment variable
 2. In the ``.beast`` directory in the home directory of the current user (ie, ``~/.beast``);
-this is usually the easiest and will be automatically created if it doesn't exist.
+   this is usually the easiest and will be automatically created if it doesn't exist.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -141,5 +141,5 @@ There are 2 possible locations for the required library files. The possible loca
 (in the order the code will search for them):
 
 1. In a directory designated by a BEAST_LIBS environment variable
-2. In the '.beast' directory in the home directory of the current user (ie, ''~/.beast');
+2. In the `.beast` directory in the home directory of the current user (ie, `~/.beast`);
 this is usually the easiest and will be automatically created if it doesn't exist.


### PR DESCRIPTION
There was an odd number of single quotes on line 144 in `install.rst` which may have caused Travis CI to fail when building the docs. I removed the extra quote and changed it to code-style text.