### PR TITLE
fix bug when only one stellar library used in CompositeStellib

### DIFF
--- a/beast/physicsmodel/stars/stellib.py
+++ b/beast/physicsmodel/stars/stellib.py
@@ -688,10 +688,13 @@ class Stellib(object):
         # Step 3: Interpolation
         # =====================
         # Do the actual interpolation, avoiding exptrapolations
-        for mk, (rT, rg, rZ) in enumerate(tqdm(zip(pts["logT"], pts["logg"], pts["Z"]),
-                                          total=ndata,
-                                          desc="Spectral grid",
-        )):
+        for mk, (rT, rg, rZ) in enumerate(
+            tqdm(
+                zip(pts["logT"], pts["logg"], pts["Z"]),
+                total=ndata,
+                desc="Spectral grid",
+            )
+        ):
             if bound_cond[mk]:
                 s = np.array(self.interp(rT, rg, rZ, 0.0)).T
                 specs[mk, :] = self.genSpectrum(s) * weights[mk]
@@ -1247,18 +1250,30 @@ class CompositeStellib(Stellib):
             "name": "Reinterpolated stellib grid",
         }
 
-        _grid = recfunctions.stack_arrays(
-            grid, defaults=None, usemask=False, asrecarray=True
-        )
+        if len(grid) > 1:
+            # combine the grids returned form different stellar libraries
+            _grid = recfunctions.stack_arrays(
+                grid, defaults=None, usemask=False, asrecarray=True
+            )
 
-        # populate the specgrid index
-        _grid["specgrid_indx"] = np.arange(len(_grid["specgrid_indx"]), dtype=np.int64)
+            # populate the specgrid index
+            _grid["specgrid_indx"] = np.arange(
+                len(_grid["specgrid_indx"]), dtype=np.int64
+            )
 
-        g = SpectralGrid(
-            l0, seds=np.vstack(seds), grid=Table(_grid), header=header, backend="memory"
-        )
+            g = SpectralGrid(
+                l0,
+                seds=np.vstack(seds),
+                grid=Table(_grid),
+                header=header,
+                backend="memory",
+            )
 
-        return g
+            return g
+
+        else:
+            # only one stellar library actually used, return it
+            return gk
 
 
 class Elodie(Stellib):


### PR DESCRIPTION
Closes #365.

When a CompositeStellib is used to generate the stellar grid, but only one stellar library is needed this caused an error.   When only a single stellar library is passed, no error.  When two are passed, then a CompositeStellib is used.  This assumed that both would be used and the resulting two grids would need to be stacked.  But when only one is needed due to the desired stellar grid (e.g., does not include the physical range of the other stellar library), then no stacking is needed.  In this case in #365, the TLusty grid was not needed in the case where the logage started at 8.5.

Fixed in this PR to just pass back the single grid (no attempt to stack is done).