### PR TITLE
Noise model and observationmodel tests

### DIFF
--- a/beast/observationmodel/extra_filters.py
+++ b/beast/observationmodel/extra_filters.py
@@ -1,9 +1,9 @@
 import numpy as np
-from .phot import IntegrationFilter, Filter
+from beast.observationmodel.phot import IntegrationFilter, Filter
 
 
 def make_integration_filter(
-    startlam, endlam, dlamb, name, observatory="SUDO", instrument="FAKE", comment=None
+    startlam, endlam, dlamb, name, observatory="PSEUDO", instrument="FAKE", comment=None
 ):
     """
     Creates a constant-filter with transmission 100%
@@ -24,11 +24,10 @@ def make_integration_filter(
     name: string
         name of the filter
 
-    observato_integration_filter(90., 913., 1, 'QION', observatory='SUDO', instrument='Fake')
-    return fry: string, (default='PSEUDO')
+    observatory: string, (default='PSEUDO')
         name of the observatory
 
-    instrument: string (default='PSEUDO')
+    instrument: string (default='FAKE')
         name of the instrument
 
     comment: string (default=None)
@@ -67,10 +66,10 @@ def make_integration_filter(
 
 
 def make_top_hat_filter(
-    startlam, endlam, dlamb, name, observatory="SUDO", instrument="FAKE", comment=None
+    startlam, endlam, dlamb, name, observatory="PSEUDO", instrument="FAKE", comment=None
 ):
     """
-    Creates a psudo-filter with transmission 100%
+    Creates a pseudo-filter with transmission 100%
     in the energy range [startlam:endlam].
 
     Parmeters
@@ -90,7 +89,7 @@ def make_top_hat_filter(
     observatory: string, (default='PSEUDO')
         name of the observatory
 
-    instrument: string (default='PSEUDO')
+    instrument: string (default='FAKE')
         name of the instrument
 
     comment: string (default=None)
@@ -133,10 +132,3 @@ def make_top_hat_filter(
     if comment is not None:
         filt.comment += "\n" + comment
     return filt
-
-
-def test():
-    f = make_integration_filter(
-        90.0, 913.0, 1, "QION", observatory="SUDO", instrument="Fake"
-    )
-    return f

--- a/beast/observationmodel/noisemodel/tests/test_splinter_noisemodel.py
+++ b/beast/observationmodel/noisemodel/tests/test_splinter_noisemodel.py
@@ -3,32 +3,23 @@ from beast.physicsmodel.grid import SpectralGrid
 
 import h5py
 import numpy as np
-import os
 import pytest
+
 
 @pytest.mark.parametrize("frac_unc", [0.01, 0.1, 0.3])
 def test_splinter_noisemodel(frac_unc):
 
     # make super simplified model SED grid
-    lamb = np.linspace(1000., 4000, 4)
+    lamb = np.linspace(1000.0, 4000, 4)
     seds = np.logspace(-4, -3, 4)[None, :] * np.array([1, 1.5])[:, None]
 
     modelsedgrid = SpectralGrid(
-        lamb=lamb,
-        seds=seds,
-        grid=[1],         # dummy input for now
-        backend="memory",
+        lamb=lamb, seds=seds, grid=[1], backend="memory"  # dummy input for now
     )
-
-    frac_unc = 0.1
 
     # make splinter noisemodel
     noise_fname = "/tmp/splinter_example_noisemodel_{:.2f}.grid.hd5".format(frac_unc)
-    make_splinter_noise_model(
-        noise_fname,
-        modelsedgrid,
-        frac_unc=frac_unc,
-    )
+    make_splinter_noise_model(noise_fname, modelsedgrid, frac_unc=frac_unc)
 
     # read entire noisemodel back in
     noisemodel = h5py.File(noise_fname)

--- a/beast/observationmodel/noisemodel/tests/test_splinter_noisemodel.py
+++ b/beast/observationmodel/noisemodel/tests/test_splinter_noisemodel.py
@@ -1,0 +1,39 @@
+from beast.observationmodel.noisemodel.splinter import make_splinter_noise_model
+from beast.physicsmodel.grid import SpectralGrid
+
+import h5py
+import numpy as np
+import os
+import pytest
+
+@pytest.mark.parametrize("frac_unc", [0.01, 0.1, 0.3])
+def test_splinter_noisemodel(frac_unc):
+
+    # make super simplified model SED grid
+    lamb = np.linspace(1000., 4000, 4)
+    seds = np.logspace(-4, -3, 4)[None, :] * np.array([1, 1.5])[:, None]
+
+    modelsedgrid = SpectralGrid(
+        lamb=lamb,
+        seds=seds,
+        grid=[1],         # dummy input for now
+        backend="memory",
+    )
+
+    frac_unc = 0.1
+
+    # make splinter noisemodel
+    noise_fname = "/tmp/splinter_example_noisemodel_{:.2f}.grid.hd5".format(frac_unc)
+    make_splinter_noise_model(
+        noise_fname,
+        modelsedgrid,
+        frac_unc=frac_unc,
+    )
+
+    # read entire noisemodel back in
+    noisemodel = h5py.File(noise_fname)
+
+    # read the estimated sigma and check if close to manually computed errors
+    sigma = noisemodel["error"]
+
+    np.testing.assert_allclose(sigma, frac_unc * seds)

--- a/beast/observationmodel/tests/test_extra_filters.py
+++ b/beast/observationmodel/tests/test_extra_filters.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from beast.observationmodel.extra_filters import make_integration_filter
+
+@pytest.mark.parametrize(
+    "lambda_start,lambda_finish,d_lambda",
+    [90., 913., 1.],
+)
+def test_extra_filters(lambda_start, lambda_finish, d_lambda):
+
+    # create example integration filter
+    f_int = make_integration_filter(
+        lambda_start, lambda_finish, d_lambda, "QION", observatory="Pseudo", instrument="Fake"
+    )
+
+    # test bandwidth and name
+    np.testing.assert_allclose(f_int.bandwidth, lambda_finish - lambda_start)
+    assert f_int.name == "Pseudo_Fake_QION"
+
+    # create example top hat filters
+    f_top = make_top_hat_filter(
+        lambda_start, lambda_finish, d_lambda, "TOP", observatory="Pseudo", instrument="Fake"
+    )
+
+    np.testing.assert_allclose(f_top.bandwidth, lambda_finish - lambda_start)
+    assert f_top.name == "Pseudo_Fake_TOP"

--- a/beast/observationmodel/tests/test_extra_filters.py
+++ b/beast/observationmodel/tests/test_extra_filters.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
 
-from beast.observationmodel.extra_filters import make_integration_filter
+from beast.observationmodel.extra_filters import make_integration_filter, make_top_hat_filter
+
 
 @pytest.mark.parametrize(
     "lambda_start,lambda_finish,d_lambda",
-    [90., 913., 1.],
+    [(90., 913., 1.), (1000, 3000, 100)],
 )
 def test_extra_filters(lambda_start, lambda_finish, d_lambda):
 
@@ -15,7 +16,7 @@ def test_extra_filters(lambda_start, lambda_finish, d_lambda):
     )
 
     # test bandwidth and name
-    np.testing.assert_allclose(f_int.bandwidth, lambda_finish - lambda_start)
+    np.testing.assert_allclose(f_int.bandwidth, lambda_finish - lambda_start - d_lambda)
     assert f_int.name == "Pseudo_Fake_QION"
 
     # create example top hat filters
@@ -23,5 +24,5 @@ def test_extra_filters(lambda_start, lambda_finish, d_lambda):
         lambda_start, lambda_finish, d_lambda, "TOP", observatory="Pseudo", instrument="Fake"
     )
 
-    np.testing.assert_allclose(f_top.bandwidth, lambda_finish - lambda_start)
+    np.testing.assert_allclose(f_top.bandwidth, lambda_finish - lambda_start - d_lambda)
     assert f_top.name == "Pseudo_Fake_TOP"


### PR DESCRIPTION
Add two small changes:
- Fix documentation and create test for `extra_filters.py`
- Create simple test for reading, writing, and verifying simple uncertainties in `splinter.py` model

Note that we may want to eventually migrate the toothpick noisemodel test to `beast/observationmodel/noisemodel/tests` (currently residing in beast/observationmodel/tests)

Addresses first point (splinter construction) of #378 