### PR TITLE
Edit Stellar Priors

### DIFF
--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -71,7 +71,7 @@ def compute_age_mass_metallicity_weights(
         uniq_ages = np.unique(_tgrid[zindxs]["logA"])
 
         # compute the age weights
-        age_grid_weights = compute_age_grid_weights(uniq_ages, **kwargs)
+        age_grid_weights = compute_age_grid_weights(uniq_ages)
         age_prior_weights = compute_age_prior_weights(uniq_ages, age_prior_model)
 
         for ak, age_val in enumerate(uniq_ages):

--- a/beast/physicsmodel/prior_weights_dust.py
+++ b/beast/physicsmodel/prior_weights_dust.py
@@ -5,6 +5,7 @@ The priors on A(V), R(V), and f_A computed as weights to use
 in the posterior calculations.
 """
 import numpy as np
+from sys import exit
 
 __all__ = ["PriorWeightsDust"]
 

--- a/beast/physicsmodel/prior_weights_dust.py
+++ b/beast/physicsmodel/prior_weights_dust.py
@@ -223,7 +223,7 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
-                N2=1.0,
+                N2=1.0
             )
         elif model["name"] == "exponential":
             self.av_priors = _exponential(self.av_vals, a=model["a"])
@@ -261,7 +261,7 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
-                N2=1.0,
+                N2=1.0
             )
         else:
             print("**error in setting the R(V) dust prior weights!**")
@@ -297,6 +297,7 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
+                N2=1.0
             )
         else:
             print("**error in setting the f_A dust prior weights!**")

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -4,6 +4,7 @@ Prior Weights
 The priors on age, mass, and metallicty are computed as weights to use
 in the posterior calculations.
 """
+from sys import exit
 import numpy as np
 from scipy.integrate import quad
 from scipy.interpolate import interp1d

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -45,9 +45,12 @@ def compute_age_prior_weights(logages, age_prior_model):
         # assumes the logace spacing is uniform
         age_weights = 1.0 / compute_age_grid_weights(logages)
     elif age_prior_model["name"] == "bins_histo":
+        # interpolate according to bins, assuming SFR constant from i to i+1
+        # and allow for bin edges input
+        if len(age_prior_model["values"]) == len(age_prior_model["logages"])-1:
+            age_prior_model["values"].append(0.0)
         ageND = interp1d(
-            age_prior_model["logages"], age_prior_model["values"], kind="nearest"
-        )
+            age_prior_model["logages"], age_prior_model["values"], kind="zero")
         age_weights = ageND(logages)
     elif age_prior_model["name"] == "bins_interp":
         # interpolate model to grid ages

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -60,8 +60,9 @@ def compute_age_prior_weights(logages, age_prior_model):
             np.array(age_prior_model["values"]),
         )
     elif age_prior_model["name"] == "exp":
-        vals = (10 ** logages) / (age_prior_model["tau"] * 1e6)
-        age_weights = np.exp(-1.0 * vals)
+        # assumes SFR(t) \propto e**(-t/tau) where age=(t0-t) and tau in Gyr
+        vals = (10 ** logages) / (age_prior_model["tau"] * 1e9)
+        age_weights = np.exp(vals)
     else:
         print(
             "input age prior ''{}'' function not supported".format(

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -61,7 +61,8 @@ def compute_age_prior_weights(logages, age_prior_model):
             np.array(age_prior_model["values"]),
         )
     elif age_prior_model["name"] == "exp":
-        # assumes SFR(t) \propto e**(-t/tau) where age=(t0-t) and tau in Gyr
+        # assumes SFR(t) \propto e**(-t/tau) \propto e**(age/tau)
+        # where age \propto -t (for age=t0-t) and tau in Gyr
         vals = (10 ** logages) / (age_prior_model["tau"] * 1e9)
         age_weights = np.exp(vals)
     else:

--- a/docs/beast_priors.rst
+++ b/docs/beast_priors.rst
@@ -54,7 +54,7 @@ For example, step like priors can be specified by:
                      'logages': [6.0, 7.0, 8.0, 9.0, 10.0],
                      'values': [1.0, 2.0, 1.0, 5.0, 3.0]}
 
-Or by using bin edges, similar to outputs from `np.histo`:
+Or using bin edges (where N = N_values+1) like those output by `np.histogram()`:
 
 .. code-block:: python
 

--- a/docs/beast_priors.rst
+++ b/docs/beast_priors.rst
@@ -54,6 +54,14 @@ For example, step like priors can be specified by:
                      'logages': [6.0, 7.0, 8.0, 9.0, 10.0],
                      'values': [1.0, 2.0, 1.0, 5.0, 3.0]}
 
+Or by using bin edges, similar to outputs from `np.histo`:
+
+.. code-block:: python
+
+  age_prior_model = {'name': 'bins_histo',
+                     'logages': [6.0, 7.0, 8.0, 9.0, 10.0],
+                     'values': [1.0, 2.0, 1.0, 5.0]}
+
 For example, lines connecting the bin value of the priors can be specified by:
 
 .. code-block:: python
@@ -62,13 +70,13 @@ For example, lines connecting the bin value of the priors can be specified by:
                     'logages': [6.0, 7.0, 8.0, 9.0, 10.0],
                     'values': [1.0, 2.0, 1.0, 5.0, 3.0]}
 
-4. An exponentially decreasing SFR starting at 1.0,
-with a 100 Myr time constant is:
+4. An exponentially decreasing SFR (in time, but here increasing with age)
+with a 0.1 Gyr time constant (with `tau` parameter in Gyr):
 
 .. code-block:: python
 
   age_prior_model = {'name': 'exp',
-                     'tau': 100.}
+                     'tau': 0.1}
 
 Plot showing examples of the possible age prior models with the parameters given above.
 
@@ -97,7 +105,7 @@ Plot showing examples of the possible age prior models with the parameters given
             "logages": [6.0, 7.0, 8.0, 9.0, 10.0],
             "values": [1.0, 2.0, 1.0, 5.0, 3.0],
         },
-        {"name": "exp", "tau": 100.0}
+        {"name": "exp", "tau": 0.1}
     ]
 
     for ap_mod in age_prior_models:


### PR DESCRIPTION
This PR builds on https://github.com/BEAST-Fitting/beast/pull/387 and edits a number of behaviors of the age priors:

1. Use `kind="zero"` for 1D interpolation of `bins_histo` age priors to better match piecewise constant SFH inputs.  Also allows for bin edges style `logages` model input.

2. Change `exp` age prior model to match canonical tau model of SFH, with decreasing SFR as function of time (or, increasing with age) and tau parameter quoted in Gyr units.

Also: edits docs to match new behavior, assorted clean-up edits.

Closes #426.