### PR TITLE
code to plot noise models

### DIFF
--- a/beast/plotting/plot_noisemodel.py
+++ b/beast/plotting/plot_noisemodel.py
@@ -1,0 +1,161 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+
+from beast.physicsmodel.grid import FileSEDGrid
+import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
+
+
+
+
+def plot_noisemodel(
+    sed_file,
+    noise_file_list,
+    plot_file,
+    samp=100,
+    color=['black','red','gold','lime','xkcd:azure'],
+):
+    """
+    Make a plot of the noise model: for each of the bandsm make plots of bias
+    and uncertainty as a function of flux
+
+    If there are multiple files in noise_file_list, each of them will be
+    overplotted in each panel.
+
+    Parameters
+    ----------
+    sed_file : string
+        path+name of the SED grid file
+
+    noise_file_list : list of strings
+        path+name of the noise model file(s)
+
+    plot_file : string
+        name of the file to save the plot
+
+    samp : int (default=100)
+        plotting all of the SED points takes a long time for a viewer to load,
+        so set this to plot every Nth point
+
+    color : list of strings (default=['black','red','gold','lime','xkcd:azure'])
+        colors to cycle through when making plots
+    """
+
+    # read in the SED grid
+    print('* reading SED grid file')
+    sed_object = FileSEDGrid(sed_file)
+    if hasattr(sed_object.seds, "read"):
+        sed_grid = sed_object.seds.read()
+    else:
+        sed_grid = sed_object.seds
+    filter_list = sed_object.filters
+    n_filter = len(filter_list)
+
+    # figure
+    fig = plt.figure(figsize=(4 * n_filter, 10))
+
+    # go through noise files
+    for n, nfile in enumerate(noise_file_list):
+
+        print('* reading '+nfile)
+
+        # read in the values
+        noisemodel_vals = noisemodel.get_noisemodelcat(nfile)
+
+        # extract error and bias
+        noise_err = noisemodel_vals.root.error[:]
+        noise_bias = noisemodel_vals.root.bias[:]
+        # error is negative where it's been extrapolated -> trim those
+        good_err = np.where(noise_err > 0)[0]
+
+        # plot things
+        for f, filt in enumerate(filter_list):
+
+            # error is negative where it's been extrapolated -> trim those
+            good_err = np.where(noise_err[:,f] > 0)[0]
+            plot_sed = sed_grid[good_err, f][::samp]
+            plot_err = noise_err[good_err, f][::samp]
+            plot_bias = noise_bias[good_err, f][::samp]
+
+            # subplot region: bias
+            ax = plt.subplot(2, n_filter, f + 1)
+
+            plt.plot(
+                np.log10(plot_sed), plot_bias/plot_sed,
+                marker='o', linestyle='none', mew=0, ms=2,
+                color=color[n % len(color)], alpha=0.1)
+
+            ax.tick_params(axis="both", which="major", labelsize=12)
+            #ax.set_xlim(ax.get_xlim()[::-1])
+            plt.xlabel(filt, fontsize=12)
+            plt.ylabel(r"Bias ($\mu$/F)", fontsize=12)
+
+
+            # subplot region: error
+            ax = plt.subplot(2, n_filter, n_filter + f + 1)
+
+            plt.plot(
+                np.log10(plot_sed), plot_err/plot_sed,
+                marker='o', linestyle='none', mew=0, ms=2,
+                color=color[n % len(color)], alpha=0.1)
+
+            ax.tick_params(axis="both", which="major", labelsize=12)
+            #ax.set_xlim(ax.get_xlim()[::-1])
+            plt.xlabel(filt, fontsize=12)
+            plt.ylabel(r"Error ($\sigma$/F)", fontsize=12)
+
+
+    plt.tight_layout()
+
+    fig.savefig(plot_file)
+    plt.close(fig)
+
+
+if __name__ == '__main__':
+
+    # commandline parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "sed_file",
+        type=str,
+        help="path+name of the sed grid file",
+    )
+    parser.add_argument(
+        "noise_file_list",
+        type=str,
+        nargs='+',
+        help="path+name of the noise model file(s)",
+    )
+    parser.add_argument(
+        "phot_file",
+        type=str,
+        help="name of the file to save the plot",
+    )
+    parser.add_argument(
+        "--samp",
+        type=int,
+        default=100,
+        help="plot every Nth point",
+    )
+    parser.add_argument(
+        "--color",
+        type=str,
+        nargs='+',
+        default=['black','red','gold','lime','xkcd:azure'],
+        help="colors to cycle through when making plots",
+    )
+
+    args = parser.parse_args()
+
+    plot_noisemodel(
+        args.sed_file,
+        args.noise_file_list,
+        args.phot_file,
+        samp=args.samp,
+        color=args.color,
+    )
+
+
+    # print help if no arguments
+    if not any(vars(args).values()):
+        parser.print_help()

--- a/beast/plotting/plot_noisemodel.py
+++ b/beast/plotting/plot_noisemodel.py
@@ -14,6 +14,7 @@ def plot_noisemodel(
     plot_file,
     samp=100,
     color=['black','red','gold','lime','xkcd:azure'],
+    label=None,
 ):
     """
     Make a plot of the noise model: for each of the bandsm make plots of bias
@@ -39,6 +40,9 @@ def plot_noisemodel(
 
     color : list of strings (default=['black','red','gold','lime','xkcd:azure'])
         colors to cycle through when making plots
+
+    label : list of strings (default=None)
+        if set, use these labels in a legend for each item in noise_file_list
     """
 
     # read in the SED grid
@@ -76,31 +80,48 @@ def plot_noisemodel(
             plot_bias = noise_bias[good_err, f][::samp]
 
             # subplot region: bias
-            ax = plt.subplot(2, n_filter, f + 1)
+            ax1 = plt.subplot(2, n_filter, f + 1)
 
-            plt.plot(
+            plot1, = ax1.plot(
                 np.log10(plot_sed), plot_bias/plot_sed,
                 marker='o', linestyle='none', mew=0, ms=2,
                 color=color[n % len(color)], alpha=0.1)
+            if label is not None:
+                plot1.set_label(label[n])
 
-            ax.tick_params(axis="both", which="major", labelsize=12)
+            ax1.tick_params(axis="both", which="major", labelsize=13)
             #ax.set_xlim(ax.get_xlim()[::-1])
             plt.xlabel('log '+filt, fontsize=12)
             plt.ylabel(r"Bias ($\mu$/F)", fontsize=12)
 
 
             # subplot region: error
-            ax = plt.subplot(2, n_filter, n_filter + f + 1)
+            ax2 = plt.subplot(2, n_filter, n_filter + f + 1)
 
-            plt.plot(
+            plot2, = ax2.plot(
                 np.log10(plot_sed), plot_err/plot_sed,
                 marker='o', linestyle='none', mew=0, ms=2,
                 color=color[n % len(color)], alpha=0.1)
+            if label is not None:
+                plot2.set_label(label[n])
 
-            ax.tick_params(axis="both", which="major", labelsize=12)
+            ax2.tick_params(axis="both", which="major", labelsize=13)
             #ax.set_xlim(ax.get_xlim()[::-1])
             plt.xlabel('log '+filt, fontsize=12)
             plt.ylabel(r"Error ($\sigma$/F)", fontsize=12)
+
+            # do a legend if this is
+            # (a) the leftmost panel
+            # (b) the last line to be added
+            # (c) there are labels set
+            if (f == 0) and (n == len(noise_file_list)-1) and (label is not None):
+                leg = ax1.legend(fontsize=12)
+                for lh in leg.legendHandles:
+                    lh._legmarker.set_alpha(1)
+                leg = ax2.legend(fontsize=12)
+                for lh in leg.legendHandles:
+                    lh._legmarker.set_alpha(1)
+
 
 
     plt.tight_layout()
@@ -142,6 +163,13 @@ if __name__ == '__main__':
         default=['black','red','gold','lime','xkcd:azure'],
         help="colors to cycle through when making plots",
     )
+    parser.add_argument(
+        "--label",
+        type=str,
+        nargs='+',
+        default=None,
+        help="if set, use these labels in a legend for each item in noise_file_list",
+    )
 
     args = parser.parse_args()
 
@@ -151,6 +179,7 @@ if __name__ == '__main__':
         args.phot_file,
         samp=args.samp,
         color=args.color,
+        label=args.label,
     )
 
 

--- a/beast/plotting/plot_noisemodel.py
+++ b/beast/plotting/plot_noisemodel.py
@@ -65,8 +65,6 @@ def plot_noisemodel(
         # extract error and bias
         noise_err = noisemodel_vals.root.error[:]
         noise_bias = noisemodel_vals.root.bias[:]
-        # error is negative where it's been extrapolated -> trim those
-        good_err = np.where(noise_err > 0)[0]
 
         # plot things
         for f, filt in enumerate(filter_list):

--- a/beast/plotting/plot_noisemodel.py
+++ b/beast/plotting/plot_noisemodel.py
@@ -87,7 +87,7 @@ def plot_noisemodel(
 
             ax.tick_params(axis="both", which="major", labelsize=12)
             #ax.set_xlim(ax.get_xlim()[::-1])
-            plt.xlabel(filt, fontsize=12)
+            plt.xlabel('log '+filt, fontsize=12)
             plt.ylabel(r"Bias ($\mu$/F)", fontsize=12)
 
 
@@ -101,7 +101,7 @@ def plot_noisemodel(
 
             ax.tick_params(axis="both", which="major", labelsize=12)
             #ax.set_xlim(ax.get_xlim()[::-1])
-            plt.xlabel(filt, fontsize=12)
+            plt.xlabel('log '+filt, fontsize=12)
             plt.ylabel(r"Error ($\sigma$/F)", fontsize=12)
 
 

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -3,12 +3,30 @@ Plotting Tools
 ##############
 
 There are `several scripts
-<https://github.com/BEAST-Fitting/beast/tree/master/beast/plotting>`_ for making diagnostic plots.  Some are described here.
+<https://github.com/BEAST-Fitting/beast/tree/master/beast/plotting>`_ for making
+diagnostic plots.  Some are described here.
 
-  * `plot_chi2_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_chi2_hist.py>`_: Make a histogram of the best chi2 values (chi2=1 and the median chi2 are marked).  Note that there is no plot of reduced chi2, because it is mathematically difficult to define the number of degrees of freedom.  Inputs are the BEAST stats file and optionally the number of bins to use for the histogram.
-  * `plot_cmd.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd.py>`_: Make a color-magnitude diagram of the observations.  Inputs are the photometry file (which can be a `simulation <https://beast.readthedocs.io/en/latest/simulations.html#plotting>`_) and the three filters.
-  * `plot_cmd_with_fits.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd_with_fits.py>`_: Similar to above, but color-coding the data points using one of the parameters from the BEAST fitting.  Takes three additional inputs: a BEAST stats file, the parameter to use, and whether to apply color after taking the log10 of the parameter.
-  * `plot_indiv_fit.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_indiv_fit.py>`_: For a given star, makes a multi-panel plot that shows the PDFs and best fits of each parameter, as well as an SED (similar to Figure 14 in `Gordon+16 <http://adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
-  * `plot_mag_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_mag_hist.py>`_: Make histograms of the magnitudes for each band in the photometry catalog.
+- `plot_chi2_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_chi2_hist.py>`_:
+  Make a histogram of the best chi2 values (chi2=1 and the median chi2 are
+  marked).  Note that there is no plot of reduced chi2, because it is mathematically
+  difficult to define the number of degrees of freedom.  Inputs are the BEAST stats
+  file and optionally the number of bins to use for the histogram.
 
+- `plot_cmd.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd.py>`_:
+  Make a color-magnitude diagram of the observations.  Inputs are the photometry
+  file (which can be a `simulation <https://beast.readthedocs.io/en/latest/simulations.html#plotting>`_)
+  and the three filters.
 
+- `plot_cmd_with_fits.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_cmd_with_fits.py>`_:
+  Similar to above, but color-coding the data points using one of the parameters
+  from the BEAST fitting.  Takes three additional inputs: a BEAST stats file,
+  the parameter to use, and whether to apply color after taking the log10 of the
+  parameter.
+
+- `plot_indiv_fit.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_indiv_fit.py>`_:
+  For a given star, makes a multi-panel plot that shows the PDFs and best fits
+  of each parameter, as well as an SED (similar to Figure 14 in
+  `Gordon+16 <http://adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
+
+- `plot_mag_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_mag_hist.py>`_:
+  Make histograms of the magnitudes for each band in the photometry catalog.

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -26,7 +26,13 @@ diagnostic plots.  Some are described here.
 - `plot_indiv_fit.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_indiv_fit.py>`_:
   For a given star, makes a multi-panel plot that shows the PDFs and best fits
   of each parameter, as well as an SED (similar to Figure 14 in
-  `Gordon+16 <http://adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
+  `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
 
 - `plot_mag_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_mag_hist.py>`_:
   Make histograms of the magnitudes for each band in the photometry catalog.
+
+- `plot_noisemodel.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_noisemodel.py>`_:
+  Plot the bias and uncertainty as a function of flux (similar to Figure 12 in
+  `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
+  Multiple noise models can be overplotted, as long as they correspond to the
+  same SED model grid.


### PR DESCRIPTION
I wrote `beast/plotting/plot_noisemodel.py` to make a similar visualization as [Figure 12 in Gordon+16](http://www.astroexplorer.org/details/apjaa2ee4f12), which plots bias and uncertainty as a function of flux.  It can do one (or more) noise models, as long as they're derived for the same SED model grid. 

Here's an example plot for one of the METAL fields.  The ubiquitous squiggles are because these noise models were made from a small set of ASTs.
![noisemodel_plot](https://user-images.githubusercontent.com/32465297/67799226-5ebe2b80-fa5b-11e9-9bd0-bfc4f8c91a1a.png)

I also added a note about the code in the documentation.


