### PR TITLE
updates to simulate_obs.py

### DIFF
--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -85,9 +85,28 @@ if __name__ == "__main__":
 
     # commandline parser
     parser = argparse.ArgumentParser()
-    parser.add_argument("physgrid", args='+', help="filename(s) of physics grid(s)")
-    parser.add_argument("noise_model", args='+', help="filename(s) of observation/noise grid(s)")
-    parser.add_argument("output_catalog", help="filename for simulated observations")
+    parser.add_argument(
+        "--physgrid_list",
+        "-p",
+        metavar="PHYS_MODEL",
+        required=True,
+        nargs='+',
+        help="filename(s) of physics grid(s)",
+    )
+    parser.add_argument(
+        "--noise_model_list",
+        "-n",
+        metavar="NOISE_MODEL",
+        required=True,
+        nargs='+',
+        help="filename(s) of observation/noise grid(s)",
+    )
+    parser.add_argument(
+        "--output_catalog",
+        "-c",
+        required=True,
+        help="filename for simulated observations",
+    )
     parser.add_argument(
         "--nsim", default=100, type=int, help="number of simulated objects"
     )
@@ -101,8 +120,8 @@ if __name__ == "__main__":
 
     # run observation simulator
     simulate_obs(
-        args.physgrid,
-        args.noise_model,
+        args.physgrid_list,
+        args.noise_model_lists,
         args.output_catalog,
         nsim=args.nsim,
         compl_filter=args.compl_filter,

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -55,7 +55,9 @@ def simulate_obs(
     simtable_list = []
 
     # make a table for each physics model + noise model
-    for physgrid, noise_model in zip(physgrid_list, noise_model_list):
+    for physgrid, noise_model in zip(
+        np.atleast_1d(physgrid_list), np.atleast_1d(noise_model_list)
+    ):
 
         # get the physics model grid - includes priors
         modelsedgrid = FileSEDGrid(physgrid)

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -1,3 +1,4 @@
+import numpy as np
 import argparse
 
 from beast.physicsmodel.grid import FileSEDGrid
@@ -8,7 +9,7 @@ from astropy.table import vstack
 
 def simulate_obs(
     physgrid_list,
-    noise_model,
+    noise_model_list,
     output_catalog,
     nsim=100,
     compl_filter="F475W",
@@ -48,7 +49,7 @@ def simulate_obs(
     # numbers of samples to do
     # (ensure there are enough for even sampling of multiple model grids)
     n_phys = len(physgrid_list)
-    samples_per_grid = int(np.ceil(n_sim/n_phys))
+    samples_per_grid = int(np.ceil(nsim/n_phys))
 
     # list to hold all simulation tables
     simtable_list = []


### PR DESCRIPTION
I made two major updates to `beast.tools.simulate_obs.py`:
* move code into a function, so it can be imported OR used with argparse
* to support subgrids, the physics and noise model inputs are now lists (where each subgrid has its corresponding noise model), and stars are drawn successively from each of them.

This is fine to merge now, or wait until I've finished a workflow example of running the simulated observations through the BEAST.