### PR TITLE
only use python 3 for LGTM

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,12 @@
+# info from documentation:
+# https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html#python_setup
+# and from the example:
+# https://help.semmle.com/lgtm-enterprise/user/Resources/downloads/lgtm.template.yml
+
+extraction:
+  python:
+    python_setup:
+      # Override the version of the Python interpreter used for setup and extraction
+      # Default: Python 3 if no version is explicitly specified, and if there are no
+      # commits to the repository before January 1, 2017. Otherwise Python 2.
+      version: 3

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -3,6 +3,9 @@
 # and from the example:
 # https://help.semmle.com/lgtm-enterprise/user/Resources/downloads/lgtm.template.yml
 
+queries:
+  - exclude: cpp
+
 extraction:
   python:
     python_setup:


### PR DESCRIPTION
I decided to devote 15 minutes to seeing if I could make LGTM not give python 2 related errors, and shockingly, I think I might have found an answer.  So I've added `lgtm.yml` to (hopefully) force it to use only python 3.

Documentation:
https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html#python_setup
Example file that I copied the settings from:
https://help.semmle.com/lgtm-enterprise/user/Resources/downloads/lgtm.template.yml