### PR TITLE
many things for parameter verification

### DIFF
--- a/beast/examples/production_runs_2019/beast_production_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_production_wrapper.py
@@ -237,12 +237,6 @@ def beast_production_wrapper():
             print('\n**** go run physics model code for '+field_names[b]+'! ****')
             continue
 
-        # list of SED files
-        model_grid_files = sorted(
-            glob.glob(
-                "./{0}_beast/{0}_beast_seds.grid{1}.hd5".format(field_names[b], gs_str)
-            )
-        )
 
         # -----------------
         # 3. make ASTs

--- a/beast/examples/production_runs_2019/beast_verification_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_verification_wrapper.py
@@ -111,8 +111,8 @@ def beast_verification_wrapper():
         im_file = im_path[b]
 
         create_datamodel(
-            gst_file,
-            ast_file,
+            gst_file_orig,
+            ast_file_orig,
             gst_filter_names,
             beast_filter_names,
             dist_mod[b],
@@ -205,8 +205,8 @@ def beast_verification_wrapper():
             proj_type='sim',
         )
 
-        # load in datamodel
-        import datamodel; importlib.reload(datamodel)
+        # load in datamodel again
+        importlib.reload(datamodel)
 
 
         # -----------------

--- a/beast/examples/production_runs_2019/beast_verification_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_verification_wrapper.py
@@ -11,10 +11,7 @@ from beast.tools.run import (
 
 from beast.tools import (
     simulate_obs,
-    setup_batch_beast_trim,
     setup_batch_beast_fit,
-    reorder_beast_results_spatial,
-    condense_beast_results_spatial,
 )
 from beast.plotting import (
     plot_param_recovery,
@@ -31,7 +28,6 @@ importlib.reload(merge_files)
 importlib.reload(create_filenames)
 
 from astropy.table import Table, vstack
-from astropy.io import fits
 
 
 def beast_verification_wrapper():
@@ -70,10 +66,6 @@ def beast_verification_wrapper():
     # the path+file for a reference image
     im_path = ["../beast_dwarfs/images/15275_IC1613_F555W_drz.fits.gz"]
     ref_filter = ["F555W"]
-
-    # choose a filter to use for removing artifacts
-    # (remove catalog sources with filter_FLAG > 99)
-    flag_filter = ["F555W"]
 
     # number of fields
     n_field = len(field_names)

--- a/beast/examples/production_runs_2019/beast_verification_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_verification_wrapper.py
@@ -1,0 +1,432 @@
+import numpy as np
+import glob
+import os
+
+from beast.tools.run import (
+    run_fitting,
+    merge_files,
+    create_filenames,
+    make_trim_scripts,
+)
+
+from beast.tools import (
+    simulate_obs,
+    setup_batch_beast_trim,
+    setup_batch_beast_fit,
+    reorder_beast_results_spatial,
+    condense_beast_results_spatial,
+)
+from beast.plotting import (
+    plot_param_recovery,
+    plot_param_err,
+    plot_triangle,
+)
+
+import importlib
+
+importlib.reload(make_trim_scripts)
+importlib.reload(run_fitting)
+importlib.reload(setup_batch_beast_fit)
+importlib.reload(merge_files)
+importlib.reload(create_filenames)
+
+from astropy.table import Table, vstack
+from astropy.io import fits
+
+
+def beast_verification_wrapper():
+    """
+    This wrapper does the processing for BEAST verification
+
+    Parameter recovery
+    * create simulated data for a given model grid + noise model
+    * generate batch script to trim models
+    * generate batch script to fit models
+    * merge stats files back together
+
+    Places for user to manually do things:
+    * editing code before use
+        - datamodel_template.py: setting up the file with desired parameters
+        - here: list the catalog filter names with the corresponding BEAST names
+        - here: number of simulated stars to generate
+        - here: choose settings (# files, nice level) for the trimming/fitting batch scripts
+    * process the ASTs, as described in BEAST documentation
+    * run the trimming scripts
+    * run the fitting scripts
+
+    BEWARE: When running the trimming/fitting scripts, ensure that the correct
+    datamodel.py file is in use.  Since it gets updated every time this code is
+    run, you may be unexpectedly be using one from another field.
+    """
+
+    # the list of fields
+    field_names = ["15275_IC1613"]
+
+    # distance moduli and velocities
+    # http://adsabs.harvard.edu/abs/2013AJ....146...86T
+    dist_mod = [24.36]
+    velocity = [-236]
+
+    # the path+file for a reference image
+    im_path = ["../beast_dwarfs/images/15275_IC1613_F555W_drz.fits.gz"]
+    ref_filter = ["F555W"]
+
+    # choose a filter to use for removing artifacts
+    # (remove catalog sources with filter_FLAG > 99)
+    flag_filter = ["F555W"]
+
+    # number of fields
+    n_field = len(field_names)
+
+    # Need to know what the correspondence is between filter names in the
+    # catalog and the BEAST filter names.
+    #
+    # These will be used to automatically determine the filters present in
+    # each GST file and fill in the datamodel.py file.  The order doesn't
+    # matter, as long as the order in one list matches the order in the other
+    # list.
+    #
+    gst_filter_names = ["F275W", "F336W", "F390M", "F555W", "F814W", "F110W", "F160W"]
+    beast_filter_names = [
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
+        "HST_WFC3_F390M",
+        "HST_WFC3_F555W",
+        "HST_WFC3_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
+    ]
+
+    for b in range(n_field):
+        # for b in [0]:
+
+        print("********")
+        print("field " + field_names[b])
+        print("********")
+
+        # -----------------
+        # 0. get original file names
+        # -----------------
+
+        print('')
+        print('retrieving original file names')
+        print('')
+
+        # paths for the data/AST files
+        gst_file_orig = './data/' + field_names[b]+'.gst_with_sourceden_cut.fits'
+        ast_file_orig = './data/' + field_names[b]+'.gst.fake_cut.fits'
+        # path for the reference image (if using for the background map)
+        im_file = im_path[b]
+
+        create_datamodel(
+            gst_file,
+            ast_file,
+            gst_filter_names,
+            beast_filter_names,
+            dist_mod[b],
+            velocity[b],
+            ref_image=im_file,
+            proj_type='beast',
+        )
+
+        # load in datamodel to get number of subgrids
+        import datamodel; importlib.reload(datamodel)
+
+        # grab relevant file names
+        file_dict = create_filenames.create_filenames(
+            use_sd=True,
+            nsubs=datamodel.n_subgrid,
+        )
+        modelsedgrid_files = file_dict['modelsedgrid_files']
+        noise_files = file_dict['noise_files']
+        sd_sub_info = file_dict["sd_sub_info"]
+        tot_files = len(sd_sub_info)
+
+
+        # -----------------
+        # 1. create simulated data
+        # -----------------
+
+        print('')
+        print('simulating data')
+        print('')
+
+        gst_file = gst_file_orig.replace('.gst','.sim.gst')
+        gst_subfile_form = gst_file.replace(
+            '.fits','_bin*_sub0.fits')
+
+        # loop through all files
+        # only grab files and simulate data when we're at sd_sub = [N,0]
+        for i in range(tot_files):
+
+            # find matches to sd_sub = [i,0]
+            inds_to_use = [ind for ind in range(tot_files)
+                if sd_sub_info[ind]==[str(i),'0']]
+
+            # if there are matches, use those corresponding files
+            if len(inds_to_use) > 0:
+
+                output_catalog = gst_subfile_form.replace('_bin*','_bin'+str(i))
+
+                if not os.path.isfile(output_catalog):
+
+                    print('generating simulated observations for bin='+str(i))
+
+                    grid_sublist = [modelsedgrid_files[x] for x in inds_to_use]
+                    noise_sublist = [noise_files[x] for x in inds_to_use]
+
+                    simulate_obs.simulate_obs(
+                        grid_sublist,
+                        noise_sublist,
+                        output_catalog,
+                        nsim=5000,
+                        compl_filter=ref_filter[b],
+                    )
+
+                else:
+                    print('simulated observations already exist for bin='+str(i))
+
+
+        # combine them all into one catalog
+        if not os.path.isfile(gst_file):
+            table_list = []
+            for cat_file in glob.glob(gst_subfile_form):
+                table_list.append(Table.read(cat_file))
+            vstack(table_list).write(gst_file, overwrite=True)
+
+        # -----------------
+        # 2. make new datamodel file
+        # -----------------
+
+        print('')
+        print('creating datamodel file')
+        print('')
+
+        create_datamodel(
+            gst_file,
+            ast_file_orig,
+            gst_filter_names,
+            beast_filter_names,
+            dist_mod[b],
+            velocity[b],
+            ref_image=im_file,
+            proj_type='sim',
+        )
+
+        # load in datamodel
+        import datamodel; importlib.reload(datamodel)
+
+
+        # -----------------
+        # 3. make symbolic links to model grids and noise models
+        # -----------------
+
+        # make new directory
+        if not os.path.isdir('./'+datamodel.project):
+            os.mkdir('./'+datamodel.project)
+
+        # symlink the physics/noise models
+        orig_phys = list(set(modelsedgrid_files))
+        for grid in orig_phys:
+            source = os.path.abspath(grid)
+            dest = os.path.abspath(grid.replace('_beast','_sim'))
+            if not os.path.islink(dest):
+                os.symlink(source, dest)
+        orig_noise = list(set(noise_files))
+        for grid in orig_noise:
+            source = os.path.abspath(grid)
+            dest = os.path.abspath(grid.replace('_beast','_sim'))
+            if not os.path.islink(dest):
+                os.symlink(source, dest)
+
+        # -----------------
+        # 4. make script to trim models
+        # -----------------
+
+        print("")
+        print("setting up script to trim models")
+        print("")
+
+        job_file_list = make_trim_scripts.make_trim_scripts(
+            num_subtrim=1, prefix='source activate b13'
+        )
+
+        if len(job_file_list) > 0:
+            print('\n**** go run trimming code for '+field_names[b]+'! ****')
+            print('Here are the command(s) to run:')
+            for job in job_file_list:
+                print('at -f '+job+' now')
+            return
+        else:
+            print('all files are trimmed for '+field_names[b])
+
+
+
+        # -----------------
+        # 5. make script to fit models
+        # -----------------
+
+        print("")
+        print("setting up script to fit models")
+        print("")
+
+        fit_run_info = setup_batch_beast_fit.setup_batch_beast_fit(
+            num_percore=1,
+            nice=19,
+            overwrite_logfile=False,
+            prefix="source activate b13",
+            use_sd=True,
+            nsubs=datamodel.n_subgrid,
+            nprocs=1,
+        )
+
+        # check if the fits exist before moving on
+        tot_remaining = len(fit_run_info["done"]) - np.sum(fit_run_info["done"])
+        if tot_remaining > 0:
+            print("\n**** go run fitting code for " + field_names[b] + "! ****")
+            print(
+                "Here are the "
+                + str(len(fit_run_info["files_to_run"]))
+                + " commands to run:"
+            )
+            for job_file in fit_run_info["files_to_run"]:
+                print("at -f ./" + job_file + " now")
+            continue
+        else:
+            print("all fits are complete for " + field_names[b])
+
+
+        # -----------------
+        # 6. plots
+        # -----------------
+
+        print('')
+        print('making plots')
+        print('')
+
+        # grab relevant file names
+        file_dict = create_filenames.create_filenames(
+            use_sd=True,
+            nsubs=datamodel.n_subgrid,
+        )
+
+        plot_param_recovery.plot_param_recovery(
+            file_dict['photometry_files'],
+            file_dict['stats_files'],
+            field_names[b]+'_param_recovery.pdf',
+            max_nbins=20,
+        )
+
+        for stats_file in file_dict['stats_files']:
+            plot_param_err.plot(stats_file, n_bins=10)
+            plot_triangle.plot_triangle(stats_file)
+
+
+def create_datamodel(
+    gst_file,
+    ast_file,
+    gst_filter_label,
+    beast_filter_label,
+    dist_mod,
+    velocity,
+    ref_image="None",
+    proj_type="beast",
+):
+    """
+    Create a datamodel.py file for the given field.  This will open the file to
+    determine the filters present - the `*_filter_label` inputs are references
+    to properly interpret the file's information.
+
+    Parameters
+    ----------
+    gst_file : string
+        the path+name of the GST file
+
+    ast_file : string
+        the path+name of the AST file
+
+    gst_filter_label : list of strings
+        Labels used to represent each filter in the photometry catalog
+
+    beast_filter_label : list of strings
+        The corresponding full labels used by the BEAST
+
+    dist_mod : float
+        distance modulus of the source (mag)
+
+    velocity : float
+        velocity to use for the source (km/s)
+
+    ref_image : string (default='None')
+        path+name of image to use as reference for ASTs
+
+    proj_type : string (default='beast')
+        type of project: BEAST run ('beast') or simulation ('sim')
+
+    Returns
+    -------
+    nothing
+
+    """
+
+    # read in the catalog
+    cat = Table.read(gst_file)
+
+    # get the list of filters
+    filter_list_base = []
+    filter_list_long = []
+    for f in range(len(gst_filter_label)):
+        filt_exist = [gst_filter_label[f] in c for c in cat.colnames]
+        if np.sum(filt_exist) > 0:
+            filter_list_base.append(gst_filter_label[f])
+            filter_list_long.append(beast_filter_label[f])
+
+    # read in the template datamodel file
+    orig_file = open("datamodel_template.py", "r")
+    datamodel_lines = np.array(orig_file.readlines())
+    orig_file.close()
+
+    # write out an edited datamodel
+    new_file = open("datamodel.py", "w")
+
+    for i in range(len(datamodel_lines)):
+
+        # replace project name with the field ID
+        if datamodel_lines[i][0:10] == 'project = ':
+            new_file.write(
+                'project = "' + gst_file.split('/')[-1].split('.')[0]+ '_'+proj_type+'"\n'
+            )
+        # obsfile
+        elif datamodel_lines[i][0:10] == "obsfile = ":
+            new_file.write('obsfile = "' + gst_file + '"\n')
+        # AST file name
+        elif datamodel_lines[i][0:10] == "astfile = ":
+            new_file.write('astfile = "' + ast_file + '"\n')
+        # BEAST filter names
+        elif datamodel_lines[i][0:10] == "filters = ":
+            new_file.write("filters = ['" + "','".join(filter_list_long) + "'] \n")
+        # catalog filter names
+        elif datamodel_lines[i][0:14] == "basefilters = ":
+            new_file.write("basefilters = ['" + "','".join(filter_list_base) + "'] \n")
+        # distance modulus
+        elif datamodel_lines[i][0:12] == "distances = ":
+            new_file.write("distances = [" + str(dist_mod) + "] \n")
+        # velocity
+        elif datamodel_lines[i][0:11] == "velocity = ":
+            new_file.write("velocity = " + str(velocity) + " * units.km / units.s \n")
+        # AST stuff
+        # elif datamodel_lines[i][0:27] == 'ast_source_density_table = ':
+        #    new_file.write('ast_source_density_table = "' + gst_file.replace('.fits','_sourcedens_map.hd5')+'" \n')
+        elif datamodel_lines[i][0:22] == "ast_reference_image = ":
+            new_file.write('ast_reference_image = "' + ref_image + '" \n')
+        # none of those -> write line as-is
+        else:
+            new_file.write(datamodel_lines[i])
+
+    new_file.close()
+
+
+
+if __name__ == "__main__":
+
+    beast_verification_wrapper()

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -203,13 +203,13 @@ def gen_SimObs_from_sedgrid(
     n_models, n_filters = flux.shape
 
     # hack to get things to run for now
-    short_filters = [filter.split(sep="_")[-1].lower() for filter in sedgrid.filters]
-    if compl_filter.lower() not in short_filters:
+    short_filters = [filter.split(sep="_")[-1].upper() for filter in sedgrid.filters]
+    if compl_filter.upper() not in short_filters:
         print("requested completeness filter not present")
-        print("%s requested" % compl_filter.lower())
+        print("%s requested" % compl_filter.upper())
         print("possible filters", short_filters)
         exit()
-    filter_k = short_filters.index(compl_filter.lower())
+    filter_k = short_filters.index(compl_filter.upper())
     print("Completeness from %s" % sedgrid.filters[filter_k])
 
     # cache the noisemodel values
@@ -241,7 +241,7 @@ def gen_SimObs_from_sedgrid(
     qnames = list(sedgrid.keys())
     # simulated data
     for k, filter in enumerate(sedgrid.filters):
-        colname = "%s_rate" % filter.split(sep="_")[-1].lower()
+        colname = "%s_RATE" % filter.split(sep="_")[-1].upper()
         simflux_wbias = flux[sim_indx, k] + model_bias[sim_indx, k]
         simflux = np.random.normal(loc=simflux_wbias, scale=model_unc[sim_indx, k])
         ot[colname] = Column(simflux / vega_flux[k])

--- a/beast/observationmodel/tests/test_simobs.py
+++ b/beast/observationmodel/tests/test_simobs.py
@@ -38,4 +38,11 @@ def test_trim_grid():
     # check that the simobs files are exactly the same
     table_cache = Table.read(simobs_fname_cache)
 
+    # to avoid issues with uppercase vs lowercase column names, make them all
+    # the same before comparing
+    for col in table_new.colnames:
+        table_new[col].name = col.upper()
+    for col in table_cache.colnames:
+        table_cache[col].name = col.upper()
+
     compare_tables(table_cache, table_new)

--- a/beast/plotting/plot_param_err.py
+++ b/beast/plotting/plot_param_err.py
@@ -1,0 +1,70 @@
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+from astropy.io import fits
+
+def plot(beast_stats_file,
+             param_list=['Av', 'Rv', 'logA', 'f_A', 'M_ini', 'Z'],#, 'distance'],
+             n_bins=200):
+    """
+    Make a plot of each parameter vs the parameter errors
+
+    Parameters with 'M_' (indicating mass) will have log10 taken to help with
+    axis scaling
+
+    Parameters
+    ----------
+    beast_stats_file : str
+        path+file for the BEAST fitting results
+
+    param_list : list of strings
+        names of the parameters to plot (default is the params in Fig 16/17
+        in Gordon+16)
+
+    n_bins : int (default=200)
+        number of bins to use in each dimension of the 2D histogram
+
+    """
+
+    # read in data
+    with fits.open(beast_stats_file) as hdu:
+        stats_table = hdu[1].data
+
+    n_param = len(param_list)
+
+    # figure
+    fig = plt.figure(figsize=(10,4*n_param/2))
+
+    # make plots
+    for p,param in enumerate(param_list):
+
+        # subplot region
+        ax = plt.subplot(n_param/2, 2, p+1)
+
+        plot_x = stats_table[param+'_p50']
+        plot_y = (stats_table[param+'_p84'] - stats_table[param+'_p16'])/2
+
+        if 'M_' in param:
+            plot_y = plot_y/(plot_x * np.log(10))
+            plot_x = np.log10(plot_x)
+
+        # plot
+        plt.hist2d(plot_x, plot_y,
+                       bins=n_bins, cmap='magma', norm=matplotlib.colors.LogNorm())
+
+
+
+        # axis labels
+        ax.tick_params(axis='both', which='major', labelsize=13)
+        #ax.set_xlim(ax.get_xlim()[::-1])
+        param_label = param
+        if 'M_' in param:
+            param_label = 'log '+param
+        plt.xlabel(param_label, fontsize=14)
+        plt.ylabel(r'$\sigma$ '+param_label, fontsize=14)
+
+
+    plt.tight_layout()
+
+    fig.savefig(beast_stats_file.replace('.fits', '_param_err.png'))
+    plt.close(fig)

--- a/beast/plotting/plot_param_recovery.py
+++ b/beast/plotting/plot_param_recovery.py
@@ -102,12 +102,3 @@ def plot_param_recovery(
 
     fig.savefig(output_plot_filename)
     plt.close(fig)
-
-
-
-
-
-
-if __name__ == '__main__':
-
-    plot_param_recovery()

--- a/beast/plotting/plot_param_recovery.py
+++ b/beast/plotting/plot_param_recovery.py
@@ -1,0 +1,113 @@
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+from astropy.io import fits
+
+
+
+def plot_param_recovery(
+    sim_data_list,
+    stats_file_list,
+    output_plot_filename,
+    file_label_list=None,
+    max_nbins=20,
+):
+    """
+    Make plots comparing the physical parameters from simulated data to the
+    recovered physical parameters
+
+    If there are multiple files input, it is presumably because they are from
+    different noise models.  If that's the case, you may want to assign labels
+    for each of them (file_label_list).
+
+    Parameters
+    ----------
+    sim_data_list : string or list of strings
+        File(s) of simulated data from beast.tools.simulate_obs, which have both
+        the photometry and physical parameters
+
+    stats_file_list : string or list of strings
+        File(s) of the corresponding stats files with the fit statistics
+
+    output_plot_filename : string
+        name of the file in which to save the output plot
+
+    file_label_list : string (default=None)
+        Labels to use for each of the files (e.g., their source density ranges)
+
+    max_nbins : int (default=10)
+        maximum number of bins to use in each dimension of the 2D histogram
+        (fewer will be used if there are fewer unique values)
+
+    """
+
+
+    # parameters to plot
+    param_list=['Av', 'logA', 'M_ini', 'Rv', 'f_A', 'Z', 'distance']
+    n_param = len(param_list)
+
+    # number of files
+    n_stat = len(sim_data_list)
+
+    # figure
+    fig = plt.figure(figsize=(5*n_stat, 4*n_param))
+
+    # iterate through the files
+    for i, (sim_stats, recov_stats) in enumerate(zip(
+        np.atleast_1d(sim_data_list), np.atleast_1d(stats_file_list)
+    )):
+
+        # read in data
+        with fits.open(sim_stats) as hdu_sim, fits.open(recov_stats) as hdu_recov:
+            sim_table = hdu_sim[1].data
+            recov_table = hdu_recov[1].data
+
+
+
+        # make plots
+        for p,param in enumerate(param_list):
+
+            # subplot region
+            ax = plt.subplot(n_param, n_stat, 1 + n_stat*p + i)
+
+            # set things to plot
+            plot_x = sim_table[param]
+            plot_y = recov_table[param+'_p50']
+
+            if ('M_' in param) or (param=='Z'):
+                plot_x = np.log10(plot_x)
+                plot_y = np.log10(plot_y)
+
+            # number of bins
+            n_uniq = len(np.unique(plot_x))
+            n_bins = [min(n_uniq, max_nbins), min(3*n_uniq, max_nbins)]
+
+            # plot
+            plt.hist2d(plot_x, plot_y,
+                           bins=n_bins, cmap='magma', norm=matplotlib.colors.LogNorm())
+
+
+
+            # axis labels
+            ax.tick_params(axis='both', which='major', labelsize=13)
+            #ax.set_xlim(ax.get_xlim()[::-1])
+            param_label = param
+            if ('M_' in param) or (param=='Z'):
+                param_label = 'log '+param
+            plt.xlabel('Simulated '+param_label, fontsize=14)
+            plt.ylabel('Recovered '+param_label, fontsize=14)
+
+
+    plt.tight_layout()
+
+    fig.savefig(output_plot_filename)
+    plt.close(fig)
+
+
+
+
+
+
+if __name__ == '__main__':
+
+    plot_param_recovery()

--- a/beast/plotting/plot_triangle.py
+++ b/beast/plotting/plot_triangle.py
@@ -84,8 +84,8 @@ def plot_triangle(
                 ax = plt.gca()
 
                 # make histogram
-                hist_output = plt.hist(plot_x, bins=20,
-                                facecolor='grey', linewidth=0.25, edgecolor='grey')
+                plt.hist(plot_x, bins=20,
+                         facecolor='grey', linewidth=0.25, edgecolor='grey')
 
                 ax.tick_params(axis='y',which='both',length=0, labelsize=14)
                 ax.tick_params(axis='x',which='both',direction='in', labelsize=14)

--- a/beast/plotting/plot_triangle.py
+++ b/beast/plotting/plot_triangle.py
@@ -1,0 +1,105 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.io import fits
+import copy
+
+def plot_triangle(
+    beast_stats_file,
+    param_list=['Av', 'Rv', 'logA', 'f_A', 'M_ini', 'Z', 'distance'],
+):
+    """
+    Make a triangle/corner plot of everything vs everything
+
+    Parameters
+    ----------
+    beast_stats_file : str
+        path+file for the BEAST fitting results
+
+    param_list : list of strings
+        names of the parameters to plot (default is the params in Fig 16/17
+        in Gordon+16)
+
+    """
+
+    n_params = len(param_list)
+
+    # read in data
+    with fits.open(beast_stats_file) as hdu:
+        stats_table = hdu[1].data
+
+    # figure
+    fig = plt.figure(figsize=(4*n_params, 4*n_params))
+
+    # iterate through the panels
+    for i,pi in enumerate(param_list):
+        for j,pj in enumerate(param_list[i:], i):
+
+            # set x/y axes
+            plot_x = stats_table[pi+'_p50']
+            plot_y = stats_table[pj+'_p50']
+            x_label = copy.copy(pi)
+            y_label = copy.copy(pj)
+            # take log if necessary
+            if ('M_' in pi) or (pi == 'Z'):
+                plot_x = np.log10(plot_x)
+                x_label = 'log '+pi
+            if ('M_' in pj) or (pj == 'Z'):
+                plot_y = np.log10(plot_y)
+                y_label = 'log '+pj
+
+
+            # not along diagonal
+            if i != j:
+
+                # set up subplot
+                plt.subplot(n_params, n_params, i + j*(n_params) + 1)
+                ax = plt.gca()
+
+                # plot points
+                plt.plot(plot_x, plot_y,
+                             marker='o', mew=0, color='black', markersize=2,
+                             linestyle='None', alpha=0.2)
+
+                ax.tick_params(axis='both', which='both', direction='in', labelsize=14,
+                                   bottom=True, top=True, left=True, right=True)
+
+                # axis labels and ticks
+                if i == 0:
+                    ax.set_ylabel(y_label, fontsize=16)
+                    #ax.get_yaxis().set_label_coords(-0.35,0.5)
+                else:
+                    ax.set_yticklabels([])
+                if j == n_params-1:
+                    ax.set_xlabel(x_label, fontsize=16)
+                    plt.xticks(rotation=-45)
+                else:
+                    ax.set_xticklabels([])
+
+
+            # along diagonal
+            if i == j:
+
+                # set up subplot
+                plt.subplot(n_params, n_params, i + j*(n_params) + 1)
+                ax = plt.gca()
+
+                # make histogram
+                hist_output = plt.hist(plot_x, bins=20,
+                                facecolor='grey', linewidth=0.25, edgecolor='grey')
+
+                ax.tick_params(axis='y',which='both',length=0, labelsize=14)
+                ax.tick_params(axis='x',which='both',direction='in', labelsize=14)
+
+                # axis labels and ticks
+                ax.set_yticklabels([])
+                if i < n_params-1:
+                    ax.set_xticklabels([])
+                if i == n_params-1:
+                    ax.set_xlabel(x_label, fontsize=16)
+                    plt.xticks(rotation=-45)
+
+    #plt.subplots_adjust(wspace=0.05, hspace=0.05)
+    plt.tight_layout()
+
+    fig.savefig(beast_stats_file.replace('.fits', '_param_triangle.pdf'))
+    plt.close(fig)

--- a/beast/tools/run/create_filenames.py
+++ b/beast/tools/run/create_filenames.py
@@ -222,7 +222,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                     )
                 )
                 modelsedgrid_trim_files.append(
-                    "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_sed_trim.grid.hd5".format(
+                    "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_seds_trim.grid.hd5".format(
                         datamodel.project, choose_sd_sub[0], choose_sd_sub[1], gridsub
                     )
                 )
@@ -286,7 +286,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                         )
                     )
                     modelsedgrid_trim_files.append(
-                        "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_sed_trim.grid.hd5".format(
+                        "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_seds_trim.grid.hd5".format(
                             datamodel.project, curr_sd, curr_sub, gridsub
                         )
                     )

--- a/beast/tools/run/make_trim_scripts.py
+++ b/beast/tools/run/make_trim_scripts.py
@@ -65,7 +65,6 @@ def make_trim_scripts(num_subtrim=1, nice=None, prefix=None):
     noise_trim_files = file_dict["noise_trim_files"]
     # the unique sets of things
     unique_sedgrid = [x for i, x in enumerate(modelsedgrid_files) if i == modelsedgrid_files.index(x)]
-    unique_sd_sub = [x for i, x in enumerate(sd_sub_info) if i == sd_sub_info.index(x)]
 
     # save the list of job files
     job_file_list = []

--- a/beast/tools/run/make_trim_scripts.py
+++ b/beast/tools/run/make_trim_scripts.py
@@ -60,7 +60,6 @@ def make_trim_scripts(num_subtrim=1, nice=None, prefix=None):
     photometry_files = file_dict["photometry_files"]
     modelsedgrid_files = file_dict["modelsedgrid_files"]
     noise_files = file_dict["noise_files"]
-    sd_sub_info = file_dict['sd_sub_info']
     modelsedgrid_trim_files = file_dict["modelsedgrid_trim_files"]
     noise_trim_files = file_dict["noise_trim_files"]
     # the unique sets of things

--- a/beast/tools/run/make_trim_scripts.py
+++ b/beast/tools/run/make_trim_scripts.py
@@ -1,0 +1,126 @@
+# system imports
+import numpy as np
+import os
+import argparse
+
+# BEAST imports
+from beast.tools import (verify_params,
+                         setup_batch_beast_trim)
+from beast.tools.run import create_filenames
+
+from difflib import SequenceMatcher
+
+
+import datamodel
+import importlib
+
+
+
+
+def make_trim_scripts(num_subtrim=1, nice=None, prefix=None):
+    """
+    `setup_batch_beast_trim.py` uses file names to create batch trim files.  This
+    generates all of the file names for that function.
+
+    NOTE: This assumes you're using source density or background dependent noise
+    models.
+
+    Parameters
+    ----------
+    num_subtrim : int (default = 1)
+        number of trim batch jobs
+
+    nice : int (default = None)
+        set this to an integer (-20 to 20) to prepend a "nice" level
+        to the trimming command
+
+    prefix : string (default=None)
+        Set this to a string (such as 'source activate astroconda') to prepend
+        to each batch file (use '\n's to make multiple lines)
+
+    Returns
+    -------
+    job_files : list of strings
+        Names of the newly created job files
+    """
+
+    # before doing ANYTHING, force datamodel to re-import (otherwise, any
+    # changes within this python session will not be loaded!)
+    importlib.reload(datamodel)
+    # check input parameters
+    verify_params.verify_input_format(datamodel)
+
+
+    # make lists of file names
+    file_dict = create_filenames.create_filenames(
+        use_sd=True,
+        nsubs=datamodel.n_subgrid,
+    )
+    # extract some useful ones
+    photometry_files = file_dict["photometry_files"]
+    modelsedgrid_files = file_dict["modelsedgrid_files"]
+    noise_files = file_dict["noise_files"]
+    sd_sub_info = file_dict['sd_sub_info']
+    modelsedgrid_trim_files = file_dict["modelsedgrid_trim_files"]
+    noise_trim_files = file_dict["noise_trim_files"]
+    # the unique sets of things
+    unique_sedgrid = [x for i, x in enumerate(modelsedgrid_files) if i == modelsedgrid_files.index(x)]
+    unique_sd_sub = [x for i, x in enumerate(sd_sub_info) if i == sd_sub_info.index(x)]
+
+    # save the list of job files
+    job_file_list = []
+
+    # iterate through each model grid
+    for i in range(datamodel.n_subgrid):
+
+        # indices for this model grid
+        grid_ind = [ind for ind,mod in enumerate(modelsedgrid_files)
+            if mod == unique_sedgrid[i] ]
+
+        # create corresponding files for each of those
+        input_noise = [noise_files[ind] for ind in grid_ind]
+        input_phot = [photometry_files[ind] for ind in grid_ind]
+        # to get the trim prefix, find the common string between trimmed noise
+        # files and trimmed SED files
+        input_trim_prefix = []
+        for ind in grid_ind:
+            str1 = modelsedgrid_trim_files[ind]
+            str2 = noise_trim_files[ind]
+            # find longest match
+            match = SequenceMatcher(None, str1, str2).find_longest_match(
+                0, len(str1), 0, len(str2)
+            )
+            # grab that substring (and remove trailing "_")
+            input_trim_prefix.append(
+                str1[match.a : match.a + match.size][:-1]
+            )
+
+
+        # check if the trimmed grids exist before moving on
+        check_trim = [os.path.isfile(noise_trim_files[ind])
+            for ind in grid_ind]
+
+        # if any aren't trimmed for this model grid, set up trimming
+        if np.sum(check_trim) < len(input_noise):
+
+            job_path = './{0}/trim_batch_jobs/'.format(datamodel.project)
+            if datamodel.n_subgrid > 1:
+                file_prefix='BEAST_gridsub'+str(i)
+            if datamodel.n_subgrid == 1:
+                file_prefix='BEAST'
+
+            # generate trimming at-queue commands
+            setup_batch_beast_trim.generic_batch_trim(unique_sedgrid[i],
+                                                      input_noise,
+                                                      input_phot,
+                                                      input_trim_prefix,
+                                                      job_path=job_path,
+                                                      file_prefix=file_prefix,
+                                                      num_subtrim=num_subtrim,
+                                                      nice=nice,
+                                                      prefix=prefix)
+
+
+            job_file_list.append(job_path+file_prefix+'_batch_trim.joblist')
+
+    return job_file_list

--- a/beast/tools/run/make_trim_scripts.py
+++ b/beast/tools/run/make_trim_scripts.py
@@ -124,3 +124,34 @@ def make_trim_scripts(num_subtrim=1, nice=None, prefix=None):
             job_file_list.append(job_path+file_prefix+'_batch_trim.joblist')
 
     return job_file_list
+
+
+if __name__ == "__main__":
+    # commandline parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--num_subtrim",
+        type=int,
+        default=1,
+        help="number of trim batch jobs",
+    )
+    parser.add_argument(
+        "--nice",
+        type=int,
+        default=None,
+        help="prepend a 'nice' level to the trimming command",
+    )
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default=None,
+        help="string to prepend to each batch file",
+    )
+
+    args = parser.parse_args()
+
+    make_trim_scripts(
+        num_subtrim=args.num_subtrim,
+        nice=args.nice,
+        prefix=args.prefix,
+    )

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 def setup_batch_beast_trim(
-    project, datafile, astfile, num_subtrim=5, nice=None, seds_fname=None, prefix=None
+    project, datafile, num_subtrim=5, nice=None, seds_fname=None, prefix=None
 ):
     """
     Sets up batch files for submission to the 'at' queue on
@@ -28,9 +28,6 @@ def setup_batch_beast_trim(
     datafile : string
         file with the observed data (FITS file) - the observed photometry,
         not the sub-files
-
-    astfile : string
-        file with ASTs
 
     num_subtrim : int (default = 5)
         number of trim batch jobs
@@ -47,7 +44,6 @@ def setup_batch_beast_trim(
         to each batch file (use '\n's to make multiple lines)
 
     """
-    ast_file = astfile
 
     if seds_fname is None:
         full_model_filename = "%s/%s_seds.grid.hd5" % (project, project)
@@ -78,7 +74,6 @@ def setup_batch_beast_trim(
         full_model_filename,
         ["%s/%s_noisemodel.hd5" % (project, project)] * n_cat_files,
         cat_files,
-        [ast_file] * n_cat_files,
         filebase_list,
         job_path=job_path,
         file_prefix="BEAST",
@@ -92,7 +87,6 @@ def generic_batch_trim(
     model_grid_file,
     noise_model_files,
     data_files,
-    ast_files,
     trimmed_file_bases,
     job_path=None,
     file_prefix="BEAST",
@@ -121,9 +115,6 @@ def generic_batch_trim(
     data_files : list of strings
         file with the observed data (FITS file)
 
-    ast_files : list of strings
-        file with ASTs
-
     trimmed_file_bases : list of strings
         prefixes (path+name) for the eventual trimmed model grid and noise model
 
@@ -147,7 +138,7 @@ def generic_batch_trim(
     """
 
     # check that everything is the same length that needs to be
-    keyword_list = [noise_model_files, data_files, ast_files, trimmed_file_bases]
+    keyword_list = [noise_model_files, data_files, trimmed_file_bases]
     length_array = np.array([len(key) for key in keyword_list])
     if len(np.unique(length_array)) != 1:
         print("input lists are not the same length!")
@@ -216,7 +207,6 @@ def generic_batch_trim(
     for i in range(n_cat_files):
         bt_f[k].write(noise_model_files[i])
         bt_f[k].write(" " + data_files[i])
-        bt_f[k].write(" " + ast_files[i])
         bt_f[k].write(" " + trimmed_file_bases[i])
         bt_f[k].write("\n")
         n_cur += 1
@@ -234,7 +224,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("projectname", help="project name to use (basename for files)")
     parser.add_argument("datafile", help="file with the observed data (FITS file)")
-    parser.add_argument("astfile", help="file with ASTs")
     parser.add_argument(
         "--num_subtrim", default=5, type=int, help="number of trim batch jobs"
     )
@@ -255,7 +244,6 @@ if __name__ == "__main__":
     setup_batch_beast_trim(
         args.projectname,
         args.datafile,
-        args.astfile,
         num_subtrim=args.num_subtrim,
         nice=args.nice,
         seds_fname=args.seds_fname,

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -60,10 +60,10 @@ def simulate_obs(
     ):
 
         # get the physics model grid - includes priors
-        modelsedgrid = FileSEDGrid(physgrid)
+        modelsedgrid = FileSEDGrid(str(physgrid))
 
         # read in the noise model - includes bias, unc, and completeness
-        noisegrid = noisemodel.get_noisemodelcat(noise_model)
+        noisegrid = noisemodel.get_noisemodelcat(str(noise_model))
 
         # generate the table
         simtable = gen_SimObs_from_sedgrid(

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -2,7 +2,7 @@
 """
 Code to create many trimmed model grids for batch runs
   Saves time by only reading the potentially huge modelsed grid once
-  and only reads in the noisemodel/astfile if it has changed
+  and only reads in the noisemodel if it has changed
 """
 
 # system imports
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "trimfile", help="file with modelgrid, astfiles, obsfiles to use"
+        "trimfile", help="file with modelgrid, obsfiles, filebase to use"
     )
     args = parser.parse_args()
 
@@ -47,10 +47,10 @@ if __name__ == "__main__":
     old_noisefile = ""
     for k in range(1, len(file_lines)):
 
-        print("/n/n")
+        print("\n\n")
 
         # file names
-        noisefile, obsfile, astfile, filebase = file_lines[k].split()
+        noisefile, obsfile, filebase = file_lines[k].split()
 
         # make sure the proper directories exist
         if not os.path.isdir(os.path.dirname(filebase)):
@@ -67,9 +67,8 @@ if __name__ == "__main__":
         if noisefile == old_noisefile:
             print("not reading noisefile - same as last")
             # print(noisefile)
-            # print(astfile)
         else:
-            print("reading noisefile/astfile")
+            print("reading noisefile")
             # read in the noise model
             noisemodel_vals = noisemodel.get_noisemodelcat(noisefile)
             old_noisefile = noisefile

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
             os.makedirs(os.path.dirname(filebase))
 
         # construct trimmed file names
-        sed_trimname = filebase + "_sed_trim.grid.hd5"
+        sed_trimname = filebase + "_seds_trim.grid.hd5"
         noisemodel_trimname = filebase + "_noisemodel_trim.hd5"
 
         print("working on " + sed_trimname)

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
         # construct trimmed file names
         sed_trimname = filebase + "_seds_trim.grid.hd5"
-        noisemodel_trimname = filebase + "_noisemodel_trim.hd5"
+        noisemodel_trimname = filebase + "_noisemodel_trim.grid.hd5"
 
         print("working on " + sed_trimname)
 

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -51,3 +51,7 @@ diagnostic plots and visualizations.  Some are described here.
   (similar to Figure 13 in `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
   If given multiple sets of files, can do additional panels to compare across
   noise models.
+
+- `plot_triangle.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_triangle.py>`_:
+  Make a triangle/corner plot of all the parameters (p50) against each other.
+  Diagonals contain histograms of each parameter.

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -41,3 +41,13 @@ diagnostic plots and visualizations.  Some are described here.
   `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
   Multiple noise models can be overplotted, as long as they correspond to the
   same SED model grid.
+
+- `plot_param_err.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_param_err.py>`_:
+  Make 2D histogram of each parameter (p50) plotted against its uncertainty
+  ((p84-p16)/2).
+
+- `plot_param_recovery.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_param_recovery.py>`_:
+  Make a 2D histogram to compare simulated and recovered model parameters
+  (similar to Figure 13 in `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
+  If given multiple sets of files, can do additional panels to compare across
+  noise models.


### PR DESCRIPTION
In working on parameter recovery tests (#435), I have made many updates:
* running of things:
  * `tools/run/make_trim_scripts.py`: moved the [rather unwieldy] trimming procedure over to its own file
  * `examples/production_runs_2019/beast_production_wrapper.py`: updated trimming section to use `make_trim_scripts`
  * `examples/production_runs_2019/beast_verification_wrapper.py`: an example wrapper for simulating observations, running them through the BEAST, and making plots
* plots
  *  `plot_param_err.py`: plot all parameter `p50`s against their uncertainties ((`p84`-`p16`)/2)
  * `plot_param_recovery.py`: 2D histogram comparing the simulated and recovered model parameters
  * `plot_triangle.py`: a triangle/corner plot of all the parameters (`p50`) against each other, with histograms along the diagonal
  * updated plotting docs to note these
* assorted related bugs/fixes
  * `observationmodel/observations.py`: changed all filter column names to all uppercase, because all lowercase was breaking things
  * `tools/simulate_obs.py`: wrap grid names in `str` (`np.atleast_1d` made them a `np.str`, which apparently didn't work)
  * `tools/run/create_filenames.py`: fixed a couple places that still had `_sed_` filenames instead of `_seds`
  * `tools/trim_many_via_obsdata.py`: for unknown reasons, it required the AST file name, but wasn't using it, so I removed it.  Also made sure trimmed files had the proper naming to match changes to `create_filenames` (part of #387).
  * `tools/setup_batch_beast_trim.py`: removed need for AST file name accordingly