### PR TITLE
fix the check for whether merging files is necessary

### DIFF
--- a/beast/tools/run/merge_files.py
+++ b/beast/tools/run/merge_files.py
@@ -24,7 +24,7 @@ def merge_files(use_sd=True, nsubs=1):
     """
 
     # if there's no SD and no subgridding, running this is unnecessary
-    if use_sd and (nsubs == 1):
+    if (not use_sd) and (nsubs == 1):
         print("No merging necessary")
         return
 


### PR DESCRIPTION
Very minor fix to `tools/run/merge_files.py`: the `if` statement to check if merging is necessary (i.e., not dividing by background/source density and not using subgrids) was incorrect.  It's fixed now.