### PR TITLE
Update how catalogs are cut

### DIFF
--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -492,11 +492,6 @@ def make_source_dens_map(cat, ra_grid, dec_grid, output_base, mag_name, mag_cut,
     # force filter magnitude name to be upper case to match column names
     mag_name = mag_name.upper()
 
-    # get the columns with fluxes
-    rate_cols = [s for s in cat.colnames if s[-4:] == "RATE"]
-    n_filters = len(rate_cols)
-
-
     N_stars = len(cat)
 
     w = make_wcs_for_map(ra_grid, dec_grid)

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -157,7 +157,7 @@ def main_make_map(args):
         ra_grid = np.linspace(ra.min(), ra.max(), n_x + 1)
         dec_grid = np.linspace(dec.min(), dec.max(), n_y + 1)
     elif args.pixsize is not None:
-        pixsize_arcsecs = args.pixsize * u.arcsec 
+        pixsize_arcsecs = args.pixsize * u.arcsec
         pixsize_degrees = pixsize_arcsecs.to(u.degree)
         n_x, n_y, ra_delt, dec_delt = calc_nx_ny_from_pixsize(cat, pixsize_degrees)
         # the ra spacing needs to be larger, as 1 degree of RA ==
@@ -496,30 +496,6 @@ def make_source_dens_map(cat, ra_grid, dec_grid, output_base, mag_name, mag_cut,
     rate_cols = [s for s in cat.colnames if s[-4:] == "RATE"]
     n_filters = len(rate_cols)
 
-    # create the indexs where any of the rates are zero and non-zero
-    #   zero = missing data, etc. -> bad for fitting
-    #   non-zero = good data, etc. -> great for fitting
-    initialize_zero = False
-    band_zero_indxs = {}
-    print("band, good, zero")
-    for cur_rate in rate_cols:
-
-        cur_good_indxs, = np.where(cat[cur_rate] != 0.0)
-        cur_indxs, = np.where(cat[cur_rate] == 0.0)
-        print(cur_rate, len(cur_good_indxs), len(cur_indxs))
-
-        if not initialize_zero:
-            initialize_zero = True
-            zero_indxs = cur_indxs
-            nonzero_indxs = cur_good_indxs
-        else:
-            zero_indxs = np.union1d(zero_indxs, cur_indxs)
-            nonzero_indxs = np.intersect1d(nonzero_indxs, cur_good_indxs)
-
-        # save the zero indexs for each band
-        band_zero_indxs[cur_rate] = zero_indxs
-
-    print("all bands", len(nonzero_indxs), len(zero_indxs))
 
     N_stars = len(cat)
 
@@ -529,8 +505,6 @@ def make_source_dens_map(cat, ra_grid, dec_grid, output_base, mag_name, mag_cut,
     n_x = len(ra_grid) - 1
     n_y = len(dec_grid) - 1
     npts_map = np.zeros([n_x, n_y], dtype=float)
-    npts_zero_map = np.zeros([n_x, n_y], dtype=float)
-    npts_band_zero_map = np.zeros([n_x, n_y, n_filters], dtype=float)
     source_dens = np.zeros(N_stars, dtype=float)
 
     # area of one pixel in square degrees
@@ -552,46 +526,14 @@ def make_source_dens_map(cat, ra_grid, dec_grid, output_base, mag_name, mag_cut,
         if n_indxs > 0:
             npts_map[i, j] = n_indxs / pix_area
 
-            # now make a map of the sources with zero fluxes in
-            #   at least one band
-            zindxs, = np.where(
-                (pix_x[zero_indxs] > i)
-                & (pix_x[zero_indxs] <= i + 1)
-                & (pix_y[zero_indxs] > j)
-                & (pix_y[zero_indxs] <= j + 1)
-            )
-            if len(zindxs) > 0:
-                npts_zero_map[i, j] = len(zindxs)
-
-            # do the same for each band
-            for k, cur_rate in enumerate(rate_cols):
-                tindxs = band_zero_indxs[cur_rate]
-                zindxs, = np.where(
-                    (pix_x[tindxs] > i)
-                    & (pix_x[tindxs] <= i + 1)
-                    & (pix_y[tindxs] > j)
-                    & (pix_y[tindxs] <= j + 1)
-                )
-                if len(zindxs) > 0:
-                    npts_band_zero_map[i, j, k] = len(zindxs)
-
         # save the source density as an entry for each source
         source_dens[indxs] = npts_map[i, j]
 
     save_map_fits(npts_map, w, output_base + "_source_den_image.fits")
-    save_map_fits(npts_zero_map, w, output_base + "_npts_zero_fluxes_image.fits")
-    for k, cur_rate in enumerate(rate_cols):
-        save_map_fits(
-            npts_band_zero_map[:, :, k], w, output_base + cur_rate + "_image.fits"
-        )
 
     # Save the source density for individual stars in a new catalog file
     cat["SourceDensity"] = source_dens
-    cat.write(output_base + "_with_sourceden_inc_zerofluxes.fits", overwrite=True)
-
-    # Save the source density for individual stars in a new catalog file
-    #   only those that have non-zero fluxes in all bands
-    cat[nonzero_indxs].write(output_base + "_with_sourceden.fits", overwrite=True)
+    cat.write(output_base + "_with_sourceden.fits", overwrite=True)
 
     return npts_map
 

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -31,7 +31,11 @@ def cut_catalogs(
         file name for the output catalog
 
     partial_overlap : boolean (default=False)
-        if True, remove sources in regions without full imaging coverage
+        if True, remove sources in regions without full imaging coverage.  This
+        is done by finding sources with RATE=0 in any filter.  If a source has
+        RATE=0 in all filters (which can only happen for ASTs), that means the
+        source was not recovered, and since we need to keep that information,
+        the source will not be removed.
 
     flagged : boolean (default=False)
         if True, remove sources with flag=99 in flag_filter
@@ -70,8 +74,10 @@ def cut_catalogs(
 
     # partial overlap
     if partial_overlap is True:
-        for filt in filters:
-            good_stars[cat[filt + "_RATE"] == 0] = 0
+        # number of RATE=0 for each source
+        n_zero_flux = np.sum([cat[filt+"_RATE"] == 0 for filt in filters], axis=0)
+        # remove sources with more than 0 and less than n_filter
+        good_stars[(n_zero_flux > 0) & (n_zero_flux < len(filters))] = 0
 
     # flagged sources
     if flagged is True:

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -38,7 +38,8 @@ def cut_catalogs(
         the source will not be removed.
 
     flagged : boolean (default=False)
-        if True, remove sources with flag=99 in flag_filter
+        if True, remove sources with flag=99 in flag_filter.  Note that this
+        will only be applied to sources with RATE>0 in flag_filter.
 
     flag_filter : string or list of strings (default=None)
         if flagged is True, set this to the filter(s) to use
@@ -81,11 +82,8 @@ def cut_catalogs(
 
     # flagged sources
     if flagged is True:
-        if type(flag_filter) == str:
-            good_stars[cat[flag_filter + "_FLAG"] >= 99] = 0
-        else:
-            for fl in flag_filter:
-                good_stars[cat[fl + "_FLAG"] >= 99] = 0
+        for fl in np.atleast_1d(flag_filter):
+            good_stars[(cat[fl + "_FLAG"] >= 99) & (cat[fl+"_RATE"] > 0)] = 0
 
     # write out the sources as a ds9 region file
     if region_file is True:

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -166,7 +166,7 @@ The code to edit catalogs can do three different things:
   any sources with flux=0 in all bands).
 * **Remove flagged sources.** This eliminates any source with `[filter]_FLAG=99`
   in the specified filter.  If that source has flux<0, it is not removed,
-  because those sources are set by `daophot` to have flag=99 regardless of
+  because those sources are set by `dolphot` to have flag=99 regardless of
   quality.
 * **Create ds9 region files.** If set, it will create a ds9 region file where
   good sources are green and removed sources are magenta.

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -28,7 +28,7 @@ These parameters are described in the beast :ref:`setup documentation
 Source Density or Background Level
 **********************************
 
-The data need to have source density information added as it is common
+The data generally need to have source density information added as it is common
 for the observation model (scatter and bias) to be strongly dependent
 on source density due to crowding/confusion noise.  The background may
 also be important in some situations, so there is code to calculate it as well.
@@ -43,19 +43,13 @@ the magnitude range of sources to use for calculating the source density
 user can also choose a band for which sources that have '[band]_FLAG == 99' are
 ignored.
 
-A number of source density images are also created.  The prefix is derived
-from the name of the input photometry catalog.
+Three files are created.  The prefix is derived from the name of the input
+photometry catalog.
 
-  * [prefix]_source_den_image.fits: an image of the source density map
-  * [prefix][band]_RATE_image.fits: for each band in the catalog, an image of
-    the number of sources with a flux of 0 (i.e., not detected in the given band)
-  * [prefix]_npts_zero_fluxes_image.fits: an image of the number of sources with
-    0 flux in at least one band
-  * [prefix]_with_sourceden_inc_zerofluxes.fits: photometry catalog with an
-    additional column that has the source density
-  * [prefix]_with_sourceden.fits: same as above, but only for sources with
-    flux > 0 in each band
-  * [prefix]_sourceden_map.hd5: contains information about the map grid
+* [prefix]_source_den_image.fits: an image of the source density map
+* [prefix]_with_sourceden.fits: photometry catalog with an
+  additional column that has the source density
+* [prefix]_sourceden_map.hd5: contains information about the map grid
 
 Command to create the observed catalog with source density column with
 a pixel scale of 5 arcsec using the 'phot_catalog.fits' catalog.
@@ -161,6 +155,21 @@ Edit/Split Catalogs
 
 You may wish to remove artifacts from the photometry catalog.  If you do so, the
 same criteria must be applied to the AST catalog.
+
+The code to edit catalogs can do three different things:
+
+* **Remove objects without full imaging coverage.** Note that the overlap is
+  determined by eliminating sources with a flux of precisely 0 in any band.
+  However, any sources with a flux of 0 in all bands are not removed, since
+  that would indicate that an artificial star was not recovered (this
+  criterion does not affect standard photometry catalogs, which do not have
+  any sources with flux=0 in all bands).
+* **Remove flagged sources.** This eliminates any source with `[filter]_FLAG=99`
+  in the specified filter.  If that source has flux<0, it is not removed,
+  because those sources are set by `daophot` to have flag=99 regardless of
+  quality.
+* **Create ds9 region files.** If set, it will create a ds9 region file where
+  good sources are green and removed sources are magenta.
 
 Commands to edit the files, both to remove flagged sources and eliminate sources
 that don't have full imaging coverage, and to create ds9 region files:


### PR DESCRIPTION
This has some changes in how catalogs are cut.
* `create_background_density_map.py`: Per discussion in #434, the code that makes the source density maps no longer does anything with the sources with zero fluxes.  They were never part of the source density map calculations anyway (since they have a Vega mag of 99). The only outputs now are the SD map fits file, the SD map hd5 file, and the catalog with a new SD column.  Any cuts based on flux=0 should be done using `cut_catalogs.py`.
* `cut_catalogs.py`: 
  * After discussion with @karllark about how completeness is calculated, we realized that removing any source with flux=0 was a problem.  Specifically, a source in the AST catalog with flux=0 in all bands is an un-recovered star, which we need to keep in the catalog.  Now, if the `partial_overlap` option is selected, only sources with between 1 and `n_bands - 1` (inclusive) bands with flux=0 are removed.
  * Even sources with a negative flux are still measurements, but they're all given `[filter]_FLAG=99` by dolphot.  Therefore, if the `flagged` option is chosen, only sources with flag=99 and flux>0 are removed.
* I updated the workflow documentation to reflect these changes.


Closes #434