### PR TITLE
Fix catalog cut for ASTs

### DIFF
--- a/beast/examples/production_runs_2019/beast_production_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_production_wrapper.py
@@ -17,10 +17,7 @@ from beast.plotting import plot_mag_hist
 from beast.tools import (
     create_background_density_map,
     split_ast_input_file,
-    subdivide_obscat_by_source_density,
     cut_catalogs,
-    split_asts_by_source_density,
-    setup_batch_beast_trim,
     setup_batch_beast_fit,
 )
 

--- a/beast/examples/production_runs_2019/beast_production_wrapper.py
+++ b/beast/examples/production_runs_2019/beast_production_wrapper.py
@@ -275,18 +275,10 @@ def beast_production_wrapper():
 
         # - photometry
         gst_file_cut = gst_file.replace(".fits", "_with_sourceden_cut.fits")
+        ast_file_cut = ast_file.replace(".fits", "_cut.fits")
         cut_catalogs.cut_catalogs(
             gst_file_sd,
             gst_file_cut,
-            partial_overlap=True,
-            flagged=True,
-            flag_filter=flag_filter[b],
-            region_file=True,
-        )
-
-        # - ASTs
-        ast_file_cut = ast_file.replace(".fits", "_cut.fits")
-        cut_catalogs.cut_catalogs(
             ast_file,
             ast_file_cut,
             partial_overlap=True,
@@ -294,7 +286,6 @@ def beast_production_wrapper():
             flag_filter=flag_filter[b],
             region_file=True,
         )
-        # test = plot_mag_hist.plot_mag_hist(ast_file_cut, stars_per_bin=200, max_bins=30)
 
         # edit the datamodel.py file to have the correct photometry file name
         # (AST file name is already automatically the cut version)

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -1,6 +1,5 @@
 import numpy as np
 from matplotlib.path import Path
-from scipy.spatial import ConvexHull
 from tqdm import tqdm
 import warnings
 

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -166,9 +166,9 @@ def pick_positions_from_map(
     catalog_boundary_xy = None
     catalog_boundary_radec = None
     if xy_pos:
-        catalog_boundary_xy = convexhull_path(x_positions, y_positions)
+        catalog_boundary_xy = cut_catalogs.convexhull_path(x_positions, y_positions)
     if radec_pos:
-        catalog_boundary_radec = convexhull_path(ra_positions, dec_positions)
+        catalog_boundary_radec = cut_catalogs.convexhull_path(ra_positions, dec_positions)
 
     # if coord_boundary set, define an additional boundary for ASTs
     if set_coord_boundary is not None:
@@ -208,12 +208,12 @@ def pick_positions_from_map(
         filt_reg_boundary_radec = None
         # evaluate one or both
         if xy_pos:
-            filt_reg_boundary_xy = convexhull_path(
+            filt_reg_boundary_xy = cut_catalogs.convexhull_path(
                 x_positions[good_stars == 1],
                 y_positions[good_stars == 1]
             )
         if radec_pos:
-            filt_reg_boundary_radec = convexhull_path(
+            filt_reg_boundary_radec = cut_catalogs.convexhull_path(
                 ra_positions[good_stars == 1],
                 dec_positions[good_stars == 1]
             )
@@ -515,29 +515,3 @@ def pick_positions(catalog, filename, separation, refimage=None, wcs_origin=1):
     astmags.add_column(column4, 3)
 
     ascii.write(astmags, filename, overwrite=True)
-
-
-def convexhull_path(x_coord, y_coord):
-    """
-    Find the convex hull for the given coordinates and make a Path object
-    from it.
-
-    Parameters
-    ----------
-    x_coord, y_coord: arrays
-        Arrays of coordinates (can be x/y or ra/dec)
-
-    Returns
-    -------
-    matplotlib Path object
-
-    """
-
-    coords = np.array(
-        [x_coord, y_coord]
-    ).T  # there's a weird astropy datatype issue that requires numpy coercion
-    hull = ConvexHull(coords)
-    bounds_x, bounds_y = coords[hull.vertices, 0], coords[hull.vertices, 1]
-    path_object = Path(np.array([bounds_x, bounds_y]).T)
-
-    return path_object

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -3,10 +3,14 @@ import argparse
 
 from astropy.table import Table
 
+from beast.observationmodel.ast.make_ast_xy_list import convexhull_path
+
 
 def cut_catalogs(
-    input_file,
-    output_file,
+    input_phot_file,
+    output_phot_file,
+    input_ast_file=None,
+    output_ast_file=None,
     partial_overlap=False,
     flagged=False,
     flag_filter=None,
@@ -14,21 +18,28 @@ def cut_catalogs(
     no_write=False,
 ):
     """
-    Remove sources from the input catalog that are
+    Remove sources from the input photometry catalog that are
     - in regions without full imaging coverage
     OR
     - flagged as bad in flag_filter
 
-    The input catalog can either be photometry or ASTs
+    Optionally also input an AST file to similarly cut.  If partial_overlap is
+    True, the overlap boundary found for the photometry catalog will be used to
+    trim the AST catalog.
 
     Parameters
     ----------
-    input_file : string
-        file name of the input catalog (photometry or AST), where data is in
-        extension 1 of the fits file
+    input_phot_file : string
+        file name of the photometry catalog
 
-    output_file : string
-        file name for the output catalog
+    output_phot_file : string
+        file name for the output photometry catalog
+
+    input_ast_file : string (default=None)
+        file name of the AST catalog
+
+    output_ast_file : string (default=None)
+        file name for the output AST catalog
 
     partial_overlap : boolean (default=False)
         if True, remove sources in regions without full imaging coverage.  This
@@ -45,11 +56,11 @@ def cut_catalogs(
         if flagged is True, set this to the filter(s) to use
 
     region_file : boolean (default=False)
-        if True, create a ds9 region file where good sources are green and
+        if True, create ds9 region file(s) where good sources are green and
         removed sources are magenta
 
     no_write : boolean (default=False)
-        if True, don't write out the catalog file.  Instead, just return it.
+        if True, don't write out the catalog file(s).  Instead, just return them.
 
     """
 
@@ -58,16 +69,98 @@ def cut_catalogs(
         print("must choose a criteria to cut catalogs")
         return
 
+    # run the cutting for the photometry file
+    phot_cat, phot_good_stars = make_cuts(
+        input_phot_file,
+        partial_overlap=partial_overlap,
+        flagged=flagged,
+        flag_filter=flag_filter,
+    )
+    print('removing {0} stars from {1}'.format(
+        int(len(phot_cat) - np.sum(phot_good_stars)), input_phot_file
+    ))
+    new_phot_cat = phot_cat[phot_good_stars == 1]
+
+    # if chosen, run the cutting for the AST file
+    if input_ast_file is not None:
+        ast_cat, temp_good_stars = make_cuts(
+            input_ast_file,
+            partial_overlap=partial_overlap,
+            flagged=flagged,
+            flag_filter=flag_filter,
+        )
+
+        # do convex hull
+        ra_col = [x for x in phot_cat.colnames if "RA" in x.upper()][0]
+        dec_col = [x for x in phot_cat.colnames if "DEC" in x.upper()][0]
+        phot_cat_boundary = convexhull_path(
+            new_phot_cat[ra_col], new_phot_cat[dec_col]
+        )
+        # check if points are inside
+        ra_col = [x for x in ast_cat.colnames if "RA" in x.upper()][0]
+        dec_col = [x for x in ast_cat.colnames if "DEC" in x.upper()][0]
+        within_bounds = phot_cat_boundary.contains_points(
+            np.array([ast_cat[ra_col], ast_cat[dec_col]]).T
+        )  # N,2 array of AST RA and Dec positions
+
+        # get final list of good stars
+        ast_good_stars = (temp_good_stars == 1) & (within_bounds == True)
+        print('removing {0} stars from {1}'.format(
+            int(len(ast_cat) - np.sum(ast_good_stars)), input_ast_file
+        ))
+        new_ast_cat = ast_cat[ast_good_stars]
+
+    # write out the sources as a ds9 region file
+    if region_file is True:
+        write_ds9(phot_cat, phot_good_stars, input_phot_file + ".reg")
+
+        if input_ast_file is not None:
+            write_ds9(ast_cat, ast_good_stars, input_ast_file + ".reg")
+
+
+    # either save it or return it
+    # - save it
+    if not no_write:
+        new_phot_cat.write(output_phot_file, format="fits", overwrite=True)
+        if input_ast_file is not None:
+            new_ast_cat.write(output_ast_file, format="fits", overwrite=True)
+    # - return it
+    else:
+        return new_phot_cat, phot_good_stars
+
+
+
+def make_cuts(cat_file, partial_overlap=False, flagged=False, flag_filter=None):
+    """
+    Wrapper to do overlap and flag cuts
+
+    Parameters
+    ----------
+    cat_file : string
+        name of the catalog file
+
+    partial_overlap : boolean (default=False)
+        see above
+
+    flagged : boolean (default=False)
+        see above
+
+    flag_filter : string (default=None)
+        see above
+
+    Returns
+    -------
+    cat : astropy table
+        the astropy table of the input catalog
+
+    good_stars : array
+        array in which 1=good star and 0=bad star
+    """
+
     # read in the catalog
-    cat = Table.read(input_file)
+    cat = Table.read(cat_file)
     filters = [c[0:-5] for c in cat.colnames if "RATE" in c and "RATERR" not in c]
     n_stars = len(cat)
-    if "RA" in cat.colnames:
-        ra_col = "RA"
-        dec_col = "DEC"
-    else:
-        ra_col = "RA_J2000"
-        dec_col = "DEC_J2000"
 
     # array to keep track of which ones are good
     # (1=good, 0=bad)
@@ -85,46 +178,47 @@ def cut_catalogs(
         for fl in np.atleast_1d(flag_filter):
             good_stars[(cat[fl + "_FLAG"] >= 99) & (cat[fl+"_RATE"] > 0)] = 0
 
-    # write out the sources as a ds9 region file
-    if region_file is True:
-        with open(input_file + ".reg", "w") as ds9_file:
+    # return results
+    return cat, good_stars
 
-            # header
-            ds9_file.write("# Region file format: DS9 version 4.1\n")
-            ds9_file.write(
-                'global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n'
-            )
-            ds9_file.write("fk5\n")
 
-            # stars
-            for i in range(n_stars):
-                if good_stars[i] == 0:
-                    ds9_file.write(
-                        "circle("
-                        + str(cat[ra_col][i])
-                        + ","
-                        + str(cat[dec_col][i])
-                        + ',0.1") # color=magenta\n'
-                    )
-                if good_stars[i] == 1:
-                    ds9_file.write(
-                        "circle("
-                        + str(cat[ra_col][i])
-                        + ","
-                        + str(cat[dec_col][i])
-                        + ',0.1")\n'
-                    )
+def write_ds9(cat, good_stars, ds9_file_name):
+    """
+    Make a ds9 region file
+    """
 
-    # make a new file with the bad stars removed
-    new_cat = cat[good_stars == 1]
+    ra_col = [x for x in cat.colnames if "RA" in x.upper()][0]
+    dec_col = [x for x in cat.colnames if "DEC" in x.upper()][0]
 
-    # either save it or return in
-    # - save it
-    if not no_write:
-        new_cat.write(output_file, format="fits", overwrite=True)
-    # - return in
-    else:
-        return new_cat, good_stars
+    with open(ds9_file_name, "w") as ds9_file:
+
+        # header
+        ds9_file.write("# Region file format: DS9 version 4.1\n")
+        ds9_file.write(
+            'global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n'
+        )
+        ds9_file.write("fk5\n")
+
+        # stars
+        for i in range(len(cat)):
+            if good_stars[i] == 0:
+                ds9_file.write(
+                    "circle("
+                    + str(cat[ra_col][i])
+                    + ","
+                    + str(cat[dec_col][i])
+                    + ',0.1") # color=magenta\n'
+                )
+            if good_stars[i] == 1:
+                ds9_file.write(
+                    "circle("
+                    + str(cat[ra_col][i])
+                    + ","
+                    + str(cat[dec_col][i])
+                    + ',0.1")\n'
+                )
+
+
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -104,7 +104,7 @@ def cut_catalogs(
         )  # N,2 array of AST RA and Dec positions
 
         # get final list of good stars
-        ast_good_stars = (temp_good_stars == 1) & (within_bounds == True)
+        ast_good_stars = (temp_good_stars == 1) & (within_bounds)
         print('removing {0} stars from {1}'.format(
             int(len(ast_cat) - np.sum(ast_good_stars)), input_ast_file
         ))

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -3,8 +3,6 @@ import argparse
 
 from astropy.table import Table
 
-from beast.observationmodel.ast.make_ast_xy_list import convexhull_path
-
 
 def cut_catalogs(
     input_phot_file,
@@ -219,6 +217,30 @@ def write_ds9(cat, good_stars, ds9_file_name):
                 )
 
 
+def convexhull_path(x_coord, y_coord):
+    """
+    Find the convex hull for the given coordinates and make a Path object
+    from it.
+
+    Parameters
+    ----------
+    x_coord, y_coord: arrays
+        Arrays of coordinates (can be x/y or ra/dec)
+
+    Returns
+    -------
+    matplotlib Path object
+
+    """
+
+    coords = np.array(
+        [x_coord, y_coord]
+    ).T  # there's a weird astropy datatype issue that requires numpy coercion
+    hull = ConvexHull(coords)
+    bounds_x, bounds_y = coords[hull.vertices, 0], coords[hull.vertices, 1]
+    path_object = Path(np.array([bounds_x, bounds_y]).T)
+
+    return path_object
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -1,5 +1,7 @@
 import numpy as np
 import argparse
+from matplotlib.path import Path
+from scipy.spatial import ConvexHull
 
 from astropy.table import Table
 

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -247,12 +247,26 @@ if __name__ == "__main__":  # pragma: no cover
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "input_file",
+        "input_phot_file",
         type=str,
-        help="file name of the input catalog (photometry or AST)",
+        help="file name of the input photometry catalog",
     )
     parser.add_argument(
-        "output_file", type=str, help="file name for the output catalog",
+        "output_phot_file",
+        type=str,
+        help="file name for the output photometry catalog",
+    )
+    parser.add_argument(
+        "--input_ast_file",
+        type=str,
+        default=None,
+        help="file name for the input AST catalog",
+    )
+    parser.add_argument(
+        "--output_ast_file",
+        type=str,
+        default=None,
+        help="file name for the output AST catalog",
     )
     parser.add_argument(
         "--partial_overlap",
@@ -289,15 +303,13 @@ if __name__ == "__main__":  # pragma: no cover
     args = parser.parse_args()
 
     cut_catalogs(
-        input_file=args.input_file,
-        output_file=args.output_file,
+        input_phot_file=args.input_phot_file,
+        output_phot_file=args.output_phot_file,
+        input_ast_file=args.input_ast_file,
+        output_ast_file=args.output_ast_file,
         partial_overlap=args.partial_overlap,
         flagged=args.flagged,
         flag_filter=args.flag_filter,
         region_file=args.region_file,
         no_write=args.no_write,
     )
-
-    # print help if no arguments
-    if not any(vars(args).values()):
-        parser.print_help()

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -171,16 +171,16 @@ The code to edit catalogs can do three different things:
 * **Create ds9 region files.** If set, it will create a ds9 region file where
   good sources are green and removed sources are magenta.
 
-Commands to edit the files, both to remove flagged sources and eliminate sources
+Command to edit the files, both to remove flagged sources and eliminate sources
 that don't have full imaging coverage, and to create ds9 region files:
 
   .. code-block:: console
 
-     $ python -m beast.tools.cut_catalogs phot_catalog_with_sourceden.fits phot_catalog_cut.fits \
-           --partial_overlap --region_file --flagged --flag_filter F475W
-
-     $ python -m beast.tools.cut_catalogs ast_catalog.fits ast_catalog_cut.fits \
-           --partial_overlap --region_file --flagged --flag_filter F475W
+  $ python -m beast.tools.cut_catalogs \
+        phot_catalog_with_sourceden.fits phot_catalog_cut.fits \
+        --input_ast_file ast_catalog.fits \
+        --output_ast_file ast_catalog_cut.fits \
+        --partial_overlap --region_file --flagged --flag_filter F475W
 
 
 The observed catalog should be split into separate files for each source


### PR DESCRIPTION
As described in #447, simply using the RATE=0 cuts wasn't working to properly remove sources that aren't in the full overlapping region.  I've updated `cut_catalogs.py` to now take in both the photometry and the AST catalogs.  If the `partial_overlap` option is chosen, it will do the RATE=0 cuts for the photometry catalog, find the boundary of the remaining sources, and apply that boundary to the AST catalog.  The AST catalog still has objects removed with RATE=0 in a subset of bands.  Also, `cut_catalogs` allows the AST files to be an optional input, so that users who only want to operate on the photometry catalog can do so.

Other changes:
* Moved the `convexhull_path` function (which calculates a convex hull and turns it into a Path object) from `make_ast_xy_list.py` to `cut_catalogs.py`, because otherwise there was an infinite circular loop of imports.
* Updated workflow docs
* Updated production run example

Closes #447