### PR TITLE
AST histogram plot

### DIFF
--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -42,7 +42,7 @@ def plot_ast(ast_file, sed_grid_file=None):
     if sed_grid_file is not None:
         modelsedgrid = FileSEDGrid(sed_grid_file)
         with Vega() as v:
-            vega_f, vega_flux, _ = v.getFlux(filter_cols)
+            _, vega_flux, _ = v.getFlux(filter_cols)
         sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
         good_seds = np.where(modelsedgrid.grid['logL'] > -9)[0]
 

--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -11,6 +11,9 @@ def plot_ast(ast_file, sed_grid_file=None):
     Make a histogram of the AST fluxes.  If an SED grid is given, also plot
     a comparison histogram of the SED fluxes.
 
+    Output plot is saved in the same location/name as ast_file, but with a .png
+    instead of .txt.
+
     Parameters
     ----------
     ast_file : string

--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+import argparse
 from astropy.table import Table
 
 from beast.physicsmodel.grid import FileSEDGrid
@@ -94,3 +95,17 @@ def plot_ast(ast_file, sed_grid_file=None):
 
     fig.savefig(ast_file.replace('.txt','.png'))
     plt.close(fig)
+
+if __name__ == "__main__":  # pragma: no cover
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "ast_file", type=str, help="name of AST input file"
+    )
+    parser.add_argument(
+        "--sed_grid_file", type=str, default=None, help="name of SED grid file"
+    )
+
+    args = parser.parse_args()
+
+    plot_ast(args.ast_file, sed_grid_file=args.sed_grid_file)

--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -12,6 +12,11 @@ def plot_ast(ast_file, sed_grid_file=None):
     Make a histogram of the AST fluxes.  If an SED grid is given, also plot
     a comparison histogram of the SED fluxes.
 
+    The histogram bins are set by the bins originally used to create the ASTs
+    (using the flux bin method), which are saved in
+       ast_file.replace('inputAST','ASTfluxbins')
+    and are automatically read in.
+
     Output plot is saved in the same location/name as ast_file, but with a .png
     instead of .txt.
 

--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -42,7 +42,7 @@ def plot_ast(ast_file, sed_grid_file=None):
     if sed_grid_file is not None:
         modelsedgrid = FileSEDGrid(sed_grid_file)
         with Vega() as v:
-            vega_f, vega_flux, lambd = v.getFlux(filter_cols)
+            vega_f, vega_flux, _ = v.getFlux(filter_cols)
         sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
         good_seds = np.where(modelsedgrid.grid['logL'] > -9)[0]
 

--- a/beast/plotting/plot_ast_histogram.py
+++ b/beast/plotting/plot_ast_histogram.py
@@ -1,0 +1,93 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.table import Table
+
+from beast.physicsmodel.grid import FileSEDGrid
+from beast.observationmodel.vega import Vega
+
+
+def plot_ast(ast_file, sed_grid_file=None):
+    """
+    Make a histogram of the AST fluxes.  If an SED grid is given, also plot
+    a comparison histogram of the SED fluxes.
+
+    Parameters
+    ----------
+    ast_file : string
+        name of AST input file
+
+    sed_grid_file : string (default=None)
+        name of SED grid file
+    """
+
+    # read in AST info
+    ast_table = Table.read(ast_file, format='ascii')
+    ast_fluxbins = Table.read(ast_file.replace('inputAST','ASTfluxbins'), format='ascii')
+
+    # get filter names (and it's even in order!)
+    filter_cols = [col for col in ast_table.colnames if '_' in col]
+    filter_list = [col[-5:] for col in filter_cols]
+    n_filter = len(filter_list)
+
+    # if chosen, read in model grid
+    if sed_grid_file is not None:
+        modelsedgrid = FileSEDGrid(sed_grid_file)
+        with Vega() as v:
+            vega_f, vega_flux, lambd = v.getFlux(filter_cols)
+        sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
+        good_seds = np.where(modelsedgrid.grid['logL'] > -9)[0]
+
+
+    # make a histogram for each filter
+    fig = plt.figure(figsize=(7,4*n_filter))
+
+    for f,filt in enumerate(filter_list):
+
+        # names of table columns with bin values
+        min_bin_col = [b for b in ast_fluxbins.colnames if ('mins' in b and filt in b)][0]
+        max_bin_col = [b for b in ast_fluxbins.colnames if ('maxs' in b and filt in b)][0]
+        # use those to make a bin list
+        bin_list = np.append(ast_fluxbins[min_bin_col], ast_fluxbins[max_bin_col][-1])
+
+        # make histograms
+        ax = plt.subplot(n_filter, 1, f+1)
+
+        ast_col = [b for b in ast_table.colnames if filt in b][0]
+
+        plt.hist(
+            ast_table[ast_col],
+            bins=bin_list,
+            normed=True,
+            facecolor='black',
+            edgecolor='none',
+            alpha=0.3,
+            label='ASTs'
+        )
+
+        if sed_grid_file is not None:
+            plt.hist(
+                sedsMags[good_seds,f],
+                bins=bin_list,
+                normed=True,
+                histtype='step',
+                facecolor='none',
+                edgecolor='black',
+                label='Model grid'
+            )
+
+        # labels
+        ax.tick_params(axis='both', which='major', labelsize=13)
+        ax.set_xlim(ax.get_xlim()[::-1])
+        plt.xlabel(filt+' (Vega mag)', fontsize=14)
+        plt.ylabel('Normalized Histogram', fontsize=14)
+
+
+        # add legend in first plot
+        if f == 0:
+            ax.legend(fontsize=14)
+
+
+    plt.tight_layout()
+
+    fig.savefig(ast_file.replace('.txt','.png'))
+    plt.close(fig)

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -11,6 +11,10 @@ diagnostic plots and visualizations.  Some are described here.
   a list of artificial stars (use `region_file_txt`).  Can also choose a
   column+value as a cut to set two different region colors.
 
+- `plot_ast_histogram.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_ast_histogram.py>`_:
+  Make a histogram of the AST fluxes for each filter.  Optionally, also include
+  a histogram of the SED grid for comparison.
+
 - `plot_chi2_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_chi2_hist.py>`_:
   Make a histogram of the best chi2 values (chi2=1 and the median chi2 are
   marked).  Note that there is no plot of reduced chi2, because it is mathematically


### PR DESCRIPTION
This adds a function `plot_ast_histogram.py` to make a histogram of AST fluxes (one histogram for each filter).  There's an optional input of the SED model grid, which will also overplot a histogram of the SED fluxes.  I also added it to the plotting docs.

Here's an example plot (sorry it's so gigantic)

![14675_LMC-2833ne-35147_beast_inputAST](https://user-images.githubusercontent.com/32465297/69361153-e01f6d00-0c59-11ea-96d0-03b60d07e468.png)
