### PR TITLE
Replace sys.exit() calls with informative Warning/Error messages

### DIFF
--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -147,8 +147,11 @@ def percentile(data, percentiles, weights=None):
             else:
                 f1 = (w[s] - p) / (w[s] - w[s - 1])
                 f2 = (p - w[s - 1]) / (w[s] - w[s - 1])
-                assert (f1 >= 0) and (f2 >= 0) and (f1 <= 1) and (f2 <= 1)
-                assert abs(f1 + f2 - 1.0) < 1e-6
+                if not (
+                    (f1 >= 0) and (f2 >= 0) and (f1 <= 1) and (f2 <= 1)
+                    and (abs(f1 + f2 - 1.0) < 1e-6)
+                ):
+                    raise AssertionError()
                 o[pk] = sd[s - 1] * f1 + sd[s] * f2
         return o
 

--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -104,8 +104,7 @@ def trim_models(
         model_icov_offdiag = sedgrid_noisemodel.root.icov_offdiag[:]
 
     if len(indxs) <= 0:
-        print("no models are brighter than the minimum ASTs run")
-        exit()
+        raise ValueError("no models are brighter than the minimum ASTs run")
 
     n_ast_indxs = len(indxs)
 
@@ -124,8 +123,7 @@ def trim_models(
             indxs = indxs[nindxs]
 
     if len(indxs) == 0:
-        print("no models that are within the data range")
-        exit()
+        raise ValueError("no models that are within the data range")
 
     print("number of original models = ", len(sedgrid.seds[:, 0]))
     print("number of ast trimmed models = ", n_ast_indxs)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -153,8 +153,8 @@ def pick_models_toothpick_style(
         bin_edges[:, f] = np.linspace(mins[f], maxes[f], N_fluxes + 1)
     bin_mins = bin_edges[:-1, :]
     bin_maxs = bin_edges[1:, :]
-    assert len(bin_mins) == N_fluxes
-    assert len(bin_maxs) == N_fluxes
+    if not len(bin_mins) == len(bin_maxs) == N_fluxes:
+        raise AssertionError()
 
     bin_count = np.zeros((N_fluxes, Nf))
     chosen_idxs = []

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -190,7 +190,7 @@ def pick_positions_from_map(
         importlib.reload(datamodel)
 
         # 1. find the sub-list of sources
-        if type(region_from_filters) == list:
+        if isinstance(region_from_filters, list):
             # good stars with user-defined partial overlap
             _, good_stars = cut_catalogs.cut_catalogs(datamodel.obsfile, 'N/A',
                                       flagged=True, flag_filter=region_from_filters,

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -138,7 +138,7 @@ class Observations(object):
         """ read the dataset from the original source file """
         from ..external.eztables import AstroTable
 
-        if type(self.inputFile) == str:
+        if isinstance(self.inputFile, str):
             self.data = AstroTable(self.inputFile)
         else:
             self.data = self.inputFile

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -205,10 +205,13 @@ def gen_SimObs_from_sedgrid(
     # hack to get things to run for now
     short_filters = [filter.split(sep="_")[-1].upper() for filter in sedgrid.filters]
     if compl_filter.upper() not in short_filters:
-        print("requested completeness filter not present")
-        print("%s requested" % compl_filter.upper())
-        print("possible filters", short_filters)
-        exit()
+        raise NotImplementedError(
+            "Requested completeness filter not present:"
+            + compl_filter.upper()
+            + "\nPossible filters:"
+            + "\n".join(short_filters)
+        )
+
     filter_k = short_filters.index(compl_filter.upper())
     print("Completeness from %s" % sedgrid.filters[filter_k])
 

--- a/beast/observationmodel/tests/test_extra_filters.py
+++ b/beast/observationmodel/tests/test_extra_filters.py
@@ -17,7 +17,8 @@ def test_extra_filters(lambda_start, lambda_finish, d_lambda):
 
     # test bandwidth and name
     np.testing.assert_allclose(f_int.bandwidth, lambda_finish - lambda_start - d_lambda)
-    assert f_int.name == "Pseudo_Fake_QION"
+    if not f_int.name == "Pseudo_Fake_QION":
+        raise AssertionError()
 
     # create example top hat filters
     f_top = make_top_hat_filter(
@@ -25,4 +26,5 @@ def test_extra_filters(lambda_start, lambda_finish, d_lambda):
     )
 
     np.testing.assert_allclose(f_top.bandwidth, lambda_finish - lambda_start - d_lambda)
-    assert f_top.name == "Pseudo_Fake_TOP"
+    if not f_top.name == "Pseudo_Fake_TOP":
+        raise AssertionError()

--- a/beast/physicsmodel/creategrid.py
+++ b/beast/physicsmodel/creategrid.py
@@ -296,7 +296,7 @@ def make_extinguished_grid(
     # get the stellar grid (no dust yet)
     # if string is provided try to load the most memory efficient backend
     # otherwise use a cache-type backend (load only when needed)
-    if type(spec_grid) == str:
+    if isinstance(spec_grid, str):
         ext = spec_grid.split(".")[-1]
         if ext in ["hdf", "hd5", "hdf5"]:
             g0 = SpectralGrid(spec_grid, backend="hdf")

--- a/beast/physicsmodel/dust/tests/test_extinction.py
+++ b/beast/physicsmodel/dust/tests/test_extinction.py
@@ -187,7 +187,8 @@ def test_extinction_Cardelli89_values(Rv):
 
 def test_extinction_generalRvFA_initialize():
     tlaw = extinction.Generalized_RvFALaw()
-    assert isinstance(tlaw, extinction.Generalized_RvFALaw)
+    if not isinstance(tlaw, extinction.Generalized_RvFALaw):
+        raise AssertionError()
 
     lam = np.linspace(2.0e3, 1.0e4, 10)
     tlaw_vals = tlaw(lam, Av=1.0, Rv=4.0, f_A=0.8)
@@ -199,8 +200,9 @@ def test_extinction_generalRvFA_initialize():
 @pytest.mark.parametrize("curve", ["F04", "G03_LMCAvg"])
 def test_extinction_dustextpkg_initialize(curve):
     tlaw = extinction.Generalized_DustExt(curve)
-    assert isinstance(tlaw, extinction.Generalized_DustExt)
-
+    if not isinstance(tlaw, extinction.Generalized_DustExt):
+        raise AssertionError()
+        
 
 @pytest.mark.parametrize(
     "curve,origExtLaw", [("G03_SMCBar", "Gordon03_SMCBar"), ("F99", "Fitzpatrick99")]

--- a/beast/physicsmodel/dust/tests/test_extinction.py
+++ b/beast/physicsmodel/dust/tests/test_extinction.py
@@ -188,7 +188,7 @@ def test_extinction_Cardelli89_values(Rv):
 def test_extinction_generalRvFA_initialize():
     tlaw = extinction.Generalized_RvFALaw()
     if not isinstance(tlaw, extinction.Generalized_RvFALaw):
-        raise AssertionError()
+        raise AssertionError("Should use Generalized_RvFALaw extinction")
 
     lam = np.linspace(2.0e3, 1.0e4, 10)
     tlaw_vals = tlaw(lam, Av=1.0, Rv=4.0, f_A=0.8)
@@ -201,7 +201,7 @@ def test_extinction_generalRvFA_initialize():
 def test_extinction_dustextpkg_initialize(curve):
     tlaw = extinction.Generalized_DustExt(curve)
     if not isinstance(tlaw, extinction.Generalized_DustExt):
-        raise AssertionError()
+        raise AssertionError("Should use Generalized_DustExt extinction")
 
 
 @pytest.mark.parametrize(

--- a/beast/physicsmodel/dust/tests/test_extinction.py
+++ b/beast/physicsmodel/dust/tests/test_extinction.py
@@ -202,7 +202,7 @@ def test_extinction_dustextpkg_initialize(curve):
     tlaw = extinction.Generalized_DustExt(curve)
     if not isinstance(tlaw, extinction.Generalized_DustExt):
         raise AssertionError()
-        
+
 
 @pytest.mark.parametrize(
     "curve,origExtLaw", [("G03_SMCBar", "Gordon03_SMCBar"), ("F99", "Fitzpatrick99")]

--- a/beast/physicsmodel/dust/tests/test_extinction.py
+++ b/beast/physicsmodel/dust/tests/test_extinction.py
@@ -6,8 +6,8 @@ from beast.physicsmodel.dust import extinction
 
 def test_extinction_Cardelli89_initialize():
     tlaw = extinction.Cardelli89()
-    assert type(tlaw) == extinction.Cardelli89
-    assert tlaw.name == "Cardelli89"
+    if not isinstance(tlaw, extinction.Cardelli89) and tlaw.name == "Cardelli89":
+        raise AssertionError("Should use Cardelli89 extinction")
 
 
 @pytest.mark.parametrize("Rv", [2.0, 3.0, 3.1, 4.0, 5.0, 6.0])
@@ -187,7 +187,7 @@ def test_extinction_Cardelli89_values(Rv):
 
 def test_extinction_generalRvFA_initialize():
     tlaw = extinction.Generalized_RvFALaw()
-    assert type(tlaw) == extinction.Generalized_RvFALaw
+    assert isinstance(tlaw, extinction.Generalized_RvFALaw)
 
     lam = np.linspace(2.0e3, 1.0e4, 10)
     tlaw_vals = tlaw(lam, Av=1.0, Rv=4.0, f_A=0.8)
@@ -199,7 +199,7 @@ def test_extinction_generalRvFA_initialize():
 @pytest.mark.parametrize("curve", ["F04", "G03_LMCAvg"])
 def test_extinction_dustextpkg_initialize(curve):
     tlaw = extinction.Generalized_DustExt(curve)
-    assert type(tlaw) == extinction.Generalized_DustExt
+    assert isinstance(tlaw, extinction.Generalized_DustExt)
 
 
 @pytest.mark.parametrize(

--- a/beast/physicsmodel/grid.py
+++ b/beast/physicsmodel/grid.py
@@ -285,9 +285,8 @@ class SpectralGrid(ModelGrid):
             if not inplace, returns a new ModelGrid instance. Otherwise returns
             nothing
         """
-        assert isinstance(
-            extLaw, extinction.ExtinctionLaw
-        ), "Expecting ExtinctionLaw object got %s" % type(extLaw)
+        if not isinstance(extLaw, extinction.ExtinctionLaw):
+            raise TypeError("Expecting ExtinctionLaw object got %s" % type(extLaw))
         extCurve = np.exp(-1.0 * extLaw.function(self.lamb[:], **kwargs))
         if not inplace:
             g = self.copy()

--- a/beast/physicsmodel/grid.py
+++ b/beast/physicsmodel/grid.py
@@ -110,7 +110,7 @@ class ModelGrid(object):
         backend = kwargs.pop("backend", None)
         if backend is None:
             self._backend = GridBackend(*args, **kwargs)
-        elif type(backend) in basestring:
+        elif isinstance(backend, basestring):
             self._backend = find_backend(backend)(*args, **kwargs)
         elif isNestedInstance(backend, GridBackend):
             self._backend = backend

--- a/beast/physicsmodel/grid.py
+++ b/beast/physicsmodel/grid.py
@@ -241,7 +241,7 @@ class SpectralGrid(ModelGrid):
         memgrid: MemoryGrid instance
             grid of SEDs
         """
-        if type(filter_names[0]) == str:
+        if isinstance(filter_names[0], str):
             flist = phot.load_filters(
                 filter_names, interp=True, lamb=self.lamb, filterLib=filterLib
             )

--- a/beast/physicsmodel/helpers/gridbackends.py
+++ b/beast/physicsmodel/helpers/gridbackends.py
@@ -301,9 +301,8 @@ class MemoryBackend(GridBackend):
             filename (incl. path) to export to
         """
         if (self.lamb is not None) & (self.seds is not None) & (self.grid is not None):
-            assert isinstance(
-                self.grid, Table
-            ), "Only eztables.Table are supported so far"
+            if not isinstance(self.grid, Table):
+                raise TypeError("Only eztables.Table are supported so far")
             r = numpy.vstack([self.seds, self.lamb])
             pyfits.writeto(fname, r, **kwargs)
             if getattr(self, "filters", None) is not None:
@@ -324,9 +323,8 @@ class MemoryBackend(GridBackend):
             if set, it will append data to each Array or Table
         """
         if (self.lamb is not None) & (self.seds is not None) & (self.grid is not None):
-            assert isinstance(
-                self.grid, Table
-            ), "Only eztables.Table are supported so far"
+            if not isinstance(self.grid, Table):
+                raise TypeError("Only eztables.Table are supported so far")
             with HDFStore(fname, mode="a") as hd:
                 if not append:
                     hd["/seds"] = self.seds[:]
@@ -533,9 +531,8 @@ class CacheBackend(GridBackend):
             filename (incl. path) to export to
         """
         if (self.lamb is not None) & (self.seds is not None) & (self.grid is not None):
-            assert isinstance(
-                self.grid, Table
-            ), "Only eztables.Table are supported so far"
+            if not isinstance(self.grid, Table):
+                raise TypeError("Only eztables.Table are supported so far")
             r = numpy.vstack([self.seds, self.lamb])
             pyfits.writeto(fname, r, **kwargs)
             del r
@@ -557,9 +554,8 @@ class CacheBackend(GridBackend):
             if set, it will append data to each Array or Table
         """
         if (self.lamb is not None) & (self.seds is not None) & (self.grid is not None):
-            assert isinstance(
-                self.grid, Table
-            ), "Only eztables.Table are supported so far"
+            if not isinstance(self.grid, Table):
+                raise TypeError("Only eztables.Table are supported so far")
             with HDFStore(fname, mode="a") as hd:
                 if not append:
                     hd["/seds"] = self.seds[:]

--- a/beast/physicsmodel/helpers/gridbackends.py
+++ b/beast/physicsmodel/helpers/gridbackends.py
@@ -219,7 +219,7 @@ class MemoryBackend(GridBackend):
             self._fromHDFBackend(lamb)
         elif isNestedInstance(lamb, GridBackend):
             self._from_GridBackend(lamb)
-        elif type(lamb) in basestring:
+        elif isinstance(lamb, basestring):
             self._from_File(lamb)
         else:
             if (seds is None) | (grid is None):

--- a/beast/physicsmodel/helpers/hdfstore.py
+++ b/beast/physicsmodel/helpers/hdfstore.py
@@ -370,7 +370,7 @@ class HDFStore(object):
             returns if any operation was actually done (True) else the file was already opened (False)
         """
         if self.source is None:
-            if type(self.lnpfile) == str:
+            if isinstance(self.lnpfile, str):
                 self.source = tables.open_file(
                     self.lnpfile, mode=self._mode, **self._open_kwargs
                 )

--- a/beast/physicsmodel/helpers/hdfstore.py
+++ b/beast/physicsmodel/helpers/hdfstore.py
@@ -606,7 +606,6 @@ def unittest():
     """unittest
     Example usage
     """
-    import numpy as np
 
     # make a store
     with HDFStore("tmp.hd5", mode="w") as hd:

--- a/beast/physicsmodel/prior_weights_dust.py
+++ b/beast/physicsmodel/prior_weights_dust.py
@@ -5,7 +5,6 @@ The priors on A(V), R(V), and f_A computed as weights to use
 in the posterior calculations.
 """
 import numpy as np
-from sys import exit
 
 __all__ = ["PriorWeightsDust"]
 
@@ -224,14 +223,17 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
-                N2=1.0
+                N2=1.0,
             )
         elif model["name"] == "exponential":
             self.av_priors = _exponential(self.av_vals, a=model["a"])
         else:
-            print("**error in setting the A(V) dust prior weights!**")
-            print("**model " + model["name"] + " not supported**")
-            exit()
+            raise NotImplementedError(
+                "**error in setting the A(V) dust prior weights!**"
+                + "**model "
+                + model["name"]
+                + " not supported**"
+            )
 
         # normalize to avoid numerical issues (too small or too large)
         self.av_priors /= np.average(self.av_priors)
@@ -262,12 +264,15 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
-                N2=1.0
+                N2=1.0,
             )
         else:
-            print("**error in setting the R(V) dust prior weights!**")
-            print("**model " + model["name"] + " not supported**")
-            exit()
+            raise NotImplementedError(
+                "**Error in setting the R(V) dust prior weights!**"
+                + "**model "
+                + model["name"]
+                + " not supported**"
+            )
 
         # normalize to avoid numerical issues (too small or too large)
         self.rv_priors /= np.average(self.rv_priors)
@@ -298,12 +303,15 @@ class PriorWeightsDust:
                 sigma1=model["sigma1"],
                 sigma2=model["sigma2"],
                 N1=model["N1_to_N2"],
-                N2=1.0
+                N2=1.0,
             )
         else:
-            print("**error in setting the f_A dust prior weights!**")
-            print("**model " + model["name"] + " not supported**")
-            exit()
+            raise NotImplementedError(
+                "**Error in setting the f_A dust prior weights!**"
+                + "**model "
+                + model["name"]
+                + " not supported**"
+            )
 
         # normalize to avoid numerical issues (too small or too large)
         self.fA_priors /= np.average(self.fA_priors)

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -4,7 +4,6 @@ Prior Weights
 The priors on age, mass, and metallicty are computed as weights to use
 in the posterior calculations.
 """
-from sys import exit
 import numpy as np
 from scipy.integrate import quad
 from scipy.interpolate import interp1d
@@ -48,10 +47,11 @@ def compute_age_prior_weights(logages, age_prior_model):
     elif age_prior_model["name"] == "bins_histo":
         # interpolate according to bins, assuming SFR constant from i to i+1
         # and allow for bin edges input
-        if len(age_prior_model["values"]) == len(age_prior_model["logages"])-1:
+        if len(age_prior_model["values"]) == len(age_prior_model["logages"]) - 1:
             age_prior_model["values"].append(0.0)
         ageND = interp1d(
-            age_prior_model["logages"], age_prior_model["values"], kind="zero")
+            age_prior_model["logages"], age_prior_model["values"], kind="zero"
+        )
         age_weights = ageND(logages)
     elif age_prior_model["name"] == "bins_interp":
         # interpolate model to grid ages
@@ -66,12 +66,11 @@ def compute_age_prior_weights(logages, age_prior_model):
         vals = (10 ** logages) / (age_prior_model["tau"] * 1e9)
         age_weights = np.exp(vals)
     else:
-        print(
+        raise NotImplementedError(
             "input age prior ''{}'' function not supported".format(
                 age_prior_model["name"]
             )
         )
-        exit()
 
     # normalize to avoid numerical issues (too small or too large)
     age_weights /= np.average(age_weights)
@@ -170,8 +169,7 @@ def compute_mass_prior_weights(masses, mass_prior_model):
     elif mass_prior_model["name"] == "salpeter":
         imf_func = imf_salpeter
     else:
-        print("input mass prior function not supported")
-        exit()
+        raise NotImplementedError("input mass prior function not supported")
 
     # calculate the average prior in each mass bin
     for i in range(len(masses)):
@@ -204,8 +202,7 @@ def compute_metallicity_prior_weights(mets, met_prior_model):
     if met_prior_model["name"] == "flat":
         met_weights = np.full(len(mets), 1.0)
     else:
-        print("input metallicity prior function not supported")
-        exit()
+        raise NotImplementedError("input metallicity prior function not supported")
 
     # normalize to avoid numerical issues (too small or too large)
     met_weights /= np.average(met_weights)

--- a/beast/physicsmodel/stars/ezpadova/parsec.json
+++ b/beast/physicsmodel/stars/ezpadova/parsec.json
@@ -70,7 +70,6 @@
 		"lsst": "LSST ugrizY, March 2012 total filter throughputs (all ABmags)",
 		"noao_ctio_mosaic2": "NOAO/CTIO/MOSAIC2 (Vegamag)",
 		"TESS_2mass_kepler": "TESS + 2MASS (Vegamags) + Kepler + SDSS griz + DDO51 (in ABmags)",
-		"ukidss": "UKIDSS ZYJHK (Vegamag)",
 		"vphas": "VPHAS+ (ABmags)",
 		"vst_omegacam": "VST/OMEGACAM (ABmag)",
 		"vilnius": "Vilnius",
@@ -88,7 +87,7 @@
 	},
 	"map_carbon_stars" : {
 		"loidl": ["loidl01", "Loidl et al. (2001) (as in Marigo et al. (2008) and Girardi et al. (2008))"],
-		"aringer": ["aringer09", "Aringer et al. (2009) (Note: The interpolation scheme has been slightly improved w.r.t. to the paper's Fig. 19."] 
+		"aringer": ["aringer09", "Aringer et al. (2009) (Note: The interpolation scheme has been slightly improved w.r.t. to the paper's Fig. 19."]
 	},
 	"map_circum_Mstars": {
 		"nodustM": ["no dust", ""],

--- a/beast/physicsmodel/stars/isochrone.py
+++ b/beast/physicsmodel/stars/isochrone.py
@@ -4,7 +4,6 @@ Isochrone class
 Intent to implement a generic module to manage isochrone mining from various
 sources.
 """
-import numpy
 import numpy as np
 from numpy import interp
 from numpy import log10
@@ -37,7 +36,7 @@ class Isochrone(object):
            Z = [ 0.0004, 0.004, 0.008, 0.02, 0.05 ]
            [Fe/H] = [ -1.7  , -0.7 , -0.4 , 0   , 0.4  ]
         """
-        return numpy.log10(metal / 0.02)
+        return np.log10(metal / 0.02)
 
     def FeHtometal(self, feh):
         """
@@ -65,17 +64,17 @@ class Isochrone(object):
 
         # compute vector of discrete derivaties for each quantity
         # and the final number of points
-        npts = (numpy.abs(numpy.divide(numpy.diff(logM), dm))).astype(int)
-        npts += (numpy.abs(numpy.divide(numpy.diff(logT), dt))).astype(int)
-        npts += (numpy.abs(numpy.divide(numpy.diff(logL), dl))).astype(int)
-        idx = numpy.hstack([[0], numpy.cumsum(npts + 1)])
+        npts = (np.abs(np.divide(np.diff(logM), dm))).astype(int)
+        npts += (np.abs(np.divide(np.diff(logT), dt))).astype(int)
+        npts += (np.abs(np.divide(np.diff(logL), dl))).astype(int)
+        idx = np.hstack([[0], np.cumsum(npts + 1)])
         # set up vectors for storage
         ntot = (npts + 1).sum()
-        newm = numpy.empty(ntot, dtype=float)
-        newdm = numpy.empty(ntot, dtype=float)
-        newt = numpy.empty(ntot, dtype=float)
-        newg = numpy.empty(ntot, dtype=float)
-        newl = numpy.empty(ntot, dtype=float)
+        newm = np.empty(ntot, dtype=float)
+        newdm = np.empty(ntot, dtype=float)
+        newt = np.empty(ntot, dtype=float)
+        newg = np.empty(ntot, dtype=float)
+        newl = np.empty(ntot, dtype=float)
 
         for i in range(len(npts)):
             a, b = idx[i], idx[i] + npts[i] + 1
@@ -83,20 +82,20 @@ class Isochrone(object):
                 # construct new 1d grids in each dimension, being careful
                 #   about endpoints
                 # append them to storage vectors
-                newm[a:b] = numpy.linspace(
+                newm[a:b] = np.linspace(
                     logM[i], logM[i + 1], npts[i] + 1, endpoint=False
                 )
-                newt[a:b] = numpy.linspace(
+                newt[a:b] = np.linspace(
                     logT[i], logT[i + 1], npts[i] + 1, endpoint=False
                 )
-                newg[a:b] = numpy.linspace(
+                newg[a:b] = np.linspace(
                     logg[i], logg[i + 1], npts[i] + 1, endpoint=False
                 )
-                newl[a:b] = numpy.linspace(
+                newl[a:b] = np.linspace(
                     logL[i], logL[i + 1], npts[i] + 1, endpoint=False
                 )
                 newdm[a:b] = (
-                    numpy.ones(npts[i] + 1) * (logM[i + 1] - logM[i]) / (npts[i] + 1)
+                    np.ones(npts[i] + 1) * (logM[i + 1] - logM[i]) / (npts[i] + 1)
                 )
             else:
                 # if the maximumum allowable difference is small,
@@ -133,8 +132,8 @@ class padova2010(Isochrone):
         self.name = "Padova 2010 (Marigo 2008 + Girardi 2010)"
         self.source = __ROOT__ + "/padova2010.iso.fits"
         self._load_table_(self.source)
-        self.ages = 10 ** numpy.unique(self.data["logA"])
-        self.Z = numpy.unique(self.data["Z"])
+        self.ages = 10 ** np.unique(self.data["logA"])
+        self.Z = np.unique(self.data["Z"])
 
     def _load_table_(self, source):
         t = Table(self.source)
@@ -142,11 +141,11 @@ class padova2010(Isochrone):
         for k in list(t.keys()):
             data[k] = t[k]
         # Alias columns
-        data["logM"] = log10(numpy.asarray(data["M_ini"]))
-        data["logg"] = numpy.asarray(data["logG"])
-        data["logT"] = numpy.asarray(data["logTe"])
-        data["logL"] = numpy.asarray(data["logL/Lo"])
-        data["logA"] = numpy.asarray(data["log(age/yr)"])
+        data["logM"] = log10(np.asarray(data["M_ini"]))
+        data["logg"] = np.asarray(data["logG"])
+        data["logT"] = np.asarray(data["logTe"])
+        data["logL"] = np.asarray(data["logL/Lo"])
+        data["logA"] = np.asarray(data["log(age/yr)"])
         # clean columns
         data.pop("log(age/yr)")
         data.pop("M_ini")
@@ -184,13 +183,13 @@ class padova2010(Isochrone):
             # no interpolation, isochrone already in the file
             t = t.selectWhere("*", "(logA == _age)", condvars={"_age": log10(_age)})
             for kn in list(t.keys()):
-                data[kn] = numpy.asarray(t[kn])
+                data[kn] = np.asarray(t[kn])
         else:
             # interpolate between isochrones
             d = (self.ages - float(_age)) ** 2
-            a1, a2 = self.ages[numpy.argsort(d)[:2]]
+            a1, a2 = self.ages[np.argsort(d)[:2]]
             # print "Warning: Interpolation between %d and %d Myr" % (a1, a2)
-            r = numpy.log10(_age / a1) / numpy.log10(a2 / a1)
+            r = np.log10(_age / a1) / np.log10(a2 / a1)
 
             t1 = t.selectWhere("*", "logA == _age", condvars={"_age": log10(a1)})
             t2 = t.selectWhere("*", "logA == _age", condvars={"_age": log10(a2)})
@@ -207,7 +206,7 @@ class padova2010(Isochrone):
         if masses is not None:
             # masses are expected in logM for interpolation
             if masses.max() > 2.3:
-                _m = numpy.log10(masses)
+                _m = np.log10(masses)
             else:
                 _m = masses
             data_logM = data["logM"][:]
@@ -227,10 +226,10 @@ class pegase(Isochrone):
         self.name = "Pegase.2 (Fioc+1997)"
         self.source = __ROOT__ + "/pegase.iso.hd5"
         self.data = tables.openFile(self.source)
-        self.ages = numpy.sort(
-            numpy.asarray([k.attrs.time for k in self.data.root.Z02]) * 1e6
+        self.ages = np.sort(
+            np.asarray([k.attrs.time for k in self.data.root.Z02]) * 1e6
         )
-        self.Z = numpy.asarray(
+        self.Z = np.asarray(
             [
                 float("0." + k[1:])
                 for k in self.data.root._g_listGroup(self.data.getNode("/"))[0]
@@ -282,9 +281,9 @@ class pegase(Isochrone):
         else:
             # interpolate between isochrones
             d = (self.ages - float(age)) ** 2
-            a1, a2 = numpy.sort(self.ages[numpy.argsort(d)[:2]] * 1e-6)
+            a1, a2 = np.sort(self.ages[np.argsort(d)[:2]] * 1e-6)
             # print "Warning: Interpolation between %d and %d Myr" % (a1, a2)
-            r = numpy.log10(_age / a1) / numpy.log10(a2 / a1)
+            r = np.log10(_age / a1) / np.log10(a2 / a1)
 
             t1 = self.data.getNode("/Z" + str(metal)[2:] + "/a" + str(int(a1)))
             t2 = self.data.getNode("/Z" + str(metal)[2:] + "/a" + str(int(a2)))
@@ -301,7 +300,7 @@ class pegase(Isochrone):
         if masses is not None:
             # masses are expected in logM for interpolation
             if masses.max() > 2.3:
-                _m = numpy.log10(masses)
+                _m = np.log10(masses)
             else:
                 _m = masses
             data_logM = data["logM"][:]

--- a/beast/physicsmodel/stars/kurucz/generate.py
+++ b/beast/physicsmodel/stars/kurucz/generate.py
@@ -80,8 +80,9 @@ def gen_spectral_grid_from_kurucz(outfile, osl, oiso, Z=0.02):
 
         only write into outfile
     """
-    assert grid.isNestedInstance(osl, stellib.Stellib)
-    assert grid.isNestedInstance(oiso, isochrone.Isochrone)
+    if not (grid.isNestedInstance(osl, stellib.Stellib)
+            and grid.isNestedInstance(oiso, isochrone.Isochrone)):
+        raise AssertionError()
     specs = np.empty((oiso.data.nrows + 1, len(osl.wavelength)), dtype=float)
     specs[-1] = osl.wavelength[:]
 

--- a/beast/physicsmodel/stars/simpletable.py
+++ b/beast/physicsmodel/stars/simpletable.py
@@ -916,7 +916,7 @@ def pprint_rec_entry(data, num=0, keys=None):
         """
     if (keys is None) or (keys == "*"):
         _keys = data.dtype.names
-    elif type(keys) in strtype:
+    elif isinstance(keys, strtype):
         _keys = [k for k in data.dtype.names if (re.match(keys, k) is not None)]
     else:
         _keys = keys
@@ -970,7 +970,7 @@ def pprint_rec_array(
         """
     if (fields is None) or (fields == "*"):
         _keys = data.dtype.names
-    elif type(fields) in strtype:
+    elif isinstance(fields, strtype):
         if "," in fields:
             _fields = fields.split(",")
         elif " " in fields:
@@ -1030,7 +1030,7 @@ def elementwise(func):
 
     @wraps(func)
     def wrapper(it, **kwargs):
-        if hasattr(it, "__iter__") & (type(it) not in strtype):
+        if hasattr(it, "__iter__") and not isinstance(it, strtype):
             _f = partial(func, **kwargs)
             return list(map(_f, it))
         else:
@@ -1460,11 +1460,11 @@ class SimpleTable(object):
         self._units = kwargs.get("units", {})
         self._desc = kwargs.get("desc", {})
 
-        if (type(fname) == dict) or (dtype in [dict, "dict"]):
+        if isinstance(fname, dict) or (dtype in [dict, "dict"]):
             self.header = fname.pop("header", {})
             self.data = _convert_dict_to_structured_ndarray(fname)
-        elif (type(fname) in strtype) or (dtype is not None):
-            if type(fname) in strtype:
+        elif isinstance(fname, strtype) or (dtype is not None):
+            if isinstance(fname, strtype):
                 extension = fname.split(".")[-1]
             else:
                 extension = None
@@ -1531,13 +1531,13 @@ class SimpleTable(object):
                 self._aliases.update(**aliases)
             else:
                 raise Exception("Format {0:s} not handled".format(extension))
-        elif type(fname) == np.ndarray:
+        elif isinstance(fname, np.ndarray):
             self.data = fname
             self.header = {}
-        elif type(fname) == pyfits.FITS_rec:
+        elif isinstance(fname, pyfits.FITS_rec):
             self.data = np.array(fname)
             self.header = {}
-        elif type(fname) == SimpleTable:
+        elif isinstance(fname, SimpleTable):
             cp = kwargs.pop("copy", True)
             if cp:
                 self.data = deepcopy(fname.data)
@@ -1557,7 +1557,7 @@ class SimpleTable(object):
         else:
             raise Exception("Type {0!s:s} not handled".format(type(fname)))
         if "NAME" not in self.header:
-            if type(fname) not in strtype:
+            if not isinstance(fname, strtype):
                 self.header["NAME"] = "No Name"
             else:
                 self.header["NAME"] = fname
@@ -1576,7 +1576,7 @@ class SimpleTable(object):
         """
         if (keys is None) or (keys == "*"):
             _keys = list(self.keys())
-        elif type(keys) in strtype:
+        elif isinstance(keys, strtype):
             _keys = [
                 k
                 for k in (list(self.keys()) + tuple(self._aliases.keys()))
@@ -1638,7 +1638,7 @@ class SimpleTable(object):
 
         if (fields is None) or (fields == "*"):
             _keys = list(self.keys())
-        elif type(fields) in strtype:
+        elif isinstance(fields, strtype):
             if "," in fields:
                 _fields = fields.split(",")
             elif " " in fields:
@@ -1797,7 +1797,7 @@ class SimpleTable(object):
         Aliases are defined by using .define_alias()
         """
         # User aliases
-        if hasattr(colname, "__iter__") & (type(colname) not in strtype):
+        if hasattr(colname, "__iter__") and not isinstance(colname, strtype):
             return [self.resolve_alias(k) for k in colname]
         else:
             if self.caseless is True:
@@ -1863,7 +1863,7 @@ class SimpleTable(object):
         """
         if (regexp is None) or (regexp == "*"):
             return self.colnames
-        elif type(regexp) in strtype:
+        elif isinstance(regexp, strtype):
             if full_match is True:
                 fn = re.fullmatch
             else:
@@ -2358,7 +2358,7 @@ class SimpleTable(object):
             list of columns
         """
 
-        if not hasattr(names, "__iter__") or type(names) in strtype:
+        if not hasattr(names, "__iter__") or isinstance(names, strtype):
             names = [names]
 
         p = [self[k] for k in names]

--- a/beast/physicsmodel/stars/simpletable.py
+++ b/beast/physicsmodel/stars/simpletable.py
@@ -2651,12 +2651,14 @@ class AstroTable(SimpleTable):
 
     def set_RA(self, val):
         """ Set the column that defines RA coordinates """
-        assert val in self, "column name {} not found in the table".format(val)
+        if val not in self:
+            raise KeyError("column name {} not found in the table".format(val))
         self._ra_name = val
 
     def set_DEC(self, val):
         """ Set the column that defines DEC coordinates """
-        assert val in self, "column name {} not found in the table".format(val)
+        if val not in self:
+            raise KeyError("column name {} not found in the table".format(val))
         self._dec_name = val
 
     def get_RA(self, degree=True):

--- a/beast/physicsmodel/stars/stellib.py
+++ b/beast/physicsmodel/stars/stellib.py
@@ -595,7 +595,8 @@ class Stellib(object):
             else:
                 _r = np.asarray(self.interp(T0, g0, Z0, **kwargs))
         else:
-            assert T0.ndim == 2, "error expecting 2d-array"
+            if not (T0.ndim == 2):
+                raise ValueError("error expecting 2d-array")
             _r = T0
         return (((self.spectra[_r[:, 0].astype(int)].T) * _r[:, 1])).sum(1)
 

--- a/beast/plotting/plot_region_diags.py
+++ b/beast/plotting/plot_region_diags.py
@@ -63,8 +63,7 @@ def make_region_diag_plots(
         )
     )
     if len(indxs2) <= 0:
-        print("no data in selection window")
-        exit()
+        raise ValueError("no data in selection window")
     else:
         stats_region = stats[indxs[indxs2]]
 

--- a/beast/plotting/tests/test_plots.py
+++ b/beast/plotting/tests/test_plots.py
@@ -1,12 +1,10 @@
 import matplotlib.pyplot as plt
 
-import os.path
 import pytest
 
 import numpy as np
 from astropy.table import Table
 from astropy.io import fits
-from astropy.utils.data import download_file
 from astropy.tests.helper import remote_data
 
 from beast.plotting import plot_indiv_fit, plot_cmd, plot_cmd_with_fits, plot_filters
@@ -56,17 +54,19 @@ def test_indiv_plot():
 
     return fig
 
+
 @remote_data
 @pytest.mark.mpl_image_compare(tolerance=10)
 def test_plot_cmd():
 
     # Download example data from phat_small
-    fitsfile =  download_rename("b15_4band_det_27_A.fits")
+    fitsfile = download_rename("b15_4band_det_27_A.fits")
 
     # Plot CMD using defaults
     fig = plot_cmd.plot(fitsfile)
 
     return fig
+
 
 @remote_data
 @pytest.mark.mpl_image_compare(tolerance=55)
@@ -76,7 +76,7 @@ def test_plot_cmd_with_fits():
     fitsfile = download_rename("b15_4band_det_27_A.fits")
 
     # Download BEAST fits to example data
-    beast_fitsfile =  download_rename("beast_example_phat_stats.fits")
+    beast_fitsfile = download_rename("beast_example_phat_stats.fits")
 
     # Plot CMD using defaults
     fig = plot_cmd_with_fits.plot(fitsfile, beast_fitsfile)
@@ -88,10 +88,16 @@ def test_plot_cmd_with_fits():
 @pytest.mark.mpl_image_compare(tolerance=18)
 def test_plot_filters():
 
-    filter_names = ['HST_WFC3_F225W', 'HST_WFC3_F275W', 'HST_WFC3_F336W',
-                    'HST_ACS_WFC_F475W', 'HST_ACS_WFC_F550M',
-                    'HST_ACS_WFC_F814W',
-                    'HST_WFC3_F110W', 'HST_WFC3_F160W']
+    filter_names = [
+        "HST_WFC3_F225W",
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
+        "HST_ACS_WFC_F475W",
+        "HST_ACS_WFC_F550M",
+        "HST_ACS_WFC_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
+    ]
 
     filters = download_rename("filters.hd5")
 

--- a/beast/tests/helpers.py
+++ b/beast/tests/helpers.py
@@ -39,7 +39,8 @@ def compare_tables(table_cache, table_new):
     table_new : astropy table
         data for comparision.
     """
-    assert len(table_new) == len(table_cache)
+    if not len(table_new) == len(table_cache):
+        raise AssertionError()
 
     for tcolname in table_new.colnames:
         # test numerical types for closeness
@@ -71,7 +72,8 @@ def compare_fits(fname_cache, fname_new):
     fits_cache = fits.open(fname_cache)
     fits_new = fits.open(fname_new)
 
-    assert len(fits_new) == len(fits_cache)
+    if not len(fits_new) == len(fits_cache):
+        raise AssertionError()
 
     for k in range(1, len(fits_new)):
         qname = fits_new[k].header["EXTNAME"]

--- a/beast/tools/run/merge_files.py
+++ b/beast/tools/run/merge_files.py
@@ -80,7 +80,7 @@ def merge_files(use_sd=True, nsubs=1):
             merged_pdf_files = []
             merged_stats_files = []
 
-            for i, sd_sub in enumerate(unique_sd_sub):
+            for sd_sub in unique_sd_sub:
 
                 # indices with the current sd_sub
                 ind = [j for j, x in enumerate(sd_sub_info) if x == sd_sub]

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -175,7 +175,7 @@ def setup_batch_beast_fit(
         #    the number of observations
         if not reg_run:
             # get the observed catalog
-            obs = Table.read(photometry_files[i])
+            obs = Table.read(phot_file)
 
             # get the fit results catalog
             t = Table.read(stats_files[i])

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -339,7 +339,8 @@ def merge_pdf1d_stats(
     # -------------
 
     nsubgrids = len(subgrid_pdf1d_fnames)
-    assert len(subgrid_stats_fnames) == nsubgrids
+    if not len(subgrid_stats_fnames) == nsubgrids:
+        raise AssertionError()
 
     nbins = {}
     with fits.open(subgrid_pdf1d_fnames[0]) as hdul_0:
@@ -357,17 +358,19 @@ def merge_pdf1d_stats(
                     pdf1d_0 = hdul_0[q].data
                     pdf1d = hdul[q].data
                     # the number of bins
-                    assert pdf1d_0.shape[1] == pdf1d.shape[1]
+                    if not pdf1d_0.shape[1] == pdf1d.shape[1]:
+                        raise AssertionError()
                     # the number of stars + 1
-                    assert pdf1d_0.shape[0] == pdf1d.shape[0]
+                    if not pdf1d_0.shape[0] == pdf1d.shape[0]:
+                        raise AssertionError()
                     # the bin centers (stored in the last row of the
                     # image) should be equal (or both nan)
-                    bin_centers_ok = (
+                    if not (
                         np.isnan(pdf1d_0[-1, 0])
                         and np.isnan(pdf1d[-1, 0])
                         or (pdf1d_0[-1, :] == pdf1d[-1, :]).all()
-                    )
-                    assert bin_centers_ok
+                    ):
+                        raise AssertionError()
 
     # Load all the stats files
     stats = [Table.read(f) for f in subgrid_stats_fnames]

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -29,7 +29,8 @@ def split_and_check(grid_fname, num_subgrids):
         sub_grids.append(sub_g.grid.data)
 
         np.testing.assert_equal(complete_g.lamb, sub_g.lamb)
-        assert complete_g.grid.columns.items() == sub_g.grid.columns.items()
+        if not complete_g.grid.columns.items() == sub_g.grid.columns.items():
+            raise AssertionError()
 
     sub_seds_reconstructed = np.concatenate(sub_seds)
     np.testing.assert_equal(sub_seds_reconstructed, complete_g.seds)
@@ -64,16 +65,21 @@ def test_reduce_grid_info():
     )
 
     for q in complete_g_info:
-        assert q in sub_g_info
-        assert complete_g_info[q]["min"] == sub_g_info[q]["min"]
-        assert complete_g_info[q]["max"] == sub_g_info[q]["max"]
+        if q not in sub_g_info:
+            raise AssertionError()
+        if not complete_g_info[q]["min"] == sub_g_info[q]["min"]:
+            raise AssertionError()
+        if not complete_g_info[q]["max"] == sub_g_info[q]["max"]:
+            raise AssertionError()
         num_unique = len(complete_g_info[q]["unique"])
         if num_unique > cap_unique:
             # Cpan still be larger if one of the sub results during the
             # reduction is larger. This is as intended.
-            assert sub_g_info[q]["num_unique"] >= cap_unique
+            if not sub_g_info[q]["num_unique"] >= cap_unique:
+                raise AssertionError()
         else:
-            assert sub_g_info[q]["num_unique"] == num_unique
+            if not sub_g_info[q]["num_unique"] == num_unique:
+                raise AssertionError()
 
 
 @remote_data
@@ -202,7 +208,8 @@ def test_merge_pdf1d_stats():
     fits_normal = fits.open(normal_pdf1d)
     fits_new = fits.open(merged_pdf1d_fname)
 
-    assert len(fits_new) == len(fits_normal)
+    if not len(fits_new) == len(fits_normal):
+        raise AssertionError()
 
     # A similar problem to the above will also occur here
     for k in range(1, len(fits_new)):
@@ -217,7 +224,8 @@ def test_merge_pdf1d_stats():
     table_normal = Table.read(normal_stats)
     table_new = Table.read(merged_stats_fname)
 
-    assert len(table_normal) == len(table_new)
+    if not len(table_normal) == len(table_new):
+        raise AssertionError()
 
     # These will normally fail, as the merging process can not be made
     # bit-correct due do floating point math (exacerbated by exponentials)

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -6,53 +6,40 @@ Created by Maria Kapala on Feb 24th 2017
 """
 from os.path import exists
 from numpy import inf
-from sys import exit
 
 
-def verify_range(param, param_name, param_lim, noexit=False):
+def verify_range(param, param_name, param_lim):
     # check if input param limits make sense
 
     if any(p < param_lim[0] for p in param):
-        print((param_name + " min value not physical."))
-        if not noexit:
-            exit()
+        raise ValueError(param_name + " min value not physical.")
 
     if any(p > param_lim[1] for p in param):
-        print((param_name + " max value not physical."))
-        if not noexit:
-            exit()
+        raise ValueError(param_name + " max value not physical.")
 
 
-def check_grid(param, param_name, param_lim, noexit=False):
+def check_grid(param, param_name, param_lim):
     # check if input param limits and grid initialisation make sense
 
     param_min, param_max, param_step = param
 
     if param_min < param_lim[0]:
-        print((param_name + " min value not physical."))
-        if not noexit:
-            exit()
+        raise ValueError(param_name + " min value not physical.")
 
     if param_max > param_lim[1]:
-        print((param_name + " max value not physical."))
-        if not noexit:
-            exit()
+        raise ValueError(param_name + " max value not physical.")
 
     if param_min > param_max:
-        print((param_name + " min value greater than max"))
-        if not noexit:
-            exit()
+        raise ValueError(param_name + " min value greater than max")
 
     if (param_max - param_min) < param_step:
         if param_max - param_min == 0.0:
-            print("Note: " + param_name + " grid is single-valued.")
+            raise UserWarning("Note: " + param_name + " grid is single-valued.")
         else:
-            print((param_name + " step value greater than (max-min)"))
-            if not noexit:
-                exit()
+            raise ValueError(param_name + " step value greater than (max-min)")
 
 
-def verify_one_input_format(param, param_name, param_format, param_lim, noexit=False):
+def verify_one_input_format(param, param_name, param_format, param_lim):
     """
     Test for an input parameter correctness of format and limits.
 
@@ -71,19 +58,14 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
        [-inf, inf] when param is not constraint at all;
        None when concerns a str parameter
 
-    noexit: boolean
-       Override exit() commands if there is an error.
-       Default = False (exit on error)
     """
 
     if "list" in param_format:
         if not isinstance(param, list):
             if param is None:
-                print("Warning: " + param_name + " is not defined.")
+                raise UserWarning(param_name + " is not defined.")
             else:
-                print((param_name + " is not in the right format - a list."))
-                if not noexit:
-                    exit()
+                raise TypeError(param_name + " is not in the right format - a list.")
         elif "float" in param_format:
             is_list_of_floats = all(isinstance(item, float) for item in param)
             if not is_list_of_floats:
@@ -91,9 +73,9 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
             elif "grid" in param_format:
                 # when param is aranged from given [min, max, step],
                 # instead of a specific list of values
-                check_grid(param, param_name, param_lim, noexit=noexit)
+                check_grid(param, param_name, param_lim)
             else:
-                verify_range(param, param_name, param_lim, noexit=noexit)
+                verify_range(param, param_name, param_lim)
 
         if "str" in param_format:
             if not isinstance(param, str):
@@ -112,7 +94,7 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
                 )
 
 
-def verify_input_format(datamodel, noexit=False):
+def verify_input_format(datamodel):
 
     """
     Import BEAST input parameters from datamodel.
@@ -124,10 +106,6 @@ def verify_input_format(datamodel, noexit=False):
     ----------
     datamodel: module
         Input parameters are initialized in datamodel
-
-    noexit: boolean
-        Override exit() commands if there is an error.
-        Default = False (exit on error)
 
     """
 
@@ -166,7 +144,6 @@ def verify_input_format(datamodel, noexit=False):
             parameters_names[i],
             param_format[i],
             parameters_limits[i],
-            noexit=noexit,
         )
 
 

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -77,7 +77,7 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
     """
 
     if "list" in param_format:
-        if type(param) is not list:
+        if not isinstance(param, list):
             if param is None:
                 print("Warning: " + param_name + " is not defined.")
             else:
@@ -85,11 +85,9 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
                 if not noexit:
                     exit()
         elif "float" in param_format:
-            is_list_of_floats = all(type(item) is float for item in param)
+            is_list_of_floats = all(isinstance(item, float) for item in param)
             if not is_list_of_floats:
-                print((param_name + " is not in the right format - list of floats."))
-                if not noexit:
-                    exit()
+                raise TypeError(param_name + " is not in the right format - list of floats.")
             elif "grid" in param_format:
                 # when param is aranged from given [min, max, step],
                 # instead of a specific list of values
@@ -98,32 +96,20 @@ def verify_one_input_format(param, param_name, param_format, param_lim, noexit=F
                 verify_range(param, param_name, param_lim, noexit=noexit)
 
         if "str" in param_format:
-            if type(param) is not str:
-                print((param_name + " is not in the right format - a string."))
-                if not noexit:
-                    exit()
+            if not isinstance(param, str):
+                raise TypeError(param_name + " is not in the right format - a string.")
             elif "file" in param_format:
                 if not exists(param):
-                    print(
-                        (param_name + " does not exist. Please provide the file path.")
-                    )
-                    if not noexit:
-                        exit()
+                    raise OSError(param_name + " does not exist. Please provide the file path.")
 
         if "version" in param_format:
-            if type(param) is not float:
-                print((param_name + " is not in the right format - a float"))
-                if not noexit:
-                    exit()
+            if not isinstance(param, float):
+                raise TypeError(param_name + " is not in the right format - a float")
             elif param not in param_lim:
-                print(
-                    (
-                        param_name
-                        + " is an invalid number, leading to version of the isochrone."
-                    )
+                raise TypeError(
+                    param_name
+                    + " is an invalid number, leading to version of the isochrone."
                 )
-                if not noexit:
-                    exit()
 
 
 def verify_input_format(datamodel, noexit=False):

--- a/beast/tools/write_sbatch_file.py
+++ b/beast/tools/write_sbatch_file.py
@@ -93,17 +93,17 @@ def write_sbatch_file(
 
         f.write("# Load any necessary modules.\n")
         f.write("# Loading modules in the script ensures a consistent environment.\n")
-        if type(modules) == str:
+        if isinstance(modules, str):
             f.write(modules + "\n")
-        elif type(modules) == list:
+        elif isinstance(modules, list):
             for item in modules:
                 f.write(item + "\n")
         f.write("\n")
 
         f.write("# Launch a job\n")
-        if type(job_command) == str:
+        if isinstance(job_command, str):
             f.write(job_command + "\n")
-        elif type(job_command) == list:
+        elif isinstance(job_command, list):
             for item in job_command:
                 f.write(item + "\n")
 


### PR DESCRIPTION
Fixes #427 by removing nearly all `exit()` calls. Instead, I use relevant + more "graceful" crashes, e.g., `NotImplementedError`, `ValueError`, `TypeError`, or in some cases, `UserWarning`. Some of the `exit()` commands are left in because it wasn't clear how to reformulate them (e.g., in `docs/conf.py`.

Note that the original PR (#453) is also included here because I accidentally branched my branch.