### PR TITLE
Fix edges of SD maps with better area calculation

### DIFF
--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -24,7 +24,8 @@ from beast.tools.density_map import DensityMap
 from beast.tools import cut_catalogs
 import itertools as it
 import os
-from shapely.geometry import box, Polygon
+from shapely import geometry
+
 
 def main():  # pragma: no cover
     parser = argparse.ArgumentParser()
@@ -501,7 +502,9 @@ def make_source_dens_map(
     pix_x, pix_y = get_pix_coords(cat, w)
 
     # make a convex hull of the catalog
-    catalog_boundary = cut_catalogs.convexhull_path(pix_x, pix_y)
+    catalog_boundary = geometry.Polygon(
+        cut_catalogs.convexhull_path(pix_x, pix_y).vertices
+    )
 
     n_x = len(ra_grid) - 1
     n_y = len(dec_grid) - 1
@@ -530,9 +533,9 @@ def make_source_dens_map(
         n_indxs = len(indxs_for_SD)
         if n_indxs > 0:
             # make a box for the current SD map pixel
-            pix_box = box(i, j, i+1, j+1)
+            pix_box = geometry.box(i, j, i+1, j+1)
             # find fractional overlap area
-            frac_area = Polygon(catalog_boundary.vertices).intersection(pix_box).area
+            frac_area = catalog_boundary.intersection(pix_box).area
             # stars per unit area
             npts_map[i, j] = n_indxs / (pix_area*frac_area)
 


### PR DESCRIPTION
We've had problems with the edges of source density (SD) maps having artificially low values.  This is because only part of the catalog overlaps the map pixel, but the full pixel area is used when evaluating sources/arcsec^2.

I changed the code to create a convex hull around the catalog, and then find the intersection between the convex hull and the pixel.  This provides an area scaling factor, so the pixel area (usually 25 arcsec^2) can be adjusted as needed for any partial overlap.

Here's an example for a METAL field:

| Before | After | 
| --- | --- |
| <img width="435" alt="sd_before" src="https://user-images.githubusercontent.com/32465297/71927061-aa2f3d00-3162-11ea-8053-12d9d52317bd.png"> | <img width="434" alt="sd_after" src="https://user-images.githubusercontent.com/32465297/71927067-ac919700-3162-11ea-81e5-9ad42f41143f.png"> |
