### PR TITLE
failing Spectral Grid tests after astropy 4.0 upgrade

### DIFF
--- a/beast/tests/helpers.py
+++ b/beast/tests/helpers.py
@@ -115,7 +115,7 @@ def compare_hdf5(fname_cache, fname_new, ctype=None):
                     cvalue.value,
                     cvalue_new.value,
                     err_msg="testing %s" % (osname),
-                    rtol=1e-6,
+                    rtol=2e-6,
                 )
             else:
                 for ckey in cvalue.dtype.fields.keys():


### PR DESCRIPTION
Fixes #413 (?)

So far, it appears that the `astropy.units` and `astropy.constants` upgrade to version 4.0 did *not* break testing (on my local machine, at least). Moreover, updates to the definitions of those constants and units should not impact the tests for `make_spectral_grid()` in `beast.physicsmodel.model_grid`, so this probably isn't the source the error.

Following the recommendation from @karllark I'm just increasing the tolerance in `compare_hdf5` from `1e-6` to `2e-6` which should get TravisCI to stop complaining. :grinning: 