### PR TITLE
Update the percentile function to speed up

### DIFF
--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -158,7 +158,6 @@ def expectation(q, weights=None):
     (1) This function is about 30% fater than usning numpy.average
         to compute expectation values -- test by Yumi Choi on 1/17/2020
     """
-    n = len(q)
 
     if weights is None:
         return np.mean(q)

--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -44,15 +44,6 @@ Note that the 50th weighted percentile is known as the weighted median.
 """
 import numpy as np
 
-try:
-    from .c_common import weighted_percentile as c_wp
-    from .c_common import expectation as c_expect
-
-    _C_code = True
-except ImportError:
-    _C_code = False
-
-_C_code = False
 
 
 def percentile(data, percentiles, weights=None):
@@ -161,28 +152,20 @@ def expectation(q, weights=None):
     -------
     e: float
         expectation value
-    
+
     NOTE
     -------
-    (1) This function is about 30% fater than usning numpy.average 
-        to compute expectation values -- test by Yumi Choi on 1/17/2020 
+    (1) This function is about 30% fater than usning numpy.average
+        to compute expectation values -- test by Yumi Choi on 1/17/2020
     """
     n = len(q)
-    if _C_code:
-        # it is faster to use expectations instead of testing all weights are
-        # ones + calling np.mean
-        if weights is None:
-            _w = np.ones(n, dtype=float)
-        else:
-            _w = np.asarray(weights, dtype=float)
-        _q = np.asarray(q, dtype=float)
-        return c_expect(_q, _w)
-    else:
-        if weights is None:
-            return np.mean(q)
-        if np.equal(weights, 1.0).all():
-            return np.mean(q)
-        _w = np.asarray(weights, dtype=float)
-        _q = np.asarray(q, dtype=float)
-        e = (_q * _w).sum() / _w.sum()
-        return e
+
+    if weights is None:
+        return np.mean(q)
+    if np.equal(weights, 1.0).all():
+        return np.mean(q)
+    _w = np.asarray(weights, dtype=float)
+    _q = np.asarray(q, dtype=float)
+    e = (_q * _w).sum() / _w.sum()
+
+    return e

--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -120,9 +120,9 @@ def percentile(data, percentiles, weights=None):
     _wt = np.asarray(weights, dtype=float)
 
     
-    i = np.argsort(_data)
-    sd = _data[i]
-    sw = _wt[i]
+    isort = np.argsort(_data)
+    sd = _data[isort]
+    sw = _wt[isort]
     aw = np.cumsum(sw)
 
     if not aw[-1] > 0:

--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -110,7 +110,7 @@ def percentile(data, percentiles, weights=None):
 
     _wt = np.asarray(weights, dtype=float)
 
-    
+
     isort = np.argsort(_data)
     sd = _data[isort]
     sw = _wt[isort]

--- a/beast/fitting/fit_metrics/common.py
+++ b/beast/fitting/fit_metrics/common.py
@@ -124,7 +124,7 @@ def percentile(data, percentiles, weights=None):
 
     return o
 
-    
+
 
 def expectation(q, weights=None):
     """


### PR DESCRIPTION
I updated the percentile function in the common.py to speed up the calculation. It returned the same stats results as a run with the original percentile function, with a 14% increase in running time for the PHAT_small example case. I also compared the running time between the expectation value function in the common.py and numpyp.average, and found that our current function is slightly faster than using numpy.average . I left a comment about this in the code.   