### PR TITLE
newer numpy versions for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,11 +76,6 @@ matrix:
         - stage: Initial tests
           env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
-        # Try MacOS X
-        - os: osx
-          stage: Initial tests
-          env: SETUP_CMD='test -a "--mpl" --remote-data'
-
         # Do a coverage test.
         - os: linux
           stage: Initial tests
@@ -108,6 +103,10 @@ matrix:
           env: ASTROPY_VERSION=development NUMPY_VERSION=development
                SETUP_CMD='test -a "--mpl" --remote-data'
                EVENT_TYPE='cron'
+
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test -a "--mpl" --remote-data'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
 
         # Try MacOS X
         - os: osx
-          stage: Cron tests
+          stage: Initial tests
           env: SETUP_CMD='test -a "--mpl" --remote-data'
 
         # Do a coverage test.

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,13 +115,13 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
                SETUP_CMD='test -a "--mpl" --remote-data'
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
                SETUP_CMD='test -a "--mpl" --remote-data'
         - os: linux
-          env: NUMPY_VERSION=1.15
+          env: NUMPY_VERSION=1.17
                SETUP_CMD='test -a "--mpl" --remote-data'
 
         # Do a PEP8 test with flake8
@@ -137,7 +137,7 @@ matrix:
                EVENT_TYPE='pull_request push cron'
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
                SETUP_CMD='test -a "--mpl" --remote-data'
 
         # Do a PEP8 test with flake8


### PR DESCRIPTION
travis tests are failing and it might just be the numpy versions used - current stable version of 1.18