### PR TITLE
Remove logL=-9.999 points in the spec grid stage not to allow them in the final SED grid

### DIFF
--- a/beast/tools/run/create_physicsmodel.py
+++ b/beast/tools/run/create_physicsmodel.py
@@ -80,6 +80,9 @@ def create_physicsmodel(nsubs=1, nprocs=1, subset=[None, None]):
         z=datamodel.z,
     )
 
+    # remove the isochrone points with logL=-9.999
+    oiso=oiso[oiso['logL']> -9]
+
     if hasattr(datamodel, "add_spectral_properties_kwargs"):
         extra_kwargs = datamodel.add_spectral_properties_kwargs
     else:


### PR DESCRIPTION
The model points with logL = -9.999 (see issue #486) has been removed before generating the spec grid. 

Closes #486