### PR TITLE
Merging lnPs and file reading tools

### DIFF
--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -99,14 +99,14 @@ def read_noise_data(
     noise_data = {}
 
     # open files for reading
-    with h5py.File(noise_filename, 'r') as noise_hdf:
+    with h5py.File(filename, 'r') as noise_hdf:
 
         # get beast physicsmodel params
         for param in tqdm(param_list, desc='reading beast data'):
             if filter_col is None:
-                noise_data[cparam] = np.array(noise_hdf[cparam])
+                noise_data[param] = np.array(noise_hdf[param])
             else:
-                noise_data[cparam] = noise_hdf[cparam][:,filter_col]
+                noise_data[param] = noise_hdf[cparam][:,filter_col]
 
     return noise_data
 
@@ -190,9 +190,9 @@ def get_lnp_grid_vals(sed_data, lnp_data):
         arrays of the SED grid parameters for the points in the lnp lists
     """
 
-    if type(sed_data) == str:
+    if isinstance(sed_data, str):
         sed_data = read_sed_data(sed_data)
-    if type(lnp_data) == str:
+    if isinstance(lnp_data, str):
         lnp_data = read_lnp_data(lnp_data)
 
     # get the keys in beast_data
@@ -206,7 +206,6 @@ def get_lnp_grid_vals(sed_data, lnp_data):
 
     # loop over the stars and extract the requested BEAST data
     for k in tqdm(range(n_stars), desc='extracting params for each lnP'):
-    #for k in range(n_stars):
         lnp_inds = lnp_data['indxs'][:, k]
         good_inds = np.isfinite(lnp_inds)
         for param in param_list:

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -1,0 +1,142 @@
+"""
+Functions for interacting with the BEAST model
+"""
+
+# system imports
+from __future__ import (absolute_import, division, print_function)
+
+# other package imports
+import numpy as np
+import h5py
+from tqdm import tqdm
+
+
+def read_lnp_data(filename, nstars):
+    """
+    Read in the sparse lnp for all the stars in the hdf5 file
+
+    Parameters
+    ----------
+    filename: string
+       name of the file with the sparse lnp values
+
+    nstars: int
+       number of stars expected in the file
+
+    Returns
+    -------
+    lnp_data: dictonary
+       contains arrays of the lnp values and indexs to the BEAST model grid
+    """
+    lnp_hdf = h5py.File(filename, 'r')
+
+    if len(lnp_hdf.keys()) != nstars:
+        print('Error: number of stars not equal between nstars image and ' +
+              'lnp file')
+        lnp_hdf.close()
+        exit()
+    else:
+        # initialize arrays
+        # - find the length of the sparse likelihoods
+        lnp_sizes = [lnp_hdf[sname]['lnp'].value.shape[0] for sname in lnp_hdf.keys()]
+        # - set arrays to the maximum size
+        lnp_vals = np.zeros((np.max(lnp_sizes), nstars), dtype=float) - np.inf
+        lnp_indxs = np.zeros((np.max(lnp_sizes), nstars), dtype=int)
+
+        # loop over all the stars (groups)
+        for k, sname in enumerate(lnp_hdf.keys()):
+            lnp_vals[:lnp_sizes[k], k] = lnp_hdf[sname]['lnp'].value
+            lnp_indxs[:lnp_sizes[k], k] = np.int64(np.array(lnp_hdf[sname]['idx'].value))
+        lnp_hdf.close()
+
+        # shift the log(likelihood) values to have a max of 0.0
+        #  ok if the same shift is applied to all stars in a pixel
+        #  avoids numerical issues later when we go to intergrate probs
+        lnp_vals -= np.max(lnp_vals)
+
+        return {'vals': lnp_vals, 'indxs': lnp_indxs}
+
+
+def read_beast_data(filename,
+                    noise_filename,
+                    beast_params=['Av', 'Rv', 'f_A',
+                                  'M_ini', 'logA', 'Z', 'distance',
+                                  'completeness'],
+                    verbose=True):
+    """
+    Read in the beast data needed by all the pixels
+
+    Parameters
+    ----------
+    filename: string
+       name of the file with the BEAST physicsmodel grid
+
+    noise_filename: string
+       name of the file with the BEAST observationmodel grid
+
+    beast_params: strings
+       contains the set of BEAST parameters to extract
+       default = [completeness, Av, Rv, f_A, M_ini, logA, Z, distance]
+
+    Returns
+    -------
+    beast_data: dictonary
+       contains arrays of the beast parameters, priors, and completeness
+    """
+    beast_data = {}
+
+    # open the full BEAST observationmodel file for reading
+    beast_noise_hdf = h5py.File(noise_filename, 'r')
+
+    # open the full BEAST physicsmodel file for reading
+    beast_seds_hdf = h5py.File(filename, 'r')
+
+    # get beast physicsmodel params
+    for cparam in tqdm(beast_params, desc='reading beast data'):
+        if cparam == 'completeness':
+            beast_data[cparam] = np.max(beast_noise_hdf[cparam], axis=1)
+        else:
+            beast_data[cparam] = beast_seds_hdf['grid'][cparam]
+
+    beast_noise_hdf.close()
+    beast_seds_hdf.close()
+
+    return beast_data
+
+
+def extract_beast_data(beast_data, lnp_data):
+    """
+    Read in the beast data for the locations where the lnp values
+    were saved
+
+    Parameters
+    ----------
+    beast_data: dictonary
+       contains arrays of the beast parameters and priors
+
+    lnp_data: dictonary
+       contains arrays of the lnp values and indexs to the BEAST model grid
+
+    Returns
+    -------
+    lnp_grid_vals: dictonary
+       contains arrays of the beast parameters and priors for the sparse
+       lnp saved model grid points
+    """
+    # get the keys in beast_data
+    beast_params = beast_data.keys()
+
+    # setup the output
+    lnp_grid_vals = {}
+    n_lnps, n_stars = lnp_data['indxs'].shape
+    for cparam in beast_params:
+        lnp_grid_vals[cparam] = np.empty((n_lnps, n_stars), dtype=float)
+
+    # loop over the stars and extract the requested BEAST data
+    # for k in tqdm(range(n_stars), desc='extracting beast data'):
+    for k in range(n_stars):
+        for cparam in beast_params:
+            lnp_grid_vals[cparam][:, k] = \
+                            beast_data[cparam][lnp_data['indxs'][:, k]]
+
+    return lnp_grid_vals

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -106,7 +106,7 @@ def read_noise_data(
             if filter_col is None:
                 noise_data[param] = np.array(noise_hdf[param])
             else:
-                noise_data[param] = noise_hdf[cparam][:,filter_col]
+                noise_data[param] = noise_hdf[param][:,filter_col]
 
     return noise_data
 

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -30,7 +30,7 @@ def read_lnp_data(filename, nstars=None, shift_lnp=True):
     Returns
     -------
     lnp_data: dictonary
-       contains arrays of the lnp values and indexs to the BEAST model grid
+       contains arrays of the lnp values and indices to the BEAST model grid
     """
 
 
@@ -157,39 +157,50 @@ def read_sed_data(
     return sed_data
 
 
-def extract_beast_data(beast_data, lnp_data):
+def get_lnp_grid_vals(sed_data, lnp_data):
     """
-    Read in the beast data for the locations where the lnp values
+    Acquire the SED parameter values for the locations where the lnp values
     were saved
 
     Parameters
     ----------
-    beast_data: dictonary
-       contains arrays of the beast parameters and priors
+    sed_data: dictonary or string
+       if dictionary: contains arrays of the beast parameters (output from
+       read_sed_data)
+       if string: name of the file with the BEAST physicsmodel grid, which will
+       be used in read_sed_data to get default parameters
 
-    lnp_data: dictonary
-       contains arrays of the lnp values and indexs to the BEAST model grid
+    lnp_data: dictonary or string
+       if dictionary: contains arrays of the lnp values and indices to the BEAST
+       model grid (output from read_lnp_data)
+       if string: name of the file with the sparse lnp values, which will be
+       used in read_lnp_data with default parameters
 
     Returns
     -------
     lnp_grid_vals: dictonary
-       contains arrays of the beast parameters and priors for the sparse
-       lnp saved model grid points
+        arrays of the SED grid parameters for the points in the lnp lists
     """
+
+    if type(sed_data) == str:
+        sed_data = read_sed_data(sed_data)
+    if type(lnp_data) == str:
+        lnp_data = read_lnp_data(lnp_data)
+
     # get the keys in beast_data
-    beast_params = beast_data.keys()
+    param_list = sed_data.keys()
 
     # setup the output
     lnp_grid_vals = {}
     n_lnps, n_stars = lnp_data['indxs'].shape
-    for cparam in beast_params:
-        lnp_grid_vals[cparam] = np.empty((n_lnps, n_stars), dtype=float)
+    for param in param_list:
+        lnp_grid_vals[param] = np.full((n_lnps, n_stars), np.nan, dtype=float)
 
     # loop over the stars and extract the requested BEAST data
     # for k in tqdm(range(n_stars), desc='extracting beast data'):
     for k in range(n_stars):
-        for cparam in beast_params:
-            lnp_grid_vals[cparam][:, k] = \
-                            beast_data[cparam][lnp_data['indxs'][:, k]]
+        for param in param_list:
+            lnp_grid_vals[param][:, k] = \
+                            sed_data[param][lnp_data['indxs'][:, k]]
 
     return lnp_grid_vals

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -113,7 +113,6 @@ def read_noise_data(
 def read_sed_data(
     filename,
     param_list=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
-    verbose=True
 ):
     """
     Read in the beast data needed by all the pixels

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -36,21 +36,29 @@ def read_lnp_data(filename, nstars=None, shift_lnp=True):
 
     with h5py.File(filename, 'r') as lnp_hdf:
 
+        # get keyword names for the stars (as opposed to filter info)
+        star_key_list = [sname for sname in lnp_hdf.keys() if 'star' in sname]
+        tot_stars = len(star_key_list)
+
         if nstars is not None:
-            if len(lnp_hdf.keys()) != nstars:
+            if tot_stars != nstars:
                 raise ValueError(
                     "Error: number of stars not equal between nstars image and lnp file"
                 )
 
         # initialize arrays
-        # - find the length of the sparse likelihoods
-        lnp_sizes = [lnp_hdf[sname]['lnp'].value.shape[0] for sname in lnp_hdf.keys()]
+        # - find the lengths of the sparse likelihoods
+        lnp_sizes = [
+            lnp_hdf[sname]['lnp'].value.shape[0]
+            for sname in star_key_list
+        ]
+        #print(lnp_sizes)
         # - set arrays to the maximum size
-        lnp_vals = np.zeros((np.max(lnp_sizes), nstars), dtype=float) - np.inf
-        lnp_indxs = np.zeros((np.max(lnp_sizes), nstars), dtype=int)
+        lnp_vals = np.zeros((np.max(lnp_sizes), tot_stars), dtype=float) - np.inf
+        lnp_indxs = np.zeros((np.max(lnp_sizes), tot_stars), dtype=int) + np.nan
 
         # loop over all the stars (groups)
-        for k, sname in enumerate(lnp_hdf.keys()):
+        for k, sname in enumerate(star_key_list):
             lnp_vals[:lnp_sizes[k], k] = lnp_hdf[sname]['lnp'].value
             lnp_indxs[:lnp_sizes[k], k] = np.int64(np.array(lnp_hdf[sname]['idx'].value))
 

--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -2,9 +2,6 @@
 Functions for interacting with the BEAST model
 """
 
-# system imports
-from __future__ import (absolute_import, division, print_function)
-
 # other package imports
 import numpy as np
 import h5py

--- a/beast/tools/run/merge_files.py
+++ b/beast/tools/run/merge_files.py
@@ -108,12 +108,13 @@ def merge_files(use_sd=True, nsubs=1):
                 merged_stats_files.append(merged_stats_fname)
 
                 # - lnP files
-                subgridding_tools.merge_lnp(
+                merged_lnp_fname = subgridding_tools.merge_lnp(
                     [lnp_files[j] for j in ind],
-                    rerun=False,
+                    re_run=False,
                     output_fname_base=out_filebase,
                     threshold=-10,
                 )
+                merged_lnp_files.append(merged_lnp_fname)
 
             # merge the merged stats files
             out_filebase = "{0}/{0}".format(datamodel.project)
@@ -135,7 +136,7 @@ def merge_files(use_sd=True, nsubs=1):
             # - lnP files
             subgridding_tools.merge_lnp(
                 lnp_files,
-                rerun=False,
+                re_run=False,
                 output_fname_base=out_filebase,
                 threshold=-10,
             )

--- a/beast/tools/run/merge_files.py
+++ b/beast/tools/run/merge_files.py
@@ -8,7 +8,6 @@ from beast.tools.run import create_filenames
 
 import datamodel
 import importlib
-importlib.reload(subgridding_tools)
 
 
 def merge_files(use_sd=True, nsubs=1):

--- a/beast/tools/run/merge_files.py
+++ b/beast/tools/run/merge_files.py
@@ -5,8 +5,10 @@ from beast.tools import verify_params, subgridding_tools, merge_beast_stats
 from beast.tools.run import create_filenames
 
 
+
 import datamodel
 import importlib
+importlib.reload(subgridding_tools)
 
 
 def merge_files(use_sd=True, nsubs=1):
@@ -47,7 +49,7 @@ def merge_files(use_sd=True, nsubs=1):
     # - output files
     stats_files = file_dict["stats_files"]
     pdf_files = file_dict["pdf_files"]
-    # lnp_files = file_dict['lnp_files']
+    lnp_files = file_dict["lnp_files"]
 
     # - other useful info
     sd_sub_info = file_dict["sd_sub_info"]
@@ -79,6 +81,7 @@ def merge_files(use_sd=True, nsubs=1):
             # lists to save the merged file names
             merged_pdf_files = []
             merged_stats_files = []
+            merged_lnp_files = []
 
             for sd_sub in unique_sd_sub:
 
@@ -90,6 +93,7 @@ def merge_files(use_sd=True, nsubs=1):
                     datamodel.project, sd_sub[0], sd_sub[1]
                 )
 
+                # - 1D PDFs and stats
                 (
                     merged_pdf1d_fname,
                     merged_stats_fname,
@@ -103,6 +107,14 @@ def merge_files(use_sd=True, nsubs=1):
                 merged_pdf_files.append(merged_pdf1d_fname)
                 merged_stats_files.append(merged_stats_fname)
 
+                # - lnP files
+                subgridding_tools.merge_lnp(
+                    [lnp_files[j] for j in ind],
+                    rerun=False,
+                    output_fname_base=out_filebase,
+                    threshold=-10,
+                )
+
             # merge the merged stats files
             out_filebase = "{0}/{0}".format(datamodel.project)
             reorder_tags = ["bin{0}_sub{1}".format(x[0], x[1]) for x in unique_sd_sub]
@@ -115,10 +127,18 @@ def merge_files(use_sd=True, nsubs=1):
 
             out_filebase = "{0}/{0}".format(datamodel.project)
 
+            # - 1D PDFs and stats
             subgridding_tools.merge_pdf1d_stats(
                 pdf_files, stats_files, output_fname_base=out_filebase
             )
 
+            # - lnP files
+            subgridding_tools.merge_lnp(
+                lnp_files,
+                rerun=False,
+                output_fname_base=out_filebase,
+                threshold=-10,
+            )
 
 if __name__ == "__main__":  # pragma: no cover
     # commandline parser

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -14,7 +14,7 @@ from beast.physicsmodel import grid
 from beast.external import eztables
 from beast.fitting.fit import save_pdf1d
 from beast.fitting.fit_metrics import percentile
-from beast.tools.read_beast_data import read_lnp_data
+from beast.tools import read_beast_data
 
 
 def uniform_slices(num_points, num_slices):
@@ -518,7 +518,7 @@ def merge_pdf1d_stats(
     return pdf1d_fname, stats_fname
 
 
-def merge_lnp_stats(
+def merge_lnp(
     subgrid_lnp_fnames,
     re_run=False,
     output_fname_base=None,
@@ -552,10 +552,17 @@ def merge_lnp_stats(
         file name of the resulting lnp fits file (newly created by this function)
     """
 
+    # create filename
     if output_fname_base is None:
         merged_lnp_fname = "combined_lnp.fits"
     else:
         merged_lnp_fname = output_fname_base + "_lnp.fits"
+
+    # check if we need to rerun
+    if os.path.isfile(merged_lnp_fname) and (re_run is False):
+        print(str(len(subgrid_lnp_fnames)) + " files already merged, skipping")
+        return merged_lnp_fname
+
 
     # dictionaries to compile all the info
     merged_lnp = defaultdict(list)
@@ -568,7 +575,7 @@ def merge_lnp_stats(
         subgrid_num = [i for i in fname.split('_') if 'gridsub' in i][0][7:]
 
         # read in the SED indices and lnP values
-        lnp_data = read_lnp_data(fname, shift_lnp=False)
+        lnp_data = read_beast_data.read_lnp_data(fname, shift_lnp=False)
         n_lnp, n_star = lnp_data['vals'].shape
 
         # save each star's values into the master dictionary

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -616,7 +616,7 @@ def merge_lnp(
 
 
     # write out the things in a new file
-    with tables.open_file(lnp_fname, "a") as out_table:
+    with tables.open_file(lnp_fname, "w") as out_table:
         for i in range(n_star):
             star_label = "star_"+str(i)
             star_group = out_table.create_group(star_label)

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -3,11 +3,11 @@ import os
 import re
 from multiprocessing import Pool
 from collections import defaultdict
+import tables
 
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
-import h5py
 
 from beast.observationmodel.noisemodel.generic_noisemodel import get_noisemodelcat
 from beast.physicsmodel import grid
@@ -597,7 +597,7 @@ def merge_lnp(
             star_label = "star_"+str(i)
             # good indices
             keep_ind = np.where(
-                np.array(merged_lnp[star_label][ind]) >
+                np.array(merged_lnp[star_label]) >
                 (max(merged_lnp[star_label]) - threshold)
             )[0]
             good_list_len[i] = len(keep_ind)
@@ -632,3 +632,6 @@ def merge_lnp(
                 'subgrid',
                 data=np.array(merged_subgrid[star_label] + n_list_pad*[np.nan])
             )
+
+
+    return merged_lnp_fname

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -616,7 +616,7 @@ def merge_lnp(
 
 
     # write out the things in a new file
-    with tables.open_file(lnp_fname, "w") as out_table:
+    with tables.open_file(merged_lnp_fname, "w") as out_table:
         for i in range(n_star):
             star_label = "star_"+str(i)
             star_group = out_table.create_group(star_label)

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -60,11 +60,6 @@ if __name__ == "__main__":
         sed_trimname = filebase + "_seds_trim.grid.hd5"
         noisemodel_trimname = filebase + "_noisemodel_trim.grid.hd5"
 
-        # if these already exist, then continue to the next set of files to trim
-        if os.path.isfile(sed_trimname) and os.path.isfile(noisemodel_trimname):
-            print("trimming already complete for "+sed_trimname)
-            continue
-
         print("working on " + sed_trimname)
 
         start_time = time.clock()

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -60,6 +60,11 @@ if __name__ == "__main__":
         sed_trimname = filebase + "_seds_trim.grid.hd5"
         noisemodel_trimname = filebase + "_noisemodel_trim.grid.hd5"
 
+        # if these already exist, then continue to the next set of files to trim
+        if os.path.isfile(sed_trimname) and os.path.isfile(noisemodel_trimname):
+            print("trimming already complete for "+sed_trimname)
+            continue
+
         print("working on " + sed_trimname)
 
         start_time = time.clock()

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -11,6 +11,10 @@ Below are details regarding the output files produced by the BEAST:
 * `*_pdf2d.fits`: Marginalized 2D PDFs for pairs of parameters
 * `*_lnp.hd5`: Sparsely sampled log likelihoods
 
+Several of the BEAST output files are saved in the hdf5 format, which can be
+more challenging to access than fits files.  There are functions in
+`tools/read_beast_data.py` to facilitate reading those files.
+
 
 Statistics file
 ===============

--- a/docs/subgrid_parallelism.rst
+++ b/docs/subgrid_parallelism.rst
@@ -13,25 +13,24 @@ sequentially, to use less memory. Of course, a combination of the two is also
 possible, splitting a grid into many subgrids, and running a couple of subgrid
 calculations at the same time.
 
-At the end of the calculation, we will possess partial PDFs and statistics of
-each subgrid, which can be merged into a single 1dpdf file and a single stats
-file. By taking into account the weights of each subgrid correctly, the
-resulting file should be equivalent to the result of a BEAST run on the full
-grid.
+At the end of the calculation, we will possess partial PDFs, statistics, and log
+likelihoods of each subgrid, which can be merged into a single 1D PDF file, a
+single stats file, and a single likelihood file. By taking into account the
+weights of each subgrid correctly, the resulting files will be equivalent to
+the result of a BEAST run on the full grid.
 
 Workflow
 ========
 
-To make use of this functionality, no extra data or changes to the datamodel
-file are needed, but you will need a custom run script that makes use of a set
-of newly implemented functions, and new options for existing functions. We will
-now give a summary of what such a run script has to pay attention to, for each
-of the steps in a BEAST run. (An example script might be provided later).
+Functions that implement subgrids can be found in ``beast.tools.subgridding_tools``.
+To make use of this functionality, simply set ``n_subgrid`` in ``datamodel`` to
+the desired number of subgrids.  An example workflow script that utilizes the
+subgridding tools can be found in
+`BEAST examples <https://github.com/BEAST-Fitting/beast-examples/tree/master/production_runs_2019>`_.
 
-Most the new functions can be found in ``beast.tools.subgridding_tools``.
+We will now give a summary of the steps in a subgrid run and how they differ
+from a non-subgridded run.
 
-Please refer to the regular example code for the single grid implementation of
-these steps (``beast/examples/phat_small``).
 
 Physics model
 -------------
@@ -83,7 +82,7 @@ Compatibility
 
 To make sure that the results of the fitting routine for the individual grids
 are compatible, there are several subtleties which come into play here. Firstly,
-it needs to be made sure that the 1dpdfs are compatible: their number of bins
+it needs to be made sure that the 1D PDFs are compatible: their number of bins
 and the values for the bin centers need to be exactly the same. To ensure this,
 we need to fix three values for each quantity:
 
@@ -100,11 +99,11 @@ a certain format. ``subgridding_tools`` contains a function called
 ``reduce_grid_info`` which will generate this dictionary for you. Just provide
 the filenames to all the (trimmed) subgrids and their (trimmed) noisemodels.
 
-This dictionary has an entry like this for each quantity (``Rv`` in this example):
+This dictionary has an entry like this for each quantity (``Av`` in this example):
 
 .. code:: python
 
-   grid_info_dict['Rv'] = {'min': 0, 'max': 10, 'num_unique': 20}
+   grid_info_dict['Av'] = {'min': 0, 'max': 10, 'num_unique': 20}
 
 Fit
 ~~~
@@ -119,8 +118,8 @@ Merge
 ~~~~~
 
 When all the subgrid fits have been successfully completed, the merge step can be
-started. To do this, just gather all the filenames for the pdf1d and stats
-files, and pass them to ``merge_pdf1d_stats``.
+started. To do this, pass the 1D PDF and stats file names to
+``merge_pdf1d_stats`` and the log likelihood file names to ``merge_lnp``.
 
 .. note::
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -348,9 +348,10 @@ Post-processing
 Create the merged stats file
 ============================
 
-The stats (catalog of fit parameters) files can then be merged into a single
-file for the field.  This only merges the stats output files, but not the
-pdf1d or lnp files (see the next section).
+The stats files (catalog of fit parameters) can then be merged into a single
+file for the field.  The 1D PDF and lnP files are merged across subgrids, but
+not yet across source density or background bins.  Merging 2D PDFs has not yet
+been implemented.
 
   .. code-block:: console
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -105,6 +105,10 @@ To create a physics model grid with 5 subgrids:
 
      $ python -m beast.tools.run.create_physicsmodel --nsubs=5
 
+If you would like to examine some of all of the grid values in the physics model,
+you can use the `read_sed_data` function in `tools/read_beast_data.py`.  This
+function can also be set to just extract the list of parameter names.
+
 
 *********************
 Artificial Star Tests
@@ -176,11 +180,11 @@ that don't have full imaging coverage, and to create ds9 region files:
 
   .. code-block:: console
 
-  $ python -m beast.tools.cut_catalogs \
-        phot_catalog_with_sourceden.fits phot_catalog_cut.fits \
-        --input_ast_file ast_catalog.fits \
-        --output_ast_file ast_catalog_cut.fits \
-        --partial_overlap --region_file --flagged --flag_filter F475W
+    $ python -m beast.tools.cut_catalogs \
+          phot_catalog_with_sourceden.fits phot_catalog_cut.fits \
+          --input_ast_file ast_catalog.fits \
+          --output_ast_file ast_catalog_cut.fits \
+          --partial_overlap --region_file --flagged --flag_filter F475W
 
 
 The observed catalog should be split into separate files for each source
@@ -242,6 +246,9 @@ with or without source density splitting.  Here are some examples:
      $ python -m beast.tools.run.create_obsmodel --use_sd --nsubs 5
      $ # no source density splitting or subgrids
      $ python -m beast.tools.run.create_obsmodel --nsubs 1
+
+If you would like to examine some of all of the values in the observation model,
+you can use the `read_noise_data` function in `tools/read_beast_data.py`.
 
 
 ******************
@@ -328,6 +335,10 @@ The fitting yields several output files (which are described in detail
   be chosen.
 * `*_lnp.hd5`: Sparsely sampled log likelihoods
 
+The contents of the `lnp` file can be easily accessed with the `read_lnp_data`
+function in `tools/read_beast_data.py`, which converts the hdf5 file structure
+into a dictionary.  If you need the SED grid values associated with the saved
+lnP points, use the `get_lnp_grid_vals` function in the same file.
 
 
 ***************


### PR DESCRIPTION
This is basically a duplicate of #468, but with just the tools in that bulleted list, and not the star type probability code.  I've copied over that list here:

* `tools/subgridding_tools.py`: Added a `merge_lnp` function to combine lnPs across subgrids.  There's an optional `threshold` argument (like the one in `fit.py`) to eliminate lnPs much smaller than the maximum, which can help reduce file size.
* `tools/run/merge_files.py`: includes `merge_lnp` in the merging for subgrids
* `tools/read_beast_data.py`: Migrated over from `read_beast.py` in the MegaBEAST (BEAST-Fitting/megabeast#40).  It has functions to extract data from the files for the noise model, SED grid, and lnPs, and return them as dictionaries.  For the SED grid, if the parameter list is `None`, it will print out all of the parameters in the file (relevant to #433).  The code also has a function to get the parameter values associated with the lnPs.
* `tools/trim_many_via_obsdata.py`: If a trimmed file already exists, it will now skip to the next one in the input file.  (This isn't immediately related, but it came up while I was testing a start-to-finish run with the lnP merging.)

