### PR TITLE
Make 2D PDFs

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -314,6 +314,7 @@ def Q_all_memory(
     stats_outname=None,
     pdf1d_outname=None,
     pdf2d_outname=None,
+    pdf2d_param_list=None,
     grid_info_dict=None,
     lnp_outname=None,
     lnp_npts=None,
@@ -373,8 +374,10 @@ def Q_all_memory(
         set to output the 1D PDFs into a FITS file with extensions
 
     pdf2d_outname : string
-        set to output the 2D PDFs (only for the main 7 fit parameters) into a
-        FITS file with extensions
+        set to output the 2D PDFs into a FITS file with extensions
+
+    pdf2d_param_list : list of strings or None
+        set to the parameters for which to make the 2D PDFs
 
     grid_info_dict: dict: {'qname': {'min': float,
                                      'max': float,
@@ -519,7 +522,7 @@ def Q_all_memory(
         # setup the 2D PDFs
         _pdf2d_params = [
             qname for qname in qnames
-            if qname in ['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance']
+            if qname in pdf2d_param_list and len(np.unique(g0[qname])) > 1
         ]
         _n_params = len(_pdf2d_params)
         pdf2d_qname_pairs = [
@@ -907,6 +910,7 @@ def summary_table_memory(
     stats_outname=None,
     pdf1d_outname=None,
     pdf2d_outname=None,
+    pdf2d_param_list=None,
     grid_info_dict=None,
     lnp_outname=None,
     use_full_cov_matrix=True,
@@ -951,6 +955,12 @@ def summary_table_memory(
                    extensions
 
     pdf1d_outname: set to output the 1D PDFs into a FITS file with extensions
+
+    pdf2d_outname : string
+        set to output the 2D PDFs into a FITS file with extensions
+
+    pdf2d_param_list : list of strings or None
+        set to the parameters for which to make the 2D PDFs
 
     grid_info_dict: dict: {'qname': {'min': float,
                                      'max': float,
@@ -1002,6 +1012,10 @@ def summary_table_memory(
         if not (key in list(g0.keys())):
             raise KeyError('Key "{0}" not recognized'.format(key))
 
+    # make sure there are 2D PDF params if needed
+    if (pdf2d_outname is not None) and (pdf2d_param_list is None):
+        raise KeyError('pdf2d_param_list cannot be None if saving 2D PDFs')
+
     # generate an IAU complient name for each source and add other inform
     res = IAU_names_and_extra_info(obs, surveyname=surveyname, extraInfo=False)
 
@@ -1019,6 +1033,7 @@ def summary_table_memory(
         stats_outname=stats_outname,
         pdf1d_outname=pdf1d_outname,
         pdf2d_outname=pdf2d_outname,
+        pdf2d_param_list=pdf2d_param_list,
         grid_info_dict=grid_info_dict,
         lnp_outname=lnp_outname,
         use_full_cov_matrix=use_full_cov_matrix,

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -374,6 +374,19 @@ def Q_all_memory(
     fast_pdf1d_objs = []
     save_pdf1d_vals = []
 
+    # setup the 2D PDFs
+    _pdf2d_params = [
+        qname for qname in qnames
+        if qname in ['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance']
+    ]
+    _n_params = len(pdf2d_params)
+    fast_pdf2d_objs = {
+        _pdf2d_params[i]+'+'+_pdf2d_params[j]:0
+        for i in range(_n_params)
+        for j in range(i+1,_n_params)
+    }
+    save_pdf2d_vals = dict(fast_pdf2d_objs)
+
     for qname in qnames:
         # q = g0[qname][g0_indxs]
         if "_bias" in qname:
@@ -383,7 +396,7 @@ def Q_all_memory(
             q = g0[qname]
 
         if grid_info_dict is not None and qname in grid_info_dict:
-            # When processing a subgrid, we actuall need the number of
+            # When processing a subgrid, we actually need the number of
             # unique values across all the subgrids to make the 1dpdfs
             # compatible
             n_uniq = grid_info_dict[qname]["num_unique"]
@@ -571,6 +584,8 @@ def Q_all_memory(
         lnp_vals[e] = lnps.max()
         lnp_indx[e] = best_full_indx
 
+        # calculate quantities for individual parameters:
+        # best value, expectation value, 1D PDF, percentiles
         for k, qname in enumerate(qnames):
             if "_bias" in qname:
                 fname = (qname.replace("_wd_bias", "")).replace("symlog", "")

--- a/beast/fitting/pdf2d.py
+++ b/beast/fitting/pdf2d.py
@@ -115,14 +115,14 @@ class pdf2d:
         self.pdf_bin_indxs = pdf_bin_indxs
 
 
-        def gen2d(self, gindxs, weights):
+    def gen2d(self, gindxs, weights):
 
-            _tgrid = np.zeros(self.n_gridvals)
-            _tgrid[gindxs] = weights
-            _vals_2d = np.zeros((self.nbins_p1, self.nbins_p2))
-            for i in range(self.nbins_p1):
-                for j in range(self.nbins_p2):
-                    if len(self.pdf_bin_indxs[i][j]) > 0:
-                        _vals_2d[i,j] = np.sum(_tgrid[self.pdf_bin_indxs[i][j]])
+        _tgrid = np.zeros(self.n_gridvals)
+        _tgrid[gindxs] = weights
+        _vals_2d = np.zeros((self.nbins_p1, self.nbins_p2))
+        for i in range(self.nbins_p1):
+            for j in range(self.nbins_p2):
+                if len(self.pdf_bin_indxs[i][j]) > 0:
+                    _vals_2d[i,j] = np.sum(_tgrid[self.pdf_bin_indxs[i][j]])
 
-            return _vals_2d
+        return _vals_2d

--- a/beast/fitting/pdf2d.py
+++ b/beast/fitting/pdf2d.py
@@ -1,0 +1,128 @@
+# class to generate 1D PDFs for many objects all with
+#  spare or full nD likelihoods on the same grid of models
+import math
+import numpy as np
+
+
+class pdf2d:
+    def __init__(
+        self,
+        gridvals_p1,
+        gridvals_p2,
+        nbins_p1,
+        nbins_p2,
+        logspacing_p1=False,
+        logspacing_p2=False,
+        minval_p1=None,
+        maxval_p1=None,
+        minval_p2=None,
+        maxval_p2=None,
+    ):
+        """
+        Create an object which can be used to efficiently generate a 1D pdf for an observed object
+
+        Parameters
+        ----------
+
+        gridvals_p1, gridvals_p2: array-like
+            values of the quantity for all the grid points
+
+        nbins_p1, nbins_p2: int
+            number of bins to use for each dimension of the 2D PDF
+
+        logspacing_p1, logspacing_p2: bool
+            whether to use logarithmic spacing for the bins of each dimension
+
+        minval_p1, maxval_p1, minval_p2, maxval_p2: float (optional)
+            override the range for the bins. this can be useful to make
+            sure that the pdfs for different runs have the same bins
+        """
+
+        # copy values over
+        self.nbins_p1 = nbins_p1
+        self.nbins_p2 = nbins_p2
+        self.n_gridvals = len(gridvals_p1) # same as len(gridvals_p2)
+        self.logspacing_p1 = logspacing_p1
+        self.logspacing_p2 = logspacing_p2
+
+        # grab copies of gridvals that can be edited without messing with originals
+        tgridvals_p1 = np.array(gridvals_p1)
+        tgridvals_p2 = np.array(gridvals_p2)
+
+        # set bin ranges
+        self.min_val_p1 = tgridvals_p1.min() if minval_p1 is None else minval_p1
+        self.max_val_p1 = tgridvals_p1.max() if maxval_p1 is None else maxval_p1
+        self.min_val_p2 = tgridvals_p2.min() if minval_p2 is None else minval_p2
+        self.max_val_p2 = tgridvals_p2.max() if maxval_p2 is None else maxval_p2
+
+        # if log spacing requested, make the transformation
+        if logspacing_p1:
+            self.min_val_p1 = math.log10(self.min_val_p1)
+            self.max_val_p1 = math.log10(self.max_val_p1)
+            tgridvals_p1 = np.log10(tgridvals_p1)
+        if logspacing_p2:
+            self.min_val_p2 = math.log10(self.min_val_p2)
+            self.max_val_p2 = math.log10(self.max_val_p2)
+            tgridvals_p2 = np.log10(tgridvals_p2)
+
+        # set bin widths
+        if self.nbins_p1 > 1:
+            self.bin_delta_p1 = (self.max_val_p1 - self.min_val_p1) / (self.nbins_p1 - 1)
+        else:
+            self.bin_delta_p1 = 1
+        if self.nbins_p2 > 1:
+            self.bin_delta_p2 = (self.max_val_p2 - self.min_val_p2) / (self.nbins_p2 - 1)
+        else:
+            self.bin_delta_p2 = 1
+
+        # set values for the bin middles/edges
+        self.bin_vals_p1 = self.min_val_p1 + np.arange(self.nbins_p1) * self.bin_delta_p1
+        self.bin_edges_p1 = (
+            self.min_val_p1 + (np.arange(self.nbins_p1 + 1) - 0.5) * self.bin_delta_p1
+        )
+        self.bin_vals_p2 = self.min_val_p2 + np.arange(self.nbins_p2) * self.bin_delta_p2
+        self.bin_edges_p2 = (
+            self.min_val_p2 + (np.arange(self.nbins_p2 + 1) - 0.5) * self.bin_delta_p2
+        )
+
+        # get PDF bin associated with each grid val
+        pdf_bin_num_p1 = np.digitize(tgridvals_p1, self.bin_edges_p1)
+        pdf_bin_num_p2 = np.digitize(tgridvals_p2, self.bin_edges_p2)
+
+        # array to hold indices for each bin
+        pdf_bin_indxs = [
+            [0 for j in range(self.nbins_p2)] for i in range(self.nbins_p1)
+        ]
+
+        for i in range(self.nbins_p1):
+            for j in range(self.nbins_p2):
+                # find the indicies for the current bin
+                cur_bin_indxs, = np.where(
+                    (pdf_bin_num_p1 == (i + 1)) & (pdf_bin_num_p2 == (j + 1))
+                )
+                # save them
+                pdf_bin_indxs[i][j] = cur_bin_indxs
+
+        # transform the bin edges back to linear spacing if log spacing
+        #  was asked for
+        if logspacing_p1:
+            self.bin_vals_p1 = np.power(10.0, self.bin_vals_p1)
+            self.bin_edges_p1 = np.power(10.0, self.bin_edges_p1)
+        if logspacing_p2:
+            self.bin_vals_p2 = np.power(10.0, self.bin_vals_p2)
+            self.bin_edges_p2 = np.power(10.0, self.bin_edges_p2)
+
+        self.pdf_bin_indxs = pdf_bin_indxs
+
+
+        def gen2d(self, gindxs, weights):
+
+            _tgrid = np.zeros(self.n_gridvals)
+            _tgrid[gindxs] = weights
+            _vals_2d = np.zeros((self.nbins_p1, self.nbins_p2))
+            for i in range(self.nbins_p1):
+                for j in range(self.nbins_p2):
+                    if len(self.pdf_bin_indxs[i][j]) > 0:
+                        _vals_2d[i,j] = np.sum(_tgrid[self.pdf_bin_indxs[i][j]])
+
+            return _vals_2d

--- a/beast/plotting/plot_indiv_pdfs.py
+++ b/beast/plotting/plot_indiv_pdfs.py
@@ -38,11 +38,16 @@ def plot_pdfs(
         ]
 
         # grab the parameter names
-        param_list = [i for x in ext_list for i in x.split('+')]
+        param_list_temp = [i for x in ext_list for i in x.split('+')]
 
         # put them in the order we want
         _plot_order = ['M_ini','logA','distance','Z','Av','Rv','f_A']
-        param_list = [p for p in _plot_order if p in param_list]
+        param_list = [p for p in _plot_order if p in param_list_temp]
+        # if there are parameters not in the predetermined plot order, append them
+        for p in param_list_temp:
+            if p not in param_list:
+                param_list.append(p)
+        # total number of parameters
         n_params = len(param_list)
 
 
@@ -113,6 +118,8 @@ def plot_pdfs(
                         )
                     except IndexError:
                         #print("  can't make contours for this")
+                        pass
+                    except ValueError:
                         pass
                     except:
                         raise

--- a/beast/plotting/plot_indiv_pdfs.py
+++ b/beast/plotting/plot_indiv_pdfs.py
@@ -1,0 +1,216 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+import matplotlib.colors as colors
+from astropy.io import fits
+import copy
+
+
+def plot_pdfs(
+    pdf1d_file, pdf2d_file, starnum
+):
+    """
+    Make a triangle/corner plot with the 1D and 2D PDFs of a star
+
+    Parameters
+    ----------
+    pdf1d_file : str
+        path+file for the BEAST 1D PDFs
+
+    pdf2d_file : list of strings
+        path+file for the BEAST 2D PDFs
+
+    starnum : int
+        the index of the star to plot
+
+    """
+
+    with fits.open(pdf2d_file) as hdu_2d, fits.open(pdf1d_file) as hdu_1d:
+
+        # start with the 2D PDF file to figure out which parameters to plot
+
+        # list of extension names
+        # - skip the extension named "PRIMARY"
+        # - skip any extension with a dimension of 1 (means that param wasn't fit)
+        ext_list = [
+            hdu_2d[i].name for i in range(len(hdu_2d))
+            if ('PRIMARY' not in hdu_2d[i].name)
+            and (1 not in hdu_2d[i].data.shape)
+        ]
+
+        # grab the parameter names
+        param_list = [i for x in ext_list for i in x.split('+')]
+
+        # put them in the order we want
+        _plot_order = ['M_ini','logA','distance','Z','Av','Rv','f_A']
+        param_list = [p for p in _plot_order if p in param_list]
+        n_params = len(param_list)
+
+
+        # figure
+        fig = plt.figure(figsize=(4 * n_params, 4 * n_params))
+
+        # label font sizes
+        label_font = 25
+        tick_font = 22
+
+        # iterate through the panels
+        for i,pi in enumerate(param_list):
+            for j,pj in enumerate(param_list[i:], i):
+
+                #print('plotting {0} and {1}'.format(pi, pj))
+
+                # not along diagonal
+                if i != j:
+
+                    # set up subplot
+                    plt.subplot(n_params, n_params, i + j*(n_params) + 1)
+                    ax = plt.gca()
+
+                    # find the 2D PDF and make sure it's properly rotated
+                    try:
+                        image = hdu_2d[pi+'+'+pj].data[starnum,:,:].T
+                    except:
+                        image = hdu_2d[pj+'+'+pi].data[starnum,:,:]
+
+                    # create axis/labels
+                    x_bins, x_label = setup_axis(pi, hdu_1d)
+                    y_bins, y_label = setup_axis(pj, hdu_1d)
+
+                    # plot 2D PDF image
+                    im = plt.imshow(
+                        np.log(image / np.max(image)),
+                        extent=(
+                            np.min(x_bins), np.max(x_bins),
+                            np.min(y_bins), np.max(y_bins)
+                        ),
+                        cmap='magma',
+                        vmin=-10,
+                        vmax=0,
+                        aspect='auto',
+                        origin='lower',
+                    )
+
+                    # attempt to plot 1/2/3 sigma contours
+                    try:
+                        im_sort = np.sort(image, axis=None)[::-1]
+                        cumsum = np.cumsum(im_sort)
+                        cumsum /= np.max(cumsum)
+                        clevels = [
+                            np.log(im_sort[np.where(cumsum < p)[0][-1]])
+                            for p in [0.68, 0.95, 0.997]
+                        ]
+                        plt.contour(
+                            x_bins,
+                            y_bins,
+                            image,
+                            levels=clevels,
+                            colors='k',
+                            linestyles='-',
+                        )
+                    except:
+                        #print("  can't make contours for this")
+                        pass
+
+
+
+                    ax.tick_params(axis='both', which='both', direction='in', labelsize=tick_font,
+                                       bottom=True, top=True, left=True, right=True)
+
+                    # axis labels and ticks
+                    if i == 0:
+                        ax.set_ylabel(y_label, fontsize=label_font)
+                        #ax.get_yaxis().set_label_coords(-0.35,0.5)
+                    else:
+                        ax.set_yticklabels([])
+                    if j == n_params-1:
+                        ax.set_xlabel(x_label, fontsize=label_font)
+                        plt.xticks(rotation=-45)
+                    else:
+                        ax.set_xticklabels([])
+
+
+                # along diagonal
+                if i == j:
+
+                    # set up subplot
+                    plt.subplot(n_params, n_params, i + j*(n_params) + 1)
+                    ax = plt.gca()
+
+                    # create axis/labels
+                    x_bins, x_label = setup_axis(pi, hdu_1d)
+
+                    # make histogram
+                    _pdf = hdu_1d[pi].data[starnum,:]
+                    plt.plot(
+                        x_bins,
+                        _pdf/np.max(_pdf),
+                        marker="o",
+                        mew=0,
+                        color="black",
+                        markersize=2,
+                        linestyle="-",
+                    )
+
+                    # axis ranges
+                    plt.xlim(np.min(x_bins), np.max(x_bins))
+                    plt.ylim(0, 1.05)
+
+                    ax.tick_params(axis='y',which='both',length=0, labelsize=tick_font)
+                    ax.tick_params(axis='x',which='both',direction='in', labelsize=tick_font)
+
+                    # axis labels and ticks
+                    ax.set_yticklabels([])
+                    if i < n_params-1:
+                        ax.set_xticklabels([])
+                    if i == n_params-1:
+                        ax.set_xlabel(x_label, fontsize=label_font)
+                        plt.xticks(rotation=-45)
+
+    #plt.subplots_adjust(wspace=0.05, hspace=0.05)
+    plt.tight_layout()
+
+    # add a colorbar
+    gs = GridSpec(nrows=20, ncols=n_params)
+    cax = fig.add_subplot(gs[0, 2:])
+    cbar = plt.colorbar(im, cax=cax, orientation='horizontal')
+    cbar.set_label('Log Likelihood', fontsize=label_font)
+    cbar.ax.tick_params(labelsize=tick_font)
+    gs.tight_layout(fig)
+
+    fig.savefig(pdf1d_file.replace('pdf1d.fits','pdfs_starnum_{0}.pdf'.format(starnum)))
+    plt.close(fig)
+
+
+def setup_axis(param, pdf1d_hdu):
+    """
+    Set up the bins and labels for a parameter
+
+    Parameters
+    ----------
+    param : string
+        name of the parameter we're binning/labeling
+
+    pdf1d_hdu : HDU object
+        the HDU for param (to get the bins)
+
+    Returns
+    -------
+    bins : numpy array
+        bin edges
+
+    label : string
+        the axis label to use
+
+    """
+
+    # mass and metallicity get log spaced
+    if ('M_' in param) or (param == 'Z'):
+        bins = np.log10(pdf1d_hdu[param].data[-1,:])
+        label = 'log '+param
+    # for all others, standard linear spacing is ok
+    else:
+        bins = pdf1d_hdu[param].data[-1,:]
+        label = copy.copy(param)
+
+    return bins, label

--- a/beast/plotting/plot_indiv_pdfs.py
+++ b/beast/plotting/plot_indiv_pdfs.py
@@ -1,7 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
-import matplotlib.colors as colors
 from astropy.io import fits
 import copy
 
@@ -92,12 +91,14 @@ def plot_pdfs(
                     )
 
                     # attempt to plot 1/2/3 sigma contours
+                    # (doesn't work if the probability is super concentrated,
+                    # which is generally due to the grid being really coarse)
                     try:
                         im_sort = np.sort(image, axis=None)[::-1]
                         cumsum = np.cumsum(im_sort)
                         cumsum /= np.max(cumsum)
                         clevels = [
-                            np.log(im_sort[np.where(cumsum < p)[0][-1]])
+                            np.log(im_sort[np.where(cumsum <= p)[0][-1]])
                             for p in [0.68, 0.95, 0.997]
                         ]
                         plt.contour(
@@ -108,9 +109,11 @@ def plot_pdfs(
                             colors='k',
                             linestyles='-',
                         )
-                    except:
+                    except IndexError:
                         #print("  can't make contours for this")
                         pass
+                    except:
+                        raise
 
 
 

--- a/beast/plotting/plot_indiv_pdfs.py
+++ b/beast/plotting/plot_indiv_pdfs.py
@@ -69,8 +69,10 @@ def plot_pdfs(
                     # find the 2D PDF and make sure it's properly rotated
                     try:
                         image = hdu_2d[pi+'+'+pj].data[starnum,:,:].T
-                    except:
+                    except KeyError:
                         image = hdu_2d[pj+'+'+pi].data[starnum,:,:]
+                    except:
+                        raise
 
                     # create axis/labels
                     x_bins, x_label = setup_axis(pi, hdu_1d)

--- a/beast/tools/run/create_filenames.py
+++ b/beast/tools/run/create_filenames.py
@@ -57,6 +57,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
     # output files
     stats_files = []
     pdf_files = []
+    pdf2d_files = []
     lnp_files = []
 
     # other potentially useful things
@@ -104,6 +105,11 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
             )
             pdf_files.append(
                 "{0}/{0}_bin{1}_sub{2}_pdf1d.fits".format(
+                    datamodel.project, choose_sd_sub[0], choose_sd_sub[1]
+                )
+            )
+            pdf2d_files.append(
+                "{0}/{0}_bin{1}_sub{2}_pdf2d.fits".format(
                     datamodel.project, choose_sd_sub[0], choose_sd_sub[1]
                 )
             )
@@ -160,6 +166,11 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                         datamodel.project, curr_sd, curr_sub
                     )
                 )
+                pdf2d_files.append(
+                    "{0}/{0}_bin{1}_sub{2}_pdf2d.fits".format(
+                        datamodel.project, curr_sd, curr_sub
+                    )
+                )
                 lnp_files.append(
                     "{0}/{0}_bin{1}_sub{2}_lnp.hd5".format(
                         datamodel.project, curr_sd, curr_sub
@@ -183,6 +194,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
 
             stats_files.append("{0}/{0}_stats.fits".format(datamodel.project))
             pdf_files.append("{0}/{0}_pdf1d.fits".format(datamodel.project))
+            pdf2d_files.append("{0}/{0}_pdf2d.fits".format(datamodel.project))
             lnp_files.append("{0}/{0}_lnp.hd5".format(datamodel.project))
 
     # ** with subgrids **
@@ -244,6 +256,11 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                 )
                 pdf_files.append(
                     "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_pdf1d.fits".format(
+                        datamodel.project, choose_sd_sub[0], choose_sd_sub[1], gridsub
+                    )
+                )
+                pdf2d_files.append(
+                    "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_pdf2d.fits".format(
                         datamodel.project, choose_sd_sub[0], choose_sd_sub[1], gridsub
                     )
                 )
@@ -311,6 +328,11 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                             datamodel.project, curr_sd, curr_sub, gridsub
                         )
                     )
+                    pdf2d_files.append(
+                        "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_pdf2d.fits".format(
+                            datamodel.project, curr_sd, curr_sub, gridsub
+                        )
+                    )
                     lnp_files.append(
                         "{0}/bin{1}_sub{2}/{0}_bin{1}_sub{2}_gridsub{3}_lnp.hd5".format(
                             datamodel.project, curr_sd, curr_sub, gridsub
@@ -356,6 +378,9 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
                 pdf_files.append(
                     "{0}/{0}_gridsub{1}_pdf1d.fits".format(datamodel.project, gridsub)
                 )
+                pdf2d_files.append(
+                    "{0}/{0}_gridsub{1}_pdf2d.fits".format(datamodel.project, gridsub)
+                )
                 lnp_files.append(
                     "{0}/{0}_gridsub{1}_lnp.hd5".format(datamodel.project, gridsub)
                 )
@@ -377,6 +402,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
             noise_trim_files,
             stats_files,
             pdf_files,
+            pdf2d_files,
             lnp_files,
         ]
     ]
@@ -392,6 +418,7 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
         "noise_trim_files": noise_trim_files,
         "stats_files": stats_files,
         "pdf_files": pdf_files,
+        "pdf2d_files": pdf2d_files,
         "lnp_files": lnp_files,
         "gridpickle_files": gridpickle_files,
         "sd_sub_info": sd_sub_info,

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -26,6 +26,7 @@ def run_fitting(
     nprocs=1,
     choose_sd_sub=None,
     choose_subgrid=None,
+    pdf2d_param_list=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
     resume=False,
 ):
     """
@@ -52,11 +53,14 @@ def run_fitting(
     choose_sd_sub : list of two strings (default=None)
         If this is set, the fitting will just be for this combo of SD+sub,
         rather than all of them.  Overrides use_sd.
-        format of the list: ['#-#','#']
+        format of the list: ['#','#']
 
     choose_subgrid : int (default=None)
         If this is set, the fitting with just be for this subgrid index.
         If nsubs=1, this is ignored.
+
+    pdf2d_param_list : list of strings or None
+        If set, do 2D PDFs of these parameters.  If None, don't make 2D PDFs.
 
     resume : boolean (default=False)
         choose whether to resume existing run or start over
@@ -94,6 +98,8 @@ def run_fitting(
     stats_files = file_dict["stats_files"]
     pdf_files = file_dict["pdf_files"]
     pdf2d_files = file_dict["pdf2d_files"]
+    if pdf2d_param_list is None:
+        pdf2d_files = [None for i in range(len(pdf2d_files))]
     lnp_files = file_dict["lnp_files"]
 
     # total number of files
@@ -158,6 +164,7 @@ def run_fitting(
                 stats_files[i],
                 pdf_files[i],
                 pdf2d_files[i],
+                pdf2d_param_list,
                 lnp_files[i],
                 None,
                 resume,
@@ -175,6 +182,7 @@ def run_fitting(
                 stats_files[i],
                 pdf_files[i],
                 pdf2d_files[i],
+                pdf2d_param_list,
                 lnp_files[i],
                 gridpickle_files[i],
                 resume,
@@ -198,6 +206,7 @@ def fit_submodel(
     stats_file,
     pdf_file,
     pdf2d_file,
+    pdf2d_param_list,
     lnp_file,
     grid_info_file=None,
     resume=False,
@@ -224,6 +233,9 @@ def fit_submodel(
 
     pdf2d_file : string
         path+name of the file to contain 2D PDF output
+
+    pdf2d_param_list: list of strings or None
+        parameters for which to make 2D PDFs (or None)
 
     lnp_file : string
         path+name of the file to contain log likelihood output
@@ -271,6 +283,7 @@ def fit_submodel(
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
             pdf2d_outname=pdf2d_file,
+            pdf2d_param_list=pdf2d_param_list,
             grid_info_dict=grid_info_dict,
             lnp_outname=lnp_file,
             do_not_normalize=True,
@@ -291,6 +304,7 @@ def fit_submodel(
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
             pdf2d_outname=pdf2d_file,
+            pdf2d_param_list=pdf2d_param_list,
             lnp_outname=lnp_file,
             surveyname=datamodel.surveyname,
         )
@@ -321,12 +335,19 @@ if __name__ == "__main__":  # pragma: no cover
     )
     parser.add_argument(
         "--choose_sd_sub",
-        nargs="+",
+        nargs=2,
         default=None,
-        help="Fit just this combo of SD+sub. Format: ['#-#','#']",
+        help="Fit just this combo of SD+sub. Format: ['#','#']",
     )
     parser.add_argument(
         "--choose_subgrid", type=int, default=None, help="Fit just this subgrid number"
+    )
+    parser.add_argument(
+        "--pdf2d_param_list",
+        type=str,
+        nargs="+",
+        default=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
+        help="If set, do 2D PDFs of these parameters. If None, don't make 2D PDFs."
     )
     parser.add_argument(
         "-r", "--resume", help="resume a fitting run", action="store_true"
@@ -334,11 +355,16 @@ if __name__ == "__main__":  # pragma: no cover
 
     args = parser.parse_args()
 
+    if 'None' in args.pdf2d_param_list:
+        args.pdf2d_param_list = None
+
+
     run_fitting(
         use_sd=args.use_sd,
         nsubs=args.nsubs,
         nprocs=args.nprocs,
         choose_sd_sub=args.choose_sd_sub,
         choose_subgrid=args.choose_subgrid,
+        pdf2d_param_list=args.pdf2d_param_list,
         resume=args.resume,
     )

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -17,7 +17,6 @@ from beast.tools.run import create_filenames
 
 import datamodel
 import importlib
-importlib.reload(fit)
 
 
 def run_fitting(

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -17,6 +17,7 @@ from beast.tools.run import create_filenames
 
 import datamodel
 import importlib
+importlib.reload(fit)
 
 
 def run_fitting(
@@ -92,6 +93,7 @@ def run_fitting(
     # output files
     stats_files = file_dict["stats_files"]
     pdf_files = file_dict["pdf_files"]
+    pdf2d_files = file_dict["pdf2d_files"]
     lnp_files = file_dict["lnp_files"]
 
     # total number of files
@@ -155,6 +157,7 @@ def run_fitting(
                 noise_trim_files[i],
                 stats_files[i],
                 pdf_files[i],
+                pdf2d_files[i],
                 lnp_files[i],
                 None,
                 resume,
@@ -171,6 +174,7 @@ def run_fitting(
                 noise_trim_files[i],
                 stats_files[i],
                 pdf_files[i],
+                pdf2d_files[i],
                 lnp_files[i],
                 gridpickle_files[i],
                 resume,
@@ -193,6 +197,7 @@ def fit_submodel(
     noise_file,
     stats_file,
     pdf_file,
+    pdf2d_file,
     lnp_file,
     grid_info_file=None,
     resume=False,
@@ -216,6 +221,9 @@ def fit_submodel(
 
     pdf_file : string
         path+name of the file to contain 1D PDF output
+
+    pdf2d_file : string
+        path+name of the file to contain 2D PDF output
 
     lnp_file : string
         path+name of the file to contain log likelihood output
@@ -262,6 +270,7 @@ def fit_submodel(
             lnp_npts=500,
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
+            pdf2d_outname=pdf2d_file,
             grid_info_dict=grid_info_dict,
             lnp_outname=lnp_file,
             do_not_normalize=True,
@@ -281,6 +290,7 @@ def fit_submodel(
             lnp_npts=500,
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
+            pdf2d_outname=pdf2d_file,
             lnp_outname=lnp_file,
             surveyname=datamodel.surveyname,
         )
@@ -332,7 +342,3 @@ if __name__ == "__main__":  # pragma: no cover
         choose_subgrid=args.choose_subgrid,
         resume=args.resume,
     )
-
-    # print help if no arguments
-    if not any(vars(args).values()):
-        parser.print_help()

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -27,6 +27,7 @@ def setup_batch_beast_fit(
     overwrite_logfile=True,
     prefix=None,
     use_sd=True,
+    pdf2d_param_list=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
     nsubs=1,
     nprocs=1,
 ):
@@ -54,6 +55,9 @@ def setup_batch_beast_fit(
     use_sd : boolean (default=True)
         If True, split runs based on source density (determined by finding
         matches to datamodel.astfile with SD info)
+
+    pdf2d_param_list : list of strings or None
+        If set, do 2D PDFs of these parameters.  If None, don't make 2D PDFs.
 
     nsubs : int (default=1)
         number of subgrids used for the physics model
@@ -268,6 +272,12 @@ def setup_batch_beast_fit(
             if nsubs > 1:
                 gs_str = " --choose_subgrid {0} ".format(gridsub_info[i])
 
+            # set 2D PDF option
+            if pdf2d_param_list is None:
+                pdf2d_str = "None"
+            else:
+                pdf2d_str = " " + " ".join(pdf2d_param_list) + " "
+
             job_command = (
                 nice_str
                 + "python -m beast.tools.run.run_fitting "
@@ -278,6 +288,8 @@ def setup_batch_beast_fit(
                 + str(nsubs)
                 + " --nprocs "
                 + str(nprocs)
+                + " --pdf2d_param_list "
+                + pdf2d_str
                 + pipe_str
                 + log_path
                 + log_files[i]
@@ -327,7 +339,13 @@ if __name__ == "__main__":  # pragma: no cover
         type=int,
         help="if True (1), remove sources with flag=99 in flag_filter",
     )
-
+    parser.add_argument(
+        "--pdf2d_param_list",
+        type=str,
+        nargs="+",
+        default=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
+        help="If set, do 2D PDFs of these parameters. If None, don't make 2D PDFs."
+    )
     parser.add_argument(
         "--nsubs",
         default=1,
@@ -343,12 +361,16 @@ if __name__ == "__main__":  # pragma: no cover
 
     args = parser.parse_args()
 
+    if 'None' in args.pdf2d_param_list:
+        args.pdf2d_param_list = None
+
     setup_batch_beast_fit(
         num_percore=args.num_percore,
         nice=args.nice,
         overwrite_logfile=bool(args.overwrite_logfile),
         prefix=args.prefix,
         use_sd=bool(args.use_sd),
+        pdf2d_param_list=args.pdf2d_param_list,
         nsubs=args.nsubs,
         nprocs=args.nprocs,
     )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ User Documentation
    Plotting Tools <plotting_tools.rst>
    Format of BEAST grid files <beast_grid_format.rst>
    Details on BEAST libraries for grid <beast_grid_inputs.rst>
-   Output statistics <outputs.rst>
+   BEAST output files <outputs.rst>
    Known issues <beast_issues.rst>
 
 Developer Documentation

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -8,161 +8,96 @@ Below are details regarding the output statistics files produced by the BEAST
 Columns in BEAST stats files
 ============================
 
-ID Name
-  * IAU suggested naming scheme used (example: PHAT J113759.63+421022.03)
-
 Data Parameters
 ---------------
 
-RA
-  * right ascention from photometry catalog
-
-DEC
-  * declination from photometry catalog
-
-field 
-  * field in the brick
-
-inside_brick 
-  * inside the brick boundaries
-inside_chipgap
-  * in ACS chip gap
-
-Photometry (units are *flux* [not mag])
-  (units are normalized Vega fluxes, e.g., flux/flux_vega)
+* `ID Name`: IAU suggested naming scheme used (example: PHAT J113759.63+421022.03)
+* `RA`: right ascension from photometry catalog
+* `DEC`: declination from photometry catalog
+* `field`: field in the brick
+* `inside_brick`: inside the brick boundaries
+* `inside_chipgap`: in ACS chip gap
+* Photometry: listed as *flux* (not mag), units are normalized Vega fluxes
+  (e.g., flux/flux_vega)
   
-  HST_WFC3_F275W
-  HST_WFC3_F336W
-  HST_ACS_WFC_F475W
-  HST_ACS_WFC_F814W
-  HST_WFC3_F110W
-  HST_WFC3_F160W
+  * `HST_WFC3_F275W`
+  * `HST_WFC3_F336W`
+  * `HST_ACS_WFC_F475W`
+  * `HST_ACS_WFC_F814W`
+  * `HST_WFC3_F110W`
+  * `HST_WFC3_F160W`
 
-BEAST goodness-of-fit metrics
+Goodness-of-fit metrics
+-----------------------
+
+* `Pmax`: maximum probability of nD PDF
+* `Pmax_indx`: index in BEAST model grid corresponding to `Pmax`
+* `specgrid_indx`: index in spectroscopic grid corresponding to `Pmax`
+* `chi2min`: minimum value of chisqr
+* `chi2min_indx`: index in BEAST model grid corresponding to `chi2min`
+
+Fitted and derived parameters
 -----------------------------
-Pmax 
-  * maxium probability of nD PDF
 
-chi2min 
-  * minimum value of chisqr
+Each parameter (listed below) has five values associated with it:
 
+* `X_Best`: best fit value ["traditional" values]
+* `X_Exp`: expectation value (average weighted by 1D PDF) [best when not using
+  uncertainties]
+* `X_p50`: 50th percentile from 1D PDF
+* `X_p16`: 16th percentile from 1D PDF (p50-p16 is proxy for -1 sigma)
+* `X_p84`: 84th percentile from 1D PDF (p84-p50 is proxy for +1 sigma)
 
-BEAST Fitting parameters
-------------------------
+Dust Parameters
+"""""""""""""""
 
-The results come in three flavors
+First 3 primary, others derived
 
-X_Best 
-  * best fit value ["traditional" values]
-
-X_Exp 
-  * expectation value (average weighted by 1D PDF) [best when not using uncertainties]
-
-X_p50 
-  * 50% value from 1D PDF
-X_p16 
-  * 16% value from 1D PDF (minus 1 sigma)
-X_p84 
-  * 84% value from 1D PDF (plus 1 sigma)
-
-[best when using uncertainites]
-[use p50 - (p50-p16) + (p84 - p50) when quoting results with uncertainties]
-
-Dust Parameters 
----------------
-
-(first 3 primary, others derived)
-
-Av = A(V) 
-  * visual extinction in magnitudes
-Rv  
-  *  R(V) = A(V)/E(B-V) = ratio of total to selective extinction
-f_A  
-  *  fraction in extinction curve from A component (MW)
-
-Rv_A  
-  *  R(V)_A = R(V) of A component of BEAST R(V)-f_A model of extinction curves
+* `Av = A(V)`: visual extinction in magnitudes
+* `Rv`: R(V) = A(V)/E(B-V) = ratio of total to selective extinction
+* `f_A`: fraction in extinction curve from A component (MW)
+* `Rv_A`: R(V)_A = R(V) of A component of BEAST R(V)-f_A model of extinction curves
 
 Stellar Parameters
-------------------
+""""""""""""""""""
 
-(first 3 primary, others derived)
+First 3 primary, others derived
 
-M_ini  
-  * initial stellar mass in solar masses
-logA  
-  * log10 of the stellar age (in years)
-Z  
-  * stellar metallicity 
+* M_ini: initial stellar mass (in solar masses)
+* logA: log10 of the stellar age (in years)
+* Z: stellar metallicity
+* M_act: current stellar mass (in solar masses)
+* logL: log10 of the stellar luminosity
+* logT: log10 of the stellar effective temperature
+* logg: log10 of the stellar surface gravity
+* mbol: bolometric magnitude
+* radius: stellar radius
 
-M_act  
-  * current stellar mass in solar masses
-logL  
-  * log10 of the stellar luminosity
-logT  
-  * log10 of the stellar effective temperature
-logg  
-  * log10 of the stellar surface gravity
-mbol  
-  * bolometric magnitude(????)
-radius  
-  * stellar radius
+Predicted Fluxes
+""""""""""""""""
 
-BEAST Model predicted values
-----------------------------
+The fitting process also predicts fluxes, both in the observed bands and in
+other bands of interest.
 
-[same flavors as the BEAST fit parameters]
-
-logHST_WFC3_F275W_nd  
-  * log10 of the unextinguished WFC3 F275W flux
-logHST_WFC3_F275W_wd  
-  * log10 of the extinguished WFC3 F275W flux
-logHST_WFC3_F336W_nd  
-  * log10 of the unextinguished WFC3 F336W flux
-logHST_WFC3_F336W_wd  
-  * log10 of the extinguished WFC3 F336W flux
-logHST_ACS_WFC_F475W_nd  
-  * log10 of the unextinguished ACS F475W flux
-logHST_ACS_WFC_F475W_wd  
-  * log10 of the extinguished ACS F475W flux
-logHST_ACS_WFC_F814W_nd  
-  * log10 of the unextinguished ACS F814W flux
-logHST_ACS_WFC_F814W_wd  
-  * log10 of the extinguished ACS F814W flux
-logHST_WFC3_F110W_nd  
-  * log10 of the unextinguished WFC3 F110W flux
-logHST_WFC3_F110W_wd  
-  * log10 of the extinguished WFC3 F110W flux
-logHST_WFC3_F160W_nd  
-  * log10 of the unextinguished WFC3 F160W flux
-logHST_WFC3_F160W_wd  
-  * log10 of the extinguished WFC3 F160W flux
-
-logGALEX_FUV_nd  
-  * log10 of the unextinguished GALEX FUV flux
-logGALEX_FUV_wd  
-  * log10 of the extinguished GALEX FUV flux
-logGALEX_NUV_nd  
-  * log10 of the unextinguished GALEX FUV flux
-logGALEX_NUV_wd  
-  * log10 of the extinguished GALEX FUV flux
-
-logF_UV_6_13e_nd  
-  * log10 of the unextinguished flux between 6 and 13 eV
-logF_UV_6_13e_wd  
-  * log10 of the extinguished flux between 6 and 13 eV
-
-logF_QION_nd  
-  * log10 of the unextinguished ionizing flux (***do not use for PHAT results - incorrect***)
-logF_QION_wd  
-  * log10 of the extinguished ionizing flux (***do not use for PHAT results - incorrect***)
-
-Extras
-------
-
-specgrid_indx  
-  * index of model in the spectral grid
-Pmax_indx  
-  * index in BEAST grid of Pmax
-chi2min_indx  
-  * index in BEAST grid of chi2min
+* `logHST_WFC3_F275W_nd`: log10 of the unextinguished WFC3 F275W flux
+* `logHST_WFC3_F275W_wd`: log10 of the extinguished WFC3 F275W flux
+* `logHST_WFC3_F336W_nd`: log10 of the unextinguished WFC3 F336W flux
+* `logHST_WFC3_F336W_wd`: log10 of the extinguished WFC3 F336W flux
+* `logHST_ACS_WFC_F475W_nd`: log10 of the unextinguished ACS F475W flux
+* `logHST_ACS_WFC_F475W_wd`: log10 of the extinguished ACS F475W flux
+* `logHST_ACS_WFC_F814W_nd`: log10 of the unextinguished ACS F814W flux
+* `logHST_ACS_WFC_F814W_wd`: log10 of the extinguished ACS F814W flux
+* `logHST_WFC3_F110W_nd`: log10 of the unextinguished WFC3 F110W flux
+* `logHST_WFC3_F110W_wd`: log10 of the extinguished WFC3 F110W flux
+* `logHST_WFC3_F160W_nd`: log10 of the unextinguished WFC3 F160W flux
+* `logHST_WFC3_F160W_wd`: log10 of the extinguished WFC3 F160W flux
+* `logGALEX_FUV_nd`: log10 of the unextinguished GALEX FUV flux
+* `logGALEX_FUV_wd`: log10 of the extinguished GALEX FUV flux
+* `logGALEX_NUV_nd`: log10 of the unextinguished GALEX FUV flux
+* `logGALEX_NUV_wd`: log10 of the extinguished GALEX FUV flux
+* `logF_UV_6_13e_nd`: log10 of the unextinguished flux between 6 and 13 eV
+* `logF_UV_6_13e_wd`: log10 of the extinguished flux between 6 and 13 eV
+* `logF_QION_nd`: log10 of the unextinguished ionizing flux (***do not use for
+  PHAT results - incorrect***)
+* `logF_QION_wd`: log10 of the extinguished ionizing flux (***do not use for
+  PHAT results - incorrect***)

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -1,12 +1,19 @@
-###########
-Output file
-###########
+############
+Output files
+############
 
-Below are details regarding the output statistics files produced by the BEAST
+Below are details regarding the output files produced by the BEAST:
+
+* `*_stats.fits`: Statistics for each of the fitted and derived parameters,
+  including the 16th/50th/84th percentiles, mean, and expectation value
+* `*_pdf1d.fits`: Marginalized 1D PDFs for each of the fitted and derived
+  parameters
+* `*_pdf2d.fits`: Marginalized 2D PDFs for each pair of the fitted parameters
+* `*_lnp.hd5`: Sparsely sampled log likelihoods
 
 
-Columns in BEAST stats files
-============================
+Statistics file
+===============
 
 Data Parameters
 ---------------
@@ -19,7 +26,7 @@ Data Parameters
 * `inside_chipgap`: in ACS chip gap
 * Photometry: listed as *flux* (not mag), units are normalized Vega fluxes
   (e.g., flux/flux_vega)
-  
+
   * `HST_WFC3_F275W`
   * `HST_WFC3_F336W`
   * `HST_ACS_WFC_F475W`
@@ -101,3 +108,91 @@ other bands of interest.
   PHAT results - incorrect***)
 * `logF_QION_wd`: log10 of the extinguished ionizing flux (***do not use for
   PHAT results - incorrect***)
+
+
+1D PDF file
+===========
+
+Each extension in the fits file is for one of the parameters listed above.  It
+contains an array with dimensions `(N_obs+1, N_bin)`, where `N_obs` is the
+number of stars and `N_bin` is the number of bins for that parameter.  Each
+entry in the array is the probability (NOT logarithmic) in each bin.  The bin
+values are listed in the last line of the array.
+
+Below is an example for `Rv` in the `phat_small` example.
+
+.. code-block:: python
+
+  >>> from astropy.io import fits
+  >>> hdu = fits.open('beast_example_phot_pdf1d.fits')
+  >>> hdu.info()
+  Filename: beast_example_phat_pdf1d.fits
+  No.    Name      Ver    Type      Cards   Dimensions   Format
+  0  PRIMARY       1 PrimaryHDU       6   (2, 2)   float64
+  1  Av            1 ImageHDU         8   (11, 270)   float64
+  2  M_act         1 ImageHDU         8   (50, 270)   float64
+  3  M_ini         1 ImageHDU         8   (50, 270)   float64
+  4  Rv            1 ImageHDU         8   (5, 270)   float64
+  5  Rv_A          1 ImageHDU         8   (9, 270)   float64
+  6  Z             1 ImageHDU         8   (5, 270)   float64
+  ...
+  >>> hdu['Rv'].data[0,:]  # 1D PDF for star 0
+  array([0.00000000e+00, 9.99753477e-01, 2.46523236e-04, 0.00000000e+00,
+       0.00000000e+00])
+  >>> hdu['Rv'].data[-1,:]  # corresponding bin values
+  array([2., 3., 4., 5., 6.])
+
+
+2D PDF file
+===========
+
+Each extension in the fits file is for one of the pairs of primary fitting
+parameters (`M_ini`, `logA`, `Z`, `distance`, `Av`, `Rv`, `f_A`).  The saved
+arrays have dimensions `(N_obs+2, N_bin_1, N_bin_2)`, where `N_obs` is the
+number of stars, `N_bin_1` is the number of bins for the first parameter, and
+`N_bin_2` is the number of bins for the second parameter.  The last two slices
+contain the bin values.
+
+Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
+
+.. code-block:: python
+
+  >>> from astropy.io import fits
+  >>> hdu = fits.open('beast_example_phot_pdf2d.fits')
+  >>> hdu.info()
+  Filename: beast_example_phat_pdf2d.fits
+  No.    Name      Ver    Type      Cards   Dimensions   Format
+  0  PRIMARY       1 PrimaryHDU       6   (2, 2)   float64
+  1  Av+M_ini      1 ImageHDU         9   (50, 11, 271)   float64
+  2  Av+Rv         1 ImageHDU         9   (5, 11, 271)   float64
+  3  Av+Z          1 ImageHDU         9   (5, 11, 271)   float64
+  4  Av+distance    1 ImageHDU         9   (1, 11, 271)   float64
+  5  Av+f_A        1 ImageHDU         9   (4, 11, 271)   float64
+  6  Av+logA       1 ImageHDU         9   (5, 11, 271)   float64
+  7  M_ini+Rv      1 ImageHDU         9   (5, 50, 271)   float64
+  8  M_ini+Z       1 ImageHDU         9   (5, 50, 271)   float64
+  ...
+  >>> hdu['Rv+f_A'].data[0,:,:]  # 2D PDF for star 0
+  array([[0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
+         [6.86784697e-01, 2.94159452e-01, 1.88093274e-02, 0.00000000e+00],
+         [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 2.46523236e-04],
+         [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
+         [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
+  >>> hdu['Rv+f_A'].data[-2,:,:]  # corresponding Rv bin values
+  array([[2., 2., 2., 2.],
+         [3., 3., 3., 3.],
+         [4., 4., 4., 4.],
+         [5., 5., 5., 5.],
+         [6., 6., 6., 6.]])
+  >>> hdu['Rv+f_A'].data[-1,:,:]  # corresponding f_A bin values
+  array([[0.25, 0.5 , 0.75, 1.  ],
+         [0.25, 0.5 , 0.75, 1.  ],
+         [0.25, 0.5 , 0.75, 1.  ],
+         [0.25, 0.5 , 0.75, 1.  ],
+         [0.25, 0.5 , 0.75, 1.  ]])
+
+
+Log Likelihood file
+===================
+
+(to be added)

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -8,7 +8,7 @@ Below are details regarding the output files produced by the BEAST:
   including the 16th/50th/84th percentiles, mean, and expectation value
 * `*_pdf1d.fits`: Marginalized 1D PDFs for each of the fitted and derived
   parameters
-* `*_pdf2d.fits`: Marginalized 2D PDFs for each pair of the fitted parameters
+* `*_pdf2d.fits`: Marginalized 2D PDFs for pairs of parameters
 * `*_lnp.hd5`: Sparsely sampled log likelihoods
 
 
@@ -146,12 +146,12 @@ Below is an example for `Rv` in the `phat_small` example.
 2D PDF file
 ===========
 
-Each extension in the fits file is for one of the pairs of primary fitting
-parameters (`M_ini`, `logA`, `Z`, `distance`, `Av`, `Rv`, `f_A`).  The saved
-arrays have dimensions `(N_obs+2, N_bin_1, N_bin_2)`, where `N_obs` is the
-number of stars, `N_bin_1` is the number of bins for the first parameter, and
-`N_bin_2` is the number of bins for the second parameter.  The last two slices
-contain the bin values.
+Each extension in the fits file is for one of the pairs of fitting parameters
+(the default is the 7 main parameters, but the user may have selected a
+different set).  The saved arrays have dimensions `(N_obs+2, N_bin_1, N_bin_2)`,
+where `N_obs` is the number of stars, `N_bin_1` is the number of bins for the
+first parameter, and `N_bin_2` is the number of bins for the second parameter.
+The last two slices contain the bin values.
 
 Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
 
@@ -166,11 +166,10 @@ Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
   1  Av+M_ini      1 ImageHDU         9   (50, 11, 271)   float64
   2  Av+Rv         1 ImageHDU         9   (5, 11, 271)   float64
   3  Av+Z          1 ImageHDU         9   (5, 11, 271)   float64
-  4  Av+distance    1 ImageHDU         9   (1, 11, 271)   float64
-  5  Av+f_A        1 ImageHDU         9   (4, 11, 271)   float64
-  6  Av+logA       1 ImageHDU         9   (5, 11, 271)   float64
-  7  M_ini+Rv      1 ImageHDU         9   (5, 50, 271)   float64
-  8  M_ini+Z       1 ImageHDU         9   (5, 50, 271)   float64
+  4  Av+f_A        1 ImageHDU         9   (4, 11, 271)   float64
+  5  Av+logA       1 ImageHDU         9   (5, 11, 271)   float64
+  6  M_ini+Rv      1 ImageHDU         9   (5, 50, 271)   float64
+  7  M_ini+Z       1 ImageHDU         9   (5, 50, 271)   float64
   ...
   >>> hdu['Rv+f_A'].data[0,:,:]  # 2D PDF for star 0 #doctest: +SKIP
   array([[0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -124,7 +124,7 @@ Below is an example for `Rv` in the `phat_small` example.
 .. code-block:: python
 
   >>> from astropy.io import fits
-  >>> hdu = fits.open('beast_example_phot_pdf1d.fits')
+  >>> hdu = fits.open('beast_example_phat_pdf1d.fits')
   >>> hdu.info()
   Filename: beast_example_phat_pdf1d.fits
   No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -158,7 +158,7 @@ Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
 .. code-block:: python
 
   >>> from astropy.io import fits
-  >>> hdu = fits.open('beast_example_phot_pdf2d.fits')
+  >>> hdu = fits.open('beast_example_phat_pdf2d.fits')
   >>> hdu.info()
   Filename: beast_example_phat_pdf2d.fits
   No.    Name      Ver    Type      Cards   Dimensions   Format

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -70,15 +70,15 @@ Stellar Parameters
 
 First 3 primary, others derived
 
-* M_ini: initial stellar mass (in solar masses)
-* logA: log10 of the stellar age (in years)
-* Z: stellar metallicity
-* M_act: current stellar mass (in solar masses)
-* logL: log10 of the stellar luminosity
-* logT: log10 of the stellar effective temperature
-* logg: log10 of the stellar surface gravity
-* mbol: bolometric magnitude
-* radius: stellar radius
+* `M_ini`: initial stellar mass (in solar masses)
+* `logA`: log10 of the stellar age (in years)
+* `Z`: stellar metallicity
+* `M_act`: current stellar mass (in solar masses)
+* `logL`: log10 of the stellar luminosity
+* `logT`: log10 of the stellar effective temperature
+* `logg`: log10 of the stellar surface gravity
+* `mbol`: bolometric magnitude
+* `radius`: stellar radius
 
 Predicted Fluxes
 """"""""""""""""

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -1,6 +1,6 @@
-############
-Output files
-############
+##################
+BEAST Output Files
+##################
 
 Below are details regarding the output files produced by the BEAST:
 

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -123,9 +123,9 @@ Below is an example for `Rv` in the `phat_small` example.
 
 .. code-block:: python
 
-  >>> from astropy.io import fits
-  >>> hdu = fits.open('beast_example_phat_pdf1d.fits')
-  >>> hdu.info()
+  >>> from astropy.io import fits #doctest: +SKIP
+  >>> hdu = fits.open('beast_example_phat_pdf1d.fits') #doctest: +SKIP
+  >>> hdu.info() #doctest: +SKIP
   Filename: beast_example_phat_pdf1d.fits
   No.    Name      Ver    Type      Cards   Dimensions   Format
   0  PRIMARY       1 PrimaryHDU       6   (2, 2)   float64
@@ -136,10 +136,10 @@ Below is an example for `Rv` in the `phat_small` example.
   5  Rv_A          1 ImageHDU         8   (9, 270)   float64
   6  Z             1 ImageHDU         8   (5, 270)   float64
   ...
-  >>> hdu['Rv'].data[0,:]  # 1D PDF for star 0
+  >>> hdu['Rv'].data[0,:]  # 1D PDF for star 0 #doctest: +SKIP
   array([0.00000000e+00, 9.99753477e-01, 2.46523236e-04, 0.00000000e+00,
        0.00000000e+00])
-  >>> hdu['Rv'].data[-1,:]  # corresponding bin values
+  >>> hdu['Rv'].data[-1,:]  # corresponding bin values #doctest: +SKIP
   array([2., 3., 4., 5., 6.])
 
 
@@ -157,9 +157,9 @@ Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
 
 .. code-block:: python
 
-  >>> from astropy.io import fits
-  >>> hdu = fits.open('beast_example_phat_pdf2d.fits')
-  >>> hdu.info()
+  >>> from astropy.io import fits #doctest: +SKIP
+  >>> hdu = fits.open('beast_example_phat_pdf2d.fits') #doctest: +SKIP
+  >>> hdu.info() #doctest: +SKIP
   Filename: beast_example_phat_pdf2d.fits
   No.    Name      Ver    Type      Cards   Dimensions   Format
   0  PRIMARY       1 PrimaryHDU       6   (2, 2)   float64
@@ -172,19 +172,19 @@ Below is an example of the `Rv` and `f_A` 2D PDF in the `phat_small` example.
   7  M_ini+Rv      1 ImageHDU         9   (5, 50, 271)   float64
   8  M_ini+Z       1 ImageHDU         9   (5, 50, 271)   float64
   ...
-  >>> hdu['Rv+f_A'].data[0,:,:]  # 2D PDF for star 0
+  >>> hdu['Rv+f_A'].data[0,:,:]  # 2D PDF for star 0 #doctest: +SKIP
   array([[0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
          [6.86784697e-01, 2.94159452e-01, 1.88093274e-02, 0.00000000e+00],
          [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 2.46523236e-04],
          [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
          [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
-  >>> hdu['Rv+f_A'].data[-2,:,:]  # corresponding Rv bin values
+  >>> hdu['Rv+f_A'].data[-2,:,:]  # corresponding Rv bin values #doctest: +SKIP
   array([[2., 2., 2., 2.],
          [3., 3., 3., 3.],
          [4., 4., 4., 4.],
          [5., 5., 5., 5.],
          [6., 6., 6., 6.]])
-  >>> hdu['Rv+f_A'].data[-1,:,:]  # corresponding f_A bin values
+  >>> hdu['Rv+f_A'].data[-1,:,:]  # corresponding f_A bin values #doctest: +SKIP
   array([[0.25, 0.5 , 0.75, 1.  ],
          [0.25, 0.5 , 0.75, 1.  ],
          [0.25, 0.5 , 0.75, 1.  ],

--- a/docs/plotting_tools.rst
+++ b/docs/plotting_tools.rst
@@ -41,6 +41,10 @@ diagnostic plots and visualizations.  Some are described here.
   of each parameter, as well as an SED (similar to Figure 14 in
   `Gordon+16 <https://ui.adsabs.harvard.edu/abs/2016ApJ...826..104G>`_).
 
+- `plot_indiv_pdfs.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_indiv_pdfs.py>`_:
+  For a given star, makes a triangle plot with all of the 2D PDFs.  Diagonals
+  contain the 1D PDFs.
+
 - `plot_mag_hist.py <https://github.com/BEAST-Fitting/beast/blob/master/beast/plotting/plot_mag_hist.py>`_:
   Make histograms of the magnitudes for each band in the photometry catalog.
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -307,7 +307,7 @@ are serial on the core).
   .. code-block:: console
 
      $ python -m beast.tools.setup_batch_beast_fit.py --num_percore 2 --nice 19 \
-           --use_sd 1 --nsubs 5
+           --use_sd 1 --nsubs 5 --pdf2d_param_list Av M_ini logT
 
 The jobs can be submitted to the batch queue via:
 
@@ -322,7 +322,10 @@ The fitting yields several output files (which are described in detail
   including the 16th/50th/84th percentiles, mean, and expectation value
 * `*_pdf1d.fits`: Marginalized 1D PDFs for each of the fitted and derived
   parameters
-* `*_pdf2d.fits`: Marginalized 2D PDFs for each pair of the fitted parameters
+* `*_pdf2d.fits`: Marginalized 2D PDFs for pairs of parameters.  If
+  `pdf2d_param_list` is set to `None`, 2D PDFs will not be generated.  The
+  default set is the 7 main BEAST parameters, but any parameters in the grid can
+  be chosen.
 * `*_lnp.hd5`: Sparsely sampled log likelihoods
 
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -315,6 +315,18 @@ The jobs can be submitted to the batch queue via:
 
      $ at -f projectname/fit_batch_jobs/beast_batch_fit_X.joblist now
 
+The fitting yields several output files (which are described in detail
+:doc:`here <outputs>`):
+
+* `*_stats.fits`: Statistics for each of the fitted and derived parameters,
+  including the 16th/50th/84th percentiles, mean, and expectation value
+* `*_pdf1d.fits`: Marginalized 1D PDFs for each of the fitted and derived
+  parameters
+* `*_pdf2d.fits`: Marginalized 2D PDFs for each pair of the fitted parameters
+* `*_lnp.hd5`: Sparsely sampled log likelihoods
+
+
+
 ***************
 Post-processing
 ***************


### PR DESCRIPTION
This is most of the work needed to create 2D PDFs.  The only missing thing is merging across source densities and/or subgrids, but I think that'll be best left to a different PR after #493 is merged.

Here's what I've changed/added:
* `fitting/pdf2d.py`: A new class (very similar to `pdf1d.py`) that assigns grid indices to each combination of the two input parameters, which later can be used to quickly evaluate the marginalized probabilities.
* `fitting/fit.py`:
  * `setup_param_bins`: Moved code that generates 1D PDF parameter bins over to its own function, since otherwise it would've been basically copy-pasted for the 2D PDFs.
  * `save_pdf2d`: saves the 2D PDFs to a fits file.  The format is one extension for each pair of parameters.
  * added code that creates the fast 2D PDF objects and uses them to calculate marginalized 2D PDFs
  * added `pdf2d_outname` as an optional input for `summary_table_memory` and `Q_all_memory`
* running tools (`tools/run/`)
  * `create_filenames.py`: added the 2D PDF filenames to the dictionary of file names it creates
  * `run_fitting.py`: update to create 2D PDFs by default (I'm assuming that's what we want?)
* `plotting/plot_indiv_pdfs.py`: makes a triangle plot of the 2D and 1D PDFs.  Examples for coarse grids are below.  The 1D PDFs are linear, and the 2D PDFs are log-scaled (is that confusing?).  There's also a section that will plot 1/2/3-sigma contours on the 2D PDFs if there are enough grid points to distinguish them.

Closes #472


| phat_small star 0 | a METAL star |
| --- | --- |
| ![phat_small_pdfs_0](https://user-images.githubusercontent.com/32465297/73018081-de575e80-3dee-11ea-8a86-7325d1b2c2a5.png) | ![metal_pdfs_20](https://user-images.githubusercontent.com/32465297/73018068-d8617d80-3dee-11ea-9581-21fd5ef50c40.png) |
