### PR TITLE
Fix a bug in removing logL=-9.999 points from isochrones

### DIFF
--- a/beast/tools/run/create_physicsmodel.py
+++ b/beast/tools/run/create_physicsmodel.py
@@ -22,7 +22,7 @@ from beast.physicsmodel.model_grid import (
 )
 from beast.physicsmodel.grid import FileSEDGrid
 from beast.tools.run.helper_functions import parallel_wrapper
-
+from beast.physicsmodel.stars.isochrone import ezIsoch
 from beast.tools import verify_params
 from beast.tools import subgridding_tools
 
@@ -81,7 +81,7 @@ def create_physicsmodel(nsubs=1, nprocs=1, subset=[None, None]):
     )
 
     # remove the isochrone points with logL=-9.999
-    oiso=oiso[oiso['logL']> -9]
+    oiso = ezIsoch(oiso.selectWhere("*","logL > -9"))
 
     if hasattr(datamodel, "add_spectral_properties_kwargs"):
         extra_kwargs = datamodel.add_spectral_properties_kwargs


### PR DESCRIPTION
The previous way to cut logL=-9.999 points was not compatible with ezIsoch. I fixed the bug and it should now remove the logL=-9.999 model points from isochrones before the generating spec grid stage. 

In the current 'create_physicsmodel.py' code, 'oiso' needs to be an instance when passing to the make_spectral_grid function. If I cut the isochrone points with logL = -9.999 in the previous way (oiso=oiso[oiso['logL']> -9]), 'oiso' becomes an ndarray. To make 'oiso' an instance after removing those model points, I had to do oiso = ezIsoch(oiso.selectWhere("*","logL > -9")). 