### PR TITLE
Skip trimming files if trimmed versions already exist

### DIFF
--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -190,7 +190,7 @@ def generic_batch_trim(
             nice_str
             + "python -m beast.tools.trim_many_via_obsdata "
             + trimfile
-            + " > "
+            + " >> "
             + log_path
             + file_prefix
             + "_trim_tr"

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -60,6 +60,11 @@ if __name__ == "__main__":
         sed_trimname = filebase + "_seds_trim.grid.hd5"
         noisemodel_trimname = filebase + "_noisemodel_trim.grid.hd5"
 
+        # if these already exist, then continue to the next set of files to trim
+        if os.path.isfile(sed_trimname) and os.path.isfile(noisemodel_trimname):
+            print("trimming already complete for "+sed_trimname)
+            continue
+
         print("working on " + sed_trimname)
 
         start_time = time.clock()

--- a/beast/tools/trim_many_via_obsdata.py
+++ b/beast/tools/trim_many_via_obsdata.py
@@ -9,6 +9,7 @@ Code to create many trimmed model grids for batch runs
 import os
 import argparse
 import time
+import warnings
 
 # BEAST imports
 import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
@@ -62,7 +63,9 @@ if __name__ == "__main__":
 
         # if these already exist, then continue to the next set of files to trim
         if os.path.isfile(sed_trimname) and os.path.isfile(noisemodel_trimname):
-            print("trimming already complete for "+sed_trimname)
+            warnings.warn(
+                "trimming already complete for {0}, skipping".format(sed_trimname)
+            )
             continue
 
         print("working on " + sed_trimname)


### PR DESCRIPTION
Moving this over from #493.

**Short explanation**

When doing trimming for production grids (and smaller grids too), trimming can take a while.  So if a trimmed file is detected, it will skip the file and move on to the next one.

**Long explanation**

The `tools/run/make_trim_scripts.py` code makes a bunch of trimming scripts/files.  The scripts call the trimming code (`tools/trim_many_via_obsdata.py`), which reads in a file, which contains an SED grid (or subgrid) and all of the source density (SD) bins.  This means the SED grid only has to be read in once by the trimming code, and then used for each of the SD bins. 

There are two situations in which re-trimming files won't happen.
1. If all of the trimmed files exist for a given subgrid, then `make_trim_scripts` won't make a trimming script for it.  If only some of them exist, it will make a trimming script.  This has been the case since `make_trim_scripts` was written.
2. In this PR, I'm adding another one: If `trim_many_via_obsdata` finds that one of the SD bins already has its files trimmed, it will skip it and go on to the next one.  This is useful if the job is cut off part way through for whatever reason - `trim_many_via_obsdata` can pick up where it left off.

@karllark was concerned in https://github.com/BEAST-Fitting/beast/pull/493#discussion_r372617323 about this all happening silently, rather than always overwriting files.  Should I add a flag to let the user choose about re-writing?
