### PR TITLE
small change to mag_cut in AST-generating code

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -59,7 +59,6 @@ def mag_limits(seds, faint_cut, Nfilter=1, bright_cut=None):
 def pick_models_toothpick_style(
     sedgrid_fname,
     filters,
-    mag_cuts,
     Nfilter,
     N_fluxes,
     min_N_per_flux,
@@ -82,9 +81,6 @@ def pick_models_toothpick_style(
 
     filters: list of string
         Names of the filters, to be used as columns of the output table
-
-    mag_cuts: list of float
-        List of magnitude limits for each filter
 
     Nfilter: integer
         In how many filters a fake star needs to be brighter than the
@@ -137,7 +133,6 @@ def pick_models_toothpick_style(
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
 
-    # idxs = mag_limits(sedsMags, mag_cuts, Nfilter=Nfilter, bright_cut=bright_cut)
     idxs = np.where(modelsedgrid.grid["logL"] > -9)[0]
     sedsMags_cut = sedsMags[idxs]
 

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -43,23 +43,8 @@ def make_ast_inputs(flux_bin_method=True):
     # check input parameters
     verify_params.verify_input_format(datamodel)
 
-    # construct magnitude cuts
-
-    mag_cuts = datamodel.ast_maglimit
+    # read in the photometry catalog
     obsdata = datamodel.get_obscat(datamodel.obsfile, datamodel.filters)
-
-    if len(mag_cuts) == 1:
-        tmp_cuts = mag_cuts
-        min_mags = np.zeros(len(datamodel.filters))
-        for k, filtername in enumerate(obsdata.filters):
-            sfiltername = obsdata.data.resolve_alias(filtername)
-            sfiltername = sfiltername.replace("rate", "vega")
-            sfiltername = sfiltername.replace("RATE", "VEGA")
-            (keep,) = np.where(obsdata[sfiltername] < 99.0)
-            min_mags[k] = np.percentile(obsdata[keep][sfiltername], 90.0)
-
-        # max. mags from the gst observation cat.
-        mag_cuts = min_mags + tmp_cuts
 
     # --------------------
     # select SEDs
@@ -96,6 +81,24 @@ def make_ast_inputs(flux_bin_method=True):
             )
 
         else:
+
+            # construct magnitude cuts
+
+            mag_cuts = datamodel.ast_maglimit
+
+            if len(mag_cuts) == 1:
+                tmp_cuts = mag_cuts
+                min_mags = np.zeros(len(datamodel.filters))
+                for k, filtername in enumerate(obsdata.filters):
+                    sfiltername = obsdata.data.resolve_alias(filtername)
+                    sfiltername = sfiltername.replace("rate", "vega")
+                    sfiltername = sfiltername.replace("RATE", "VEGA")
+                    (keep,) = np.where(obsdata[sfiltername] < 99.0)
+                    min_mags[k] = np.percentile(obsdata[keep][sfiltername], 90.0)
+
+                # max. mags from the gst observation cat.
+                mag_cuts = min_mags + tmp_cuts
+
 
             N_models = datamodel.ast_models_selected_per_age
 

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -87,7 +87,6 @@ def make_ast_inputs(flux_bin_method=True):
             chosen_seds = pick_models_toothpick_style(
                 modelsedgrid_filename,
                 datamodel.filters,
-                mag_cuts,
                 Nfilters,
                 N_fluxes,
                 min_N_per_flux,


### PR DESCRIPTION
I noticed that `make_ast_input_list.pick_models_toothpick_style`, which does the flux bin AST selection method, had `mag_cuts` as an input even though the code doesn't use it, so I removed it.  I also moved the chunk of code in `tools/run/make_ast_inputs.py` that constructs `mag_cuts` so that it only runs if the random SED selection method is used.