### PR TITLE
Fix warnings in verify_params

### DIFF
--- a/beast/tools/tests/test_verify_warnings.py
+++ b/beast/tools/tests/test_verify_warnings.py
@@ -1,0 +1,46 @@
+import pytest
+from beast.tools import verify_params
+
+class datamodel_mock:
+    """A simple mock datamodel"""
+    obsfile = 'photometry.fits'
+    astfile = 'ast.fits'
+    logt = [6.0, 10.13, 0.05]
+    age_prior_model = {'name': 'flat_log'}
+    mass_prior_model = {'name': 'kroupa'}
+    z = [0.00452, 0.00254, 0.00143]
+    met_prior_model = {'name': 'flat'}
+    avs = [0.0, 4.0, 0.1]
+    av_prior_model = {'name': 'lognormal',
+                      'max_pos': 0.76,
+                      'sigma': 0.73,
+                      'N': 10.}
+    rvs = [3.0, 6.0, 1.0]
+    rv_prior_model = {'name': 'flat'}
+    fAs = [0.0, 1.0, 0.25]
+    fA_prior_model = {'name': 'flat'}
+
+class datamodel_mock_nofA(datamodel_mock):
+    """Mock datamodel w/ fAs=None"""
+    fAs = None
+
+class datamodel_mock_allowwarn(datamodel_mock_nofA):
+    """Mock datamodel w/ fAs=None and allow_warnings = True"""
+    allow_warnings = True
+
+def test_verifyparams_nowarning():
+    """Test: verify_params for case of no warnings or exceptions."""
+    with pytest.warns(None) as record:
+        verify_params.verify_input_format(datamodel_mock())
+    assert len(record) == 0
+
+def test_verifyparams_error():
+    """Test: verify_params for case of warning raising exception."""
+    with pytest.raises(UserWarning) as exc:
+        verify_params.verify_input_format(datamodel_mock_nofA())
+    assert exc.value.args[0] == "fAs is not defined."
+
+def test_verifyparams_allowwarn():
+    """Test: verify_params for case of warning with no exception."""
+    with pytest.warns(UserWarning, match="fAs is not defined."):
+        verify_params.verify_input_format(datamodel_mock_allowwarn())

--- a/beast/tools/tests/test_verify_warnings.py
+++ b/beast/tools/tests/test_verify_warnings.py
@@ -44,3 +44,33 @@ def test_verifyparams_allowwarn():
     """Test: verify_params for case of warning with no exception."""
     with pytest.warns(UserWarning, match="fAs is not defined."):
         verify_params.verify_input_format(datamodel_mock_allowwarn())
+
+class datamodel_mock_RV(datamodel_mock):
+    """Mock datamodel w/ single-valued R_V"""
+    rvs = [3.1, 3.1, 1.0]
+
+class datamodel_mock_noallowRV(datamodel_mock):
+    """Mock datamodel w/ single-valued R_V"""
+    rvs = [3.1, 3.1, 1.0]
+    allow_warnings = False
+
+class datamodel_mock_allowwarnRV(datamodel_mock_RV):
+    """Mock datamodel w/ single-valued R_V and allow_warnings = True"""
+    allow_warnings = True
+
+def test_verifyparams_errorRV():
+    """Test: verify_params for case of warning raising exception."""
+    with pytest.raises(UserWarning) as exc:
+        verify_params.verify_input_format(datamodel_mock_RV())
+    assert exc.value.args[0] == "Note: rvs grid is single-valued."
+
+def test_verifyparams_errorRV():
+    """Test: verify_params for case of warning raising exception."""
+    with pytest.raises(UserWarning) as exc:
+        verify_params.verify_input_format(datamodel_mock_noallowRV())
+    assert exc.value.args[0] == "Note: rvs grid is single-valued."
+
+def test_verifyparams_allowwarnRV():
+    """Test: verify_params for case of warning with no exception."""
+    with pytest.warns(UserWarning, match="Note: rvs grid is single-valued."):
+        verify_params.verify_input_format(datamodel_mock_allowwarnRV())

--- a/beast/tools/tests/test_verify_warnings.py
+++ b/beast/tools/tests/test_verify_warnings.py
@@ -64,8 +64,8 @@ def test_verifyparams_errorRV():
         verify_params.verify_input_format(datamodel_mock_RV())
     assert exc.value.args[0] == "Note: rvs grid is single-valued."
 
-def test_verifyparams_errorRV():
-    """Test: verify_params for case of warning raising exception."""
+def test_verifyparams_noallowRV():
+    """Test: verify_params when warn raising except w/ allow_warnings=False"""
     with pytest.raises(UserWarning) as exc:
         verify_params.verify_input_format(datamodel_mock_noallowRV())
     assert exc.value.args[0] == "Note: rvs grid is single-valued."

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -6,6 +6,7 @@ Created by Maria Kapala on Feb 24th 2017
 """
 from os.path import exists
 from numpy import inf
+import warnings
 
 
 def verify_range(param, param_name, param_lim):
@@ -34,7 +35,7 @@ def check_grid(param, param_name, param_lim):
 
     if (param_max - param_min) < param_step:
         if param_max - param_min == 0.0:
-            raise UserWarning("Note: " + param_name + " grid is single-valued.")
+            warnings.warn("Note: " + param_name + " grid is single-valued.")
         else:
             raise ValueError(param_name + " step value greater than (max-min)")
 
@@ -63,7 +64,7 @@ def verify_one_input_format(param, param_name, param_format, param_lim):
     if "list" in param_format:
         if not isinstance(param, list):
             if param is None:
-                raise UserWarning(param_name + " is not defined.")
+                warnings.warn(param_name + " is not defined.")
             else:
                 raise TypeError(param_name + " is not in the right format - a list.")
         elif "float" in param_format:

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -113,7 +113,8 @@ def verify_input_format(datamodel):
     try:
         if datamodel.allow_warnings:
             print('verify_input_format: using non-interrupting warnings')
-    except NameError:
+    except AttributeError:
+        print('verify_input_format: enable warning interrupt')
         warnings.simplefilter('error', UserWarning)
 
     parameters = [

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -110,6 +110,12 @@ def verify_input_format(datamodel):
 
     """
 
+    try:
+        if datamodel.allow_warnings:
+            print('verify_input_format: using non-interrupting warnings')
+    except NameError:
+        warnings.simplefilter('error', UserWarning)
+
     parameters = [
         datamodel.z,
         datamodel.obsfile,

--- a/beast/tools/verify_params.py
+++ b/beast/tools/verify_params.py
@@ -113,8 +113,9 @@ def verify_input_format(datamodel):
     try:
         if datamodel.allow_warnings:
             print('verify_input_format: using non-interrupting warnings')
+        else:
+            warnings.simplefilter('error', UserWarning)
     except AttributeError:
-        print('verify_input_format: enable warning interrupt')
         warnings.simplefilter('error', UserWarning)
 
     parameters = [

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -73,11 +73,11 @@ Define list of filternames as ``additional_filters`` and alter ``add_spectral_pr
 
 ``add_spectral_properties_kwargs = dict(filternames=filters + additional_filters)``
 
-Skip verify_params exit
-^^^^^^^^^^^^^^^^^^^^^^^
-Add ``noexit=True`` keyword to ``verify_input_format()`` call in run_beast.py:
+Allow non-interrupting warnings in verify_params
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Set ``allow_verify_warnings`` boolean variable in datamodel.py to allow non-interrupting warnings. Default: raise UserWarning exception.
 
-``verify_params.verify_input_format(datamodel, noexit=True)``
+``allow_verify_warnings = True``
 
 Remove constant SFH prior
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In #460, @jwuphysics swapped `exit()` interrupts with errors and warnings.  The non-interrupting warnings, which were previously handled by the `noexit` option, were not actually implemented as warnings but as interrupting errors.

This PR swaps the non-existent `UserWarning` with a `warnings.warn()` call (whose default type is UserWarning).