### PR TITLE
Fix string search for identifying bin#/sub# in file names

### DIFF
--- a/beast/tools/run/create_filenames.py
+++ b/beast/tools/run/create_filenames.py
@@ -130,8 +130,8 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
 
             for phot_file in photometry_files:
                 # get the sd/sub number
-                dpos = phot_file.find("_bin")
-                spos = phot_file.find("sub")
+                dpos = phot_file.rfind("_bin")
+                spos = phot_file.rfind("sub")
                 ppos = phot_file.rfind(".")
                 curr_sd = phot_file[dpos + 4 : spos - 1]
                 curr_sub = phot_file[spos + 3 : ppos]
@@ -288,8 +288,8 @@ def create_filenames(use_sd=True, nsubs=1, choose_sd_sub=None, choose_subgrid=No
 
             for phot_file in phot_file_list:
                 # get the sd/sub number
-                dpos = phot_file.find("_bin")
-                spos = phot_file.find("sub")
+                dpos = phot_file.rfind("_bin")
+                spos = phot_file.rfind("sub")
                 ppos = phot_file.rfind(".")
                 curr_sd = phot_file[dpos + 4 : spos - 1]
                 curr_sub = phot_file[spos + 3 : ppos]

--- a/beast/tools/run/create_obsmodel.py
+++ b/beast/tools/run/create_obsmodel.py
@@ -63,7 +63,7 @@ def create_obsmodel(use_sd=True, nsubs=1, nprocs=1, subset=[None, None], use_rat
 
         sd_list = []
         for ast_file in ast_file_list:
-            dpos = ast_file.find("_bin")
+            dpos = ast_file.rfind("_bin")
             ppos = ast_file.rfind(".")
             sd_list.append(ast_file[dpos + 4 : ppos])
         print("sd list: ", sd_list)

--- a/beast/tools/setup_batch_beast_trim.py
+++ b/beast/tools/setup_batch_beast_trim.py
@@ -51,7 +51,7 @@ def setup_batch_beast_trim(
         full_model_filename = seds_fname
 
     # photometry files
-    cat_files = sorted(glob.glob(datafile.replace(".fits", "*_sub*.fits")))
+    cat_files = sorted(glob.glob(datafile.replace(".fits", "*_bin*_sub*.fits")))
     n_cat_files = len(cat_files)
 
     # setup the subdirectory for the batch and log files
@@ -61,13 +61,13 @@ def setup_batch_beast_trim(
     filebase_list = []
     for cat_file in cat_files:
         # get the sd/sub number
-        dpos = cat_file.find("SD_")
-        spos = cat_file.find("sub")
+        dpos = cat_file.rfind("_bin")
+        spos = cat_file.rfind("sub")
         ppos = cat_file.rfind(".")
-        curr_sd = cat_file[dpos + 3 : spos - 1]
+        curr_sd = cat_file[dpos + 4 : spos - 1]
         curr_sub = cat_file[spos + 3 : ppos]
 
-        filebase_list.append("%s/%s_sd%s_sub%s" % (project, project, curr_sd, curr_sub))
+        filebase_list.append("%s/%s_bin%s_sub%s" % (project, project, curr_sd, curr_sub))
 
     # call the generic batch trim code
     generic_batch_trim(


### PR DESCRIPTION
There are a few places where the bin number and sub-bin number of a file are found by locating "_bin" and "sub" in the file name.  These were done with `.find()`, so if the file name had those sets of characters elsewhere, it would incorrectly use those positions.  I switched to `.rfind()`, since the bin/sub info will always be at the end of the file name.

Thanks @christinawlindberg for finding the bug!

This needs to be included in the production run branch.