### PR TITLE
distance grid and prior weights (fixes multidistance bug)

### DIFF
--- a/beast/physicsmodel/grid_weights_stars.py
+++ b/beast/physicsmodel/grid_weights_stars.py
@@ -11,6 +11,7 @@ for the non-uniform spacing.
 import numpy as np
 
 __all__ = [
+    "compute_distance_grid_weights",
     "compute_age_grid_weights",
     "compute_mass_grid_weights",
     "compute_metallicity_grid_weights",
@@ -136,3 +137,33 @@ def compute_metallicity_grid_weights(mets):
     mets_weights /= np.average(mets_weights)
 
     return mets_weights
+
+
+def compute_distance_grid_weights(dists):
+    """
+    Computes the distance weights to set a uniform prior on linear distance
+
+    Parameters
+    ----------
+    dists : numpy vector
+        distances
+
+    Returns
+    -------
+    dist_weights : numpy vector
+       weights to provide a flat distance
+    """
+    # sort
+    sindxs = np.argsort(dists)
+
+    # Compute the bin boundaries
+    dists_bounds = compute_bin_boundaries(dists[sindxs])
+
+    # compute the weights = mass bin widths
+    dists_weights = np.empty(len(dists))
+    dists_weights[sindxs] = np.diff(dists_bounds)
+
+    # normalize to avoid numerical issues (too small or too large)
+    dists_weights /= np.average(dists_weights)
+
+    return dists_weights

--- a/beast/physicsmodel/grid_weights_stars.py
+++ b/beast/physicsmodel/grid_weights_stars.py
@@ -99,7 +99,7 @@ def compute_mass_grid_weights(masses):
     # Compute the mass bin boundaries
     masses_bounds = compute_bin_boundaries(masses[sindxs])
 
-    # compute the weights = mass bin widths
+    # compute the weights = bin widths
     mass_weights = np.empty(len(masses))
     mass_weights[sindxs] = np.diff(masses_bounds)
 
@@ -129,7 +129,7 @@ def compute_metallicity_grid_weights(mets):
     # Compute the mass bin boundaries
     mets_bounds = compute_bin_boundaries(mets[sindxs])
 
-    # compute the weights = mass bin widths
+    # compute the weights = bin widths
     mets_weights = np.empty(len(mets))
     mets_weights[sindxs] = np.diff(mets_bounds)
 
@@ -154,13 +154,14 @@ def compute_distance_grid_weights(dists):
        weights to provide a flat distance
     """
     # sort
-    sindxs = np.argsort(dists)
+    tdists = np.array(dists)
+    sindxs = np.argsort(tdists)
 
     # Compute the bin boundaries
-    dists_bounds = compute_bin_boundaries(dists[sindxs])
+    dists_bounds = compute_bin_boundaries(tdists[sindxs])
 
-    # compute the weights = mass bin widths
-    dists_weights = np.empty(len(dists))
+    # compute the weights = bin widths
+    dists_weights = np.empty(len(tdists))
     dists_weights[sindxs] = np.diff(dists_bounds)
 
     # normalize to avoid numerical issues (too small or too large)

--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -8,7 +8,7 @@ from beast.physicsmodel import creategrid
 from beast.physicsmodel.stars import isochrone, stellib
 from beast.physicsmodel.stars.isochrone import ezIsoch
 from beast.physicsmodel.dust import extinction
-from beast.physicsmodel.grid_and_prior_weights import compute_age_mass_metallicity_weights
+from beast.physicsmodel.grid_and_prior_weights import compute_distance_age_mass_metallicity_weights
 
 __all__ = [
     "make_iso_table",
@@ -243,6 +243,7 @@ def make_spectral_grid(
 
 
 def add_stellar_priors(project, specgrid,
+                       distance_prior_model={'name': 'flat'},
                        age_prior_model={'name': 'flat'},
                        mass_prior_model={'name': 'kroupa'},
                        met_prior_model={'name': 'flat'},
@@ -259,6 +260,9 @@ def add_stellar_priors(project, specgrid,
 
     specgrid: grid.SpectralGrid object
         spectral grid to transform
+
+    distance_prior_model: dict
+        dict including prior model name and parameters
 
     age_prior_model: dict
         dict including prior model name and parameters
@@ -287,8 +291,9 @@ def add_stellar_priors(project, specgrid,
         if verbose:
             print("Make Prior Weights")
 
-        compute_age_mass_metallicity_weights(
+        compute_distance_age_mass_metallicity_weights(
             specgrid.grid,
+            distance_prior_model=distance_prior_model,
             age_prior_model=age_prior_model,
             mass_prior_model=mass_prior_model,
             met_prior_model=met_prior_model,

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -14,6 +14,7 @@ from beast.physicsmodel.grid_weights_stars import (
 )
 
 __all__ = [
+    "compute_distance_prior_weights",
     "compute_age_prior_weights",
     "compute_mass_prior_weights",
     "compute_metallicity_prior_weights",
@@ -197,7 +198,7 @@ def compute_metallicity_prior_weights(mets, met_prior_model):
     Returns
     -------
     metallicity_weights : numpy vector
-       weights to provide a flat metallicity
+       weights to provide the requested prior model
     """
     if met_prior_model["name"] == "flat":
         met_weights = np.full(len(mets), 1.0)
@@ -208,3 +209,30 @@ def compute_metallicity_prior_weights(mets, met_prior_model):
     met_weights /= np.average(met_weights)
 
     return met_weights
+
+
+def compute_distance_prior_weights(dists, dist_prior_model):
+    """
+    Computes the distance prior for the specified model
+
+    Parameters
+    ----------
+    dists : numpy vector
+        distances
+    dist_prior_model: dict
+        dict including prior model name and parameters
+
+    Returns
+    -------
+    dists_weights : numpy vector
+       weights to provide the requested prior model
+    """
+    if dist_prior_model["name"] == "flat":
+        dists_weights = np.full(len(dists), 1.0)
+    else:
+        raise NotImplementedError("input distance prior function not supported")
+
+    # normalize to avoid numerical issues (too small or too large)
+    dists_weights /= np.average(dists_weights)
+
+    return dists_weights

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -65,7 +65,7 @@ def compute_age_prior_weights(logages, age_prior_model):
         # assumes SFR(t) \propto e**(-t/tau) \propto e**(age/tau)
         # where age \propto -t (for age=t0-t) and tau in Gyr
         vals = (10 ** logages) / (age_prior_model["tau"] * 1e9)
-        age_weights = np.exp(vals)
+        age_weights = np.exp(-1.0 * vals)
     else:
         raise NotImplementedError(
             "input age prior ''{}'' function not supported".format(

--- a/beast/physicsmodel/tests/test_stellar_grid_weights.py
+++ b/beast/physicsmodel/tests/test_stellar_grid_weights.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from beast.physicsmodel.grid_weights_stars import compute_distance_grid_weights
+
+
+def test_flat_distance_grid_weight():
+    """
+    Test the flat distance grid weights
+    """
+    dists = [10., 100., 1000.]
+    expected_weights = [0.18181818, 1.0, 1.81818182]
+
+    weight = compute_distance_grid_weights(dists)
+
+    np.testing.assert_allclose(weight, expected_weights)

--- a/beast/physicsmodel/tests/test_stellar_prior_weights.py
+++ b/beast/physicsmodel/tests/test_stellar_prior_weights.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from beast.physicsmodel.prior_weights_stars import compute_distance_prior_weights
+
+
+def test_flat_distance_prior_weight():
+    """
+    Test the flat distance prior
+    """
+    dists = [10., 100., 1000.]
+    dist_prior_model = {"name": "flat"}
+    weight = compute_distance_prior_weights(dists, dist_prior_model)
+
+    np.testing.assert_allclose(weight, np.full((len(weight)), 1.0))

--- a/beast/tools/run/create_physicsmodel.py
+++ b/beast/tools/run/create_physicsmodel.py
@@ -81,7 +81,7 @@ def create_physicsmodel(nsubs=1, nprocs=1, subset=[None, None]):
     )
 
     # remove the isochrone points with logL=-9.999
-    oiso = ezIsoch(oiso.selectWhere("*","logL > -9"))
+    oiso = ezIsoch(oiso.selectWhere("*", "logL > -9"))
 
     if hasattr(datamodel, "add_spectral_properties_kwargs"):
         extra_kwargs = datamodel.add_spectral_properties_kwargs
@@ -113,6 +113,7 @@ def create_physicsmodel(nsubs=1, nprocs=1, subset=[None, None]):
         age_prior_model=datamodel.age_prior_model,
         mass_prior_model=datamodel.mass_prior_model,
         met_prior_model=datamodel.met_prior_model,
+        distance_prior_model=datamodel.distance_prior_model,
     )
 
     # --------------------

--- a/docs/beast_priors.rst
+++ b/docs/beast_priors.rst
@@ -177,7 +177,7 @@ The metallicity prior can be
 
   met_prior_model = {'name': 'flat'}
 
-Plot showing examples of the possible mass prior models with the parameters given above.
+Plot showing examples of the possible metallicity prior models with the parameters given above.
 
 .. plot::
 
@@ -202,6 +202,41 @@ Plot showing examples of the possible mass prior models with the parameters give
     plt.tight_layout()
     plt.show()
 
+Distance
+--------
+
+The distance prior can be
+
+1. Flat
+
+.. code-block:: python
+
+  distance_prior_model = {'name': 'flat'}
+
+Plot showing examples of the possible distance prior models with the parameters given above.
+
+.. plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from beast.physicsmodel.prior_weights_stars import compute_distance_prior_weights
+
+    fig, ax = plt.subplots()
+
+    # met grid with linear spacing
+    dists = np.linspace(8e6, 9e6)
+
+    distance_prior_models = [{"name": "flat"},]
+
+    for mp_mod in distance_prior_models:
+        ax.plot(dists, compute_distance_prior_weights(dists, mp_mod), label=mp_mod["name"])
+
+    ax.set_ylabel("probability")
+    ax.set_xlabel("distance [pc]")
+    ax.legend(loc="best")
+    plt.tight_layout()
+    plt.show()
 
 Extinction
 ==========
@@ -416,9 +451,3 @@ given by sigma.
     ax.legend(loc="best")
     plt.tight_layout()
     plt.show()
-
-
-Distance
-========
-
-[TBD]


### PR DESCRIPTION
Fixes the bug that resulted in NaNs for the grid weights when more than 1 distance was present in the grid. Closes #514.

As part of this fix, it made sense to implement the code to explicitly compute the grid and prior weights for distance.  Done similar to how the same for metallicity is handled.  Like metallicity, a flat prior is the only currently supported prior shape.  Other distance priors can be easily implemented now.  Closes #45.