### PR TITLE
Changes for more high mass stars in simulated catalogs

### DIFF
--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -160,6 +160,7 @@ def gen_SimObs_from_sedgrid(
     compl_filter="F475W",
     ranseed=None,
     vega_fname=None,
+    use_weight='weight',
 ):
     """
     Generate simulated observations using the physics and observation grids.
@@ -193,6 +194,10 @@ def gen_SimObs_from_sedgrid(
         filename for the vega info
         usefule for testing
 
+    use_weight : string (default='weight')
+        Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
+        choose the weighting for SED selection.
+
     Returns
     -------
     simtable : astropy Table
@@ -224,7 +229,7 @@ def gen_SimObs_from_sedgrid(
     # using both as the grid weight needed to account for the finite size
     #   of each grid bin
     # if we change to interpolating between grid points, need to rethink this
-    gridweights = sedgrid["weight"] * model_compl[:, filter_k]
+    gridweights = sedgrid[use_weight] * model_compl[:, filter_k]
     # need to sum to 1
     gridweights = gridweights / np.sum(gridweights)
 

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -160,7 +160,7 @@ def gen_SimObs_from_sedgrid(
     compl_filter="F475W",
     ranseed=None,
     vega_fname=None,
-    use_weight='weight',
+    weight_to_use='weight',
 ):
     """
     Generate simulated observations using the physics and observation grids.
@@ -194,7 +194,7 @@ def gen_SimObs_from_sedgrid(
         filename for the vega info
         usefule for testing
 
-    use_weight : string (default='weight')
+    weight_to_use : string (default='weight')
         Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
         choose the weighting for SED selection.
 
@@ -229,7 +229,7 @@ def gen_SimObs_from_sedgrid(
     # using both as the grid weight needed to account for the finite size
     #   of each grid bin
     # if we change to interpolating between grid points, need to rethink this
-    gridweights = sedgrid[use_weight] * model_compl[:, filter_k]
+    gridweights = sedgrid[weight_to_use] * model_compl[:, filter_k]
     # need to sum to 1
     gridweights = gridweights / np.sum(gridweights)
 

--- a/beast/physicsmodel/prior_weights_stars.py
+++ b/beast/physicsmodel/prior_weights_stars.py
@@ -154,28 +154,37 @@ def compute_mass_prior_weights(masses, mass_prior_model):
       Unnormalized IMF integral for each input mass
       integration is done between each bin's boundaries
     """
-    # sort the initial mass along this isochrone
-    sindxs = np.argsort(masses)
 
-    # Compute the mass bin boundaries
-    mass_bounds = compute_bin_boundaries(masses[sindxs])
+    # if the prior is an IMF:
+    if mass_prior_model["name"] in ["kroupa", "salpeter"]:
 
-    # compute the weights = mass bin widths
-    mass_weights = np.empty(len(masses))
+        # sort the initial mass along this isochrone
+        sindxs = np.argsort(masses)
 
-    # integrate the IMF over each bin
-    if mass_prior_model["name"] == "kroupa":
-        imf_func = imf_kroupa
-    elif mass_prior_model["name"] == "salpeter":
-        imf_func = imf_salpeter
+        # Compute the mass bin boundaries
+        mass_bounds = compute_bin_boundaries(masses[sindxs])
+
+        # compute the weights = mass bin widths
+        mass_weights = np.empty(len(masses))
+
+        # integrate the IMF over each bin
+        if mass_prior_model["name"] == "kroupa":
+            imf_func = imf_kroupa
+        if mass_prior_model["name"] == "salpeter":
+            imf_func = imf_salpeter
+
+        # calculate the average prior in each mass bin
+        for i in range(len(masses)):
+            mass_weights[sindxs[i]] = (quad(imf_func, mass_bounds[i], mass_bounds[i + 1]))[
+                0
+            ] / (mass_bounds[i + 1] - mass_bounds[i])
+
+    # if the prior is flat:
+    elif mass_prior_model["name"] == "flat_linear":
+        mass_weights = np.full(len(masses), 1.0)
+
     else:
         raise NotImplementedError("input mass prior function not supported")
-
-    # calculate the average prior in each mass bin
-    for i in range(len(masses)):
-        mass_weights[sindxs[i]] = (quad(imf_func, mass_bounds[i], mass_bounds[i + 1]))[
-            0
-        ] / (mass_bounds[i + 1] - mass_bounds[i])
 
     # normalize to avoid numerical issues (too small or too large)
     mass_weights /= np.average(mass_weights)

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -14,7 +14,7 @@ def simulate_obs(
     output_catalog,
     nsim=100,
     compl_filter="F475W",
-    use_weight='weight',
+    weight_to_use='weight',
     ranseed=None,
 ):
     """
@@ -43,7 +43,7 @@ def simulate_obs(
     compl_filter : string (default='F475W')
         filter name to use for completeness
 
-    use_weight : string (default='weight')
+    weight_to_use : string (default='weight')
         Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
         choose the weighting for SED selection.
 
@@ -77,7 +77,7 @@ def simulate_obs(
             noisegrid,
             nsim=samples_per_grid,
             compl_filter=compl_filter,
-            use_weight=use_weight,
+            weight_to_use=weight_to_use,
             ranseed=ranseed,
         )
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":  # pragma: no cover
         "--compl_filter", default="F475W", help="filter name to use for completeness"
     )
     parser.add_argument(
-        "--use_weight",
+        "--weight_to_use",
         default="weight",
         type=str,
         help="""Set to either 'weight' (prior+grid), 'prior_weight', or
@@ -139,6 +139,6 @@ if __name__ == "__main__":  # pragma: no cover
         args.output_catalog,
         nsim=args.nsim,
         compl_filter=args.compl_filter,
-        use_weight=args.use_weight,
+        weight_to_use=args.weight_to_use,
         ranseed=args.ranseed,
     )

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -14,6 +14,7 @@ def simulate_obs(
     output_catalog,
     nsim=100,
     compl_filter="F475W",
+    use_weight='weight',
     ranseed=None,
 ):
     """
@@ -41,6 +42,10 @@ def simulate_obs(
 
     compl_filter : string (default='F475W')
         filter name to use for completeness
+
+    use_weight : string (default='weight')
+        Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
+        choose the weighting for SED selection.
 
     ranseed : int
         seed for random number generator
@@ -72,6 +77,7 @@ def simulate_obs(
             noisegrid,
             nsim=samples_per_grid,
             compl_filter=compl_filter,
+            use_weight=use_weight,
             ranseed=ranseed,
         )
 
@@ -115,6 +121,13 @@ if __name__ == "__main__":  # pragma: no cover
         "--compl_filter", default="F475W", help="filter name to use for completeness"
     )
     parser.add_argument(
+        "--use_weight",
+        default="weight",
+        type=str,
+        help="""Set to either 'weight' (prior+grid), 'prior_weight', or
+        'grid_weight' to choose the weighting for SED selection."""
+    )
+    parser.add_argument(
         "--ranseed", default=None, type=int, help="seed for random number generator"
     )
     args = parser.parse_args()
@@ -126,5 +139,6 @@ if __name__ == "__main__":  # pragma: no cover
         args.output_catalog,
         nsim=args.nsim,
         compl_filter=args.compl_filter,
+        use_weight=args.use_weight,
         ranseed=args.ranseed,
     )

--- a/docs/beast_priors.rst
+++ b/docs/beast_priors.rst
@@ -136,6 +136,15 @@ The two mass function supported are:
 
   mass_prior_model = {'name': 'salpeter'}
 
+There is also a flat mass prior.  This is useful for creating grids for BEAST
+verification (see :doc:`Simulations <simulations>`), and should not be
+used for a standard fitting run.
+
+.. code-block:: python
+
+  mass_prior_model = {'name': 'flat_linear'}
+
+
 Plot showing examples of the possible mass prior models with the parameters given above.
 
 .. plot::
@@ -152,7 +161,8 @@ Plot showing examples of the possible mass prior models with the parameters give
 
     mass_prior_models = [
         {"name": "kroupa"},
-        {"name": "salpeter"}
+        {"name": "salpeter"},
+        {"name": "flat_linear"}
     ]
 
     for mp_mod in mass_prior_models:

--- a/docs/beast_priors.rst
+++ b/docs/beast_priors.rst
@@ -142,7 +142,7 @@ used for a standard fitting run.
 
 .. code-block:: python
 
-  mass_prior_model = {'name': 'flat_linear'}
+  mass_prior_model = {'name': 'flat'}
 
 
 Plot showing examples of the possible mass prior models with the parameters given above.
@@ -162,7 +162,7 @@ Plot showing examples of the possible mass prior models with the parameters give
     mass_prior_models = [
         {"name": "kroupa"},
         {"name": "salpeter"},
-        {"name": "flat_linear"}
+        {"name": "flat"}
     ]
 
     for mp_mod in mass_prior_models:

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -42,10 +42,10 @@ from the physicsgrid file.  The names of the observed columns are
 the observed data are given).
 
 When creating simulated observations, using the standard IMF mass prior will
-skew your catalog to lower-mass stars.  If you wish to sample the full range of
-stellar masses, you can set the mass prior to `{'name': 'flat'}` and the
-age prior to `{'name': 'flat_log'}` in `datamodel.py` before creating the
-model grid.
+skew your catalog to lower-mass stars.  If you wish to sample an equal number of
+stars across all masses, use a flat IMF and a log-flat age prior.  To do this,
+set the mass prior to `{'name': 'flat'}` and the age prior to
+`{'name': 'flat_log'}` in `datamodel.py` before creating the model grid.
 
 *********
 Truncheon

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -26,12 +26,14 @@ of this file will determine the type of file output (e.g. filebase.fits for
 a FITS file).
 The number of observations to simulate is given by the `--nsim` parameter.
 The filter to use for the completeness function is given by the
-`--compl_filter` parameter.
+`--compl_filter` parameter.  By default, the SEDs are randomly chosen, and
+weighted by their grid+prior weights; this can be changed with the `--use_weight`
+parameter.
 
 .. code-block:: console
 
    $ python simulate_obs.py physicsgrid obsgrid outfile \
-                --nsim 200 --compl_filter f475w
+                --nsim 200 --compl_filter F475W
 
 The output file gives the simulated data in the observed data columns
 identified in the physicsgrid file along with all the model parameters

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -41,6 +41,12 @@ from the physicsgrid file.  The names of the observed columns are
 `band_rate` and the units are normalized Vega fluxes (to match how
 the observed data are given).
 
+When creating simulated observations, using the standard IMF mass prior will
+skew your catalog to lower-mass stars.  If you wish to sample the full range of
+stellar masses, you can set the mass prior to `{'name': 'flat_linear'}` and the
+age prior to `{'name': 'flat_log'}` in `datamodel.py` before creating the
+model grid.
+
 *********
 Truncheon
 *********

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -43,7 +43,7 @@ the observed data are given).
 
 When creating simulated observations, using the standard IMF mass prior will
 skew your catalog to lower-mass stars.  If you wish to sample the full range of
-stellar masses, you can set the mass prior to `{'name': 'flat_linear'}` and the
+stellar masses, you can set the mass prior to `{'name': 'flat'}` and the
 age prior to `{'name': 'flat_log'}` in `datamodel.py` before creating the
 model grid.
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -27,8 +27,8 @@ a FITS file).
 The number of observations to simulate is given by the `--nsim` parameter.
 The filter to use for the completeness function is given by the
 `--compl_filter` parameter.  By default, the SEDs are randomly chosen, and
-weighted by their grid+prior weights; this can be changed with the `--use_weight`
-parameter.
+weighted by their grid+prior weights; this can be changed with the
+`--weight_to_use` parameter.
 
 .. code-block:: console
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -42,8 +42,8 @@ from the physicsgrid file.  The names of the observed columns are
 the observed data are given).
 
 When creating simulated observations, using the standard IMF mass prior will
-skew your catalog to lower-mass stars.  If you wish to sample an equal number of
-stars across all masses, use a flat IMF and a log-flat age prior.  To do this,
+skew your catalog to lower-mass stars.  If you wish to have similar weights for
+stars of all masses, use a flat IMF and a log-flat age prior.  To do this,
 set the mass prior to `{'name': 'flat'}` and the age prior to
 `{'name': 'flat_log'}` in `datamodel.py` before creating the model grid.
 


### PR DESCRIPTION
As described in #517, the simulations weren't making high mass stars.  I've made two changes to improve this: 
* The code to create simulated observations (`tools/simulate_obs.py`, `gen_SimObs_from_sedgrid` in `observationmodel/observations.py`) now had a keyword `use_weight`.  The user can choose `weight` (prior+grid), `weight_prior`, or `weight_grid` to choose the weighting for selecting of SEDs.
* I added a flat mass prior, so the high mass stars are chosen at more similar rates to low mass stars.

I also updated the docs to describe these.

Closes #517 