### PR TITLE
Updates to remove_filters.py

### DIFF
--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -12,54 +12,139 @@ from beast.physicsmodel.grid import FileSEDGrid, SpectralGrid
 import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
 
 
-def remove_filters_from_files(catfile, physgrid, obsgrid, outbase, rm_filters):
+def remove_filters_from_files(
+    catfile,
+    physgrid=None,
+    obsgrid=None,
+    outbase=None,
+    physgrid_outfile=None,
+    rm_filters=None,
+):
+    """
+    Remove filters from catalog, physics grid, and/or obsmodel grid.  This has
+    two primary use cases:
 
-    # remove the requested filters from the catalog file
+    1. When making simulated observations, you want to test how your fit quality
+       changes with different combinations of filters.  In that case, put in
+       files for both `physgrid` and `obsgrid`.  Set `rm_filters` to the
+       filter(s) you wish to remove, and they will be removed both from those
+       and from the catalog file.
+
+    2. When running the BEAST, you have a master physics model grid with all
+       filters present in the survey, but some fields don't have observations in
+       all of those filters.  In that case, put the master grid in `physgrid`
+       and set `rm_filters` to None.  The catalog will be used to determine the
+       filters to remove (if any).  `obsgrid` should be left as None, because in
+       this use case, the obsmodel grid has not yet been generated.
+
+
+    Parameters
+    ----------
+    catfile : string
+        file name of photometry catalog
+
+    physgrid : string (default=None)
+        If set, remove filters from this physics model grid
+
+    obsgrid : string (default=None)
+        If set, remove filters from this obsmodel grid
+
+    outbase : string (default=None)
+        Path+file to prepend to all output file names.  Useful for case 1 above.
+
+    physgrid_outfile : string (default=None)
+        Path+name of the output physics model grid.  Useful for case 2 above.
+
+    rm_filters : string or list of strings (default=None)
+        If set, these are the filters to remove from all of the files.  If not
+        set, only the filters present in catfile will be retained in physgrid
+        and/or obsgrid.
+
+    """
+
+    # read in the photometry catalog
     cat = Table.read(catfile)
-    for cfilter in rm_filters:
-        colname = "{}_rate".format(cfilter)
-        if colname in cat.colnames:
-            cat.remove_column(colname)
+
+    # if set, remove the requested filters from the catalog
+    if rm_filters is not None:
+        for cfilter in np.atleast_1d(rm_filters):
+            colname = "{}_rate".format(cfilter)
+            if colname in cat.colnames:
+                cat.remove_column(colname)
+            else:
+                print("{} not in catalog file".format(colname))
+        cat.write("{}_cat.fits".format(outbase), overwrite=True)
+
+    # if not set, extract the filter names that are present
+    if rm_filters is None:
+        cat_filters = [f[:-5] for f in cat.colnames if f[-4:].lower() == 'rate']
+
+
+    # if set, process the SED grid
+    if physgrid is not None:
+
+        # read in the sed grid
+        g0 = FileSEDGrid(physgrid, backend="cache")
+
+        # extract info
+        filters = g0.header["filters"].split(" ")
+        shortfilters = [(cfilter.split("_"))[-1].lower() for cfilter in filters]
+        nlamb = []
+        nfilters = []
+        rindxs = []
+
+        # loop through filters and determine what needs deleting
+        for csfilter, clamb, cfilter in zip(shortfilters, g0.lamb, filters):
+
+            # if the user chose the filters to remove
+            if rm_filters is not None:
+                if csfilter not in np.atleast_1d(rm_filters):
+                    nlamb.append(clamb)
+                    nfilters.append(cfilter)
+                else:
+                    rindxs.append(shortfilters.index(csfilter))
+
+            # if the removed filters are determined from the catalog file
+            if rm_filters is None:
+                if csfilter in cat_filters:
+                    nlamb.append(clamb)
+                    nfilters.append(cfilter)
+                else:
+                    rindxs.append(shortfilters.index(csfilter))
+
+        # delete column(s)
+        if len(rindxs) > 0:
+            nseds = np.delete(g0.seds, rindxs, 1)
+
+        print("orig filters: {}".format(" ".join(filters)))
+        print(" new filters: {}".format(" ".join(nfilters)))
+
+        # save the modified grid
+        g = SpectralGrid(np.array(nlamb), seds=nseds, grid=g0.grid, backend="memory")
+        g.grid.header["filters"] = " ".join(nfilters)
+        if physgrid_outfile is not None:
+            g.writeHDF(physgrid_outfile)
+        elif outbase is not None:
+            g.writeHDF("{}_sed.grid.hd5".format(outbase))
         else:
-            print("{} not in catalog file".format(colname))
-    cat.write("{}_cat.fits".format(outbase), overwrite=True)
+            raise ValueError('Need to set either outbase or physgrid_outfile')
 
-    # get the sed grid and process
-    g0 = FileSEDGrid(physgrid, backend="cache")
-    filters = g0.header["filters"].split(" ")
-    shortfilters = [(cfilter.split("_"))[-1].lower() for cfilter in filters]
-    nlamb = []
-    nfilters = []
-    rindxs = []
-    for csfilter, clamb, cfilter in zip(shortfilters, g0.lamb, filters):
-        if csfilter not in rm_filters:
-            nlamb.append(clamb)
-            nfilters.append(cfilter)
-        else:
-            rindxs.append(shortfilters.index(csfilter))
-    nseds = np.delete(g0.seds, rindxs, 1)
 
-    print("orig filters: {}".format(" ".join(filters)))
-    print(" new filters: {}".format(" ".join(nfilters)))
-
-    g = SpectralGrid(np.array(nlamb), seds=nseds, grid=g0.grid, backend="memory")
-    g.grid.header["filters"] = " ".join(nfilters)
-    g.writeHDF("{}_sed.grid.hd5".format(outbase))
-
-    # get and process the observation model
-    obsgrid = noisemodel.get_noisemodelcat(obsgrid)
-    with tables.open_file("{}_noisemodel.grid.hd5".format(outbase), "w") as outfile:
-        outfile.create_array(
-            outfile.root, "bias", np.delete(obsgrid.root.bias, rindxs, 1)
-        )
-        outfile.create_array(
-            outfile.root, "error", np.delete(obsgrid.root.error, rindxs, 1)
-        )
-        outfile.create_array(
-            outfile.root,
-            "completeness",
-            np.delete(obsgrid.root.completeness, rindxs, 1),
-        )
+    # if set, process the observation model
+    if obsgrid is not None:
+        obsgrid = noisemodel.get_noisemodelcat(obsgrid)
+        with tables.open_file("{}_noisemodel.grid.hd5".format(outbase), "w") as outfile:
+            outfile.create_array(
+                outfile.root, "bias", np.delete(obsgrid.root.bias, rindxs, 1)
+            )
+            outfile.create_array(
+                outfile.root, "error", np.delete(obsgrid.root.error, rindxs, 1)
+            )
+            outfile.create_array(
+                outfile.root,
+                "completeness",
+                np.delete(obsgrid.root.completeness, rindxs, 1),
+            )
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -67,15 +152,48 @@ if __name__ == "__main__":  # pragma: no cover
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument("catfile", help="filename of photometry catalog")
-    parser.add_argument("physgrid", help="filename of physics grid")
-    parser.add_argument("obsgrid", help="filename of observation/nosie grid")
     parser.add_argument(
-        "outbase", default="lessfilters", help="filename for simulated observations"
+        "--physgrid",
+        type=str,
+        default=None,
+        help="If set, remove filters from this physics model grid file"
     )
-    parser.add_argument("--rm_filters", type=str, nargs="*", help="filters to remove")
+    parser.add_argument(
+        "--obsgrid",
+        type=str,
+        default=None,
+        help="If set, remove filters from this observation/noisemodel grid file"
+    )
+    parser.add_argument(
+        "--outbase",
+        type=str,
+        default=None,
+        help="Path+file to prepend to all output file names"
+    )
+    parser.add_argument(
+        "--physgrid_outfile",
+        type=str,
+        default=None,
+        help="""Path+name of the output physics model grid. Takes precendence
+        over the default file name constructed from outbase."""
+    )
+    parser.add_argument(
+        "--rm_filters",
+        type=str,
+        nargs="*",
+        default=None,
+        help="""If set, these are the filters to remove from all of the files.
+        If not set, only the filters present in catfile will be retained in
+        physgrid and/or obsgrid."""
+    )
     args = parser.parse_args()
 
-    # do the merge
+    # do the filter removal
     remove_filters_from_files(
-        args.catfile, args.physgrid, args.obsgrid, args.outbase, args.rm_filters
+        args.catfile,
+        physgrid=args.physgrid,
+        obsgrid=args.obsgrid,
+        outbase=args.outbase,
+        physgrid_outfile=args.physgrid_outfile,
+        rm_filters=args.rm_filters,
     )

--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -28,14 +28,17 @@ def remove_filters_from_files(
        changes with different combinations of filters.  In that case, put in
        files for both `physgrid` and `obsgrid`.  Set `rm_filters` to the
        filter(s) you wish to remove, and they will be removed both from those
-       and from the catalog file.
+       and from the catalog file.  The three new files will be output with the
+       name prefix set in `outbase`.
 
     2. When running the BEAST, you have a master physics model grid with all
        filters present in the survey, but some fields don't have observations in
        all of those filters.  In that case, put the master grid in `physgrid`
        and set `rm_filters` to None.  The catalog will be used to determine the
        filters to remove (if any).  `obsgrid` should be left as None, because in
-       this use case, the obsmodel grid has not yet been generated.
+       this use case, the obsmodel grid has not yet been generated.  The output
+       physics model grid will be named using the filename in `physgrid_outfile`
+       (if given) or with the prefix in `outbase`.
 
 
     Parameters
@@ -134,7 +137,7 @@ def remove_filters_from_files(
         if physgrid_outfile is not None:
             g.writeHDF(physgrid_outfile)
         elif outbase is not None:
-            g.writeHDF("{}_sed.grid.hd5".format(outbase))
+            g.writeHDF("{}_seds.grid.hd5".format(outbase))
         else:
             raise ValueError('Need to set either outbase or physgrid_outfile')
 

--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -72,8 +72,10 @@ def remove_filters_from_files(
     if rm_filters is not None:
         for cfilter in np.atleast_1d(rm_filters):
             colname = "{}_rate".format(cfilter)
-            if colname in cat.colnames:
-                cat.remove_column(colname)
+            if colname.upper() in cat.colnames:
+                cat.remove_column(colname.upper())
+            elif colname.lower() in cat.colnames:
+                cat.remove_column(colname.lower())
             else:
                 print("{} not in catalog file".format(colname))
         cat.write("{}_cat.fits".format(outbase), overwrite=True)
@@ -91,7 +93,7 @@ def remove_filters_from_files(
 
         # extract info
         filters = g0.header["filters"].split(" ")
-        shortfilters = [(cfilter.split("_"))[-1].lower() for cfilter in filters]
+        shortfilters = [(cfilter.split("_"))[-1].upper() for cfilter in filters]
         nlamb = []
         nfilters = []
         rindxs = []
@@ -125,6 +127,8 @@ def remove_filters_from_files(
         # delete column(s)
         if len(rindxs) > 0:
             nseds = np.delete(g0.seds, rindxs, 1)
+        else:
+            nseds = g0.seds
         for rcol in rgridcols:
             g0.grid.delCol(rcol)
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -75,17 +75,17 @@ simulations with the BEAST.  A quicker way to do this is to create the
 physics/observation grid set with the full set of desired filters, create
 the desired simulations, remove filters from the model and simulations as
 needed, and then fit with the BEAST.  This has the benefit of the simulations
-with different filter sets are exactly the same expect for the removed filters.
+with different filter sets are exactly the same except for the removed filters.
 
 As an example, to remove the filters F275W and F336W from the simulated
-observations contained in 'catfile' and the 'physgrid'/'obsgrid' set of models
-use the following command.
+observations contained in 'catfile.fits' and the 'physgrid.hd5'/'obsgrid.hd5'
+set of models use the following command.
 
 .. code-block:: console
 
-   $ python remove_filters.py catfile physgrid obsgrid outbase \
-                --rm_filters F275W F336W
+   $ python remove_filters.py catfile.fits --physgrid physgrid.hd5 \
+        --obsgrid obsgrid.hd5 --outbase outbase --rm_filters F275W F336W
 
 New physics/observation model grids and simulated observation files are
-created as 'outbase_sed.grid.hd5', 'outbase_noisemodel.grid.hd5', and
+created as 'outbase_seds.grid.hd5', 'outbase_noisemodel.grid.hd5', and
 'outbase_cat.fits'.

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -105,7 +105,22 @@ To create a physics model grid with 5 subgrids:
 
      $ python -m beast.tools.run.create_physicsmodel --nsubs=5
 
-If you would like to examine some of all of the grid values in the physics model,
+If you're running the BEAST on a survey in which different fields have different
+filters, you may wish to save time by creating a master grid with all possible
+filters and just copying out the subset of filters you need for each field.  To
+do this, create a `datamodel.py` file with all relevant filters listed in
+`filters` and `basefilters`, and run `create_physicsmodel` as above.  Then use
+`remove_filters` to create each modified grid.  The list of filters to remove
+will be determined by what's present in the input catalog file.  If you're using
+subgrids, repeat the command for each subgrid.
+
+  .. code-block:: console
+
+     $ python -m beast.tools.remove_filters.py catfile.fits \
+         --physgrid master_physgrid.hd5 --physgrid_outfile new_physgrid.hd5
+
+
+If you would like to examine some or all of the grid values in a physics model,
 you can use the `read_sed_data` function in `tools/read_beast_data.py`.  This
 function can also be set to just extract the list of parameter names.
 


### PR DESCRIPTION
I've changed `tools/remove_filters.py` a bit so it's more flexible.  Now it can serve two use cases (I've copied the descriptions over from the docstring):
```
1. When making simulated observations, you want to test how your fit quality
   changes with different combinations of filters.  In that case, put in
   files for both `physgrid` and `obsgrid`.  Set `rm_filters` to the
   filter(s) you wish to remove, and they will be removed both from those
   and from the catalog file.  The three new files will be output with the
   name prefix set in `outbase`.

2. When running the BEAST, you have a master physics model grid with all
   filters present in the survey, but some fields don't have observations in
   all of those filters.  In that case, put the master grid in `physgrid`
   and set `rm_filters` to None.  The catalog will be used to determine the
   filters to remove (if any).  `obsgrid` should be left as None, because in
   this use case, the obsmodel grid has not yet been generated.  The output
   physics model grid will be named using the filename in `physgrid_outfile`
   (if given) or with the prefix in `outbase`.
```
I've updated the docs (both for Simulations and Workflow) with info about these options.