### PR TITLE
add max A_V parameter to extinguished O star probability

### DIFF
--- a/beast/tools/star_type_probability.py
+++ b/beast/tools/star_type_probability.py
@@ -42,8 +42,8 @@ def star_type_probability(
 
     ext_O_star_params : dict or None
         Set to a dictionary to override the default cuts for extinguished early
-        type stars.  Allowed keywords are 'min_M_ini' (float) and 'min_Av'
-        (float).
+        type stars.  Allowed keywords are 'min_M_ini' (float), 'min_Av' (float),
+        and 'max_Av' (float).
 
     dusty_agb_params : dict or None
         Set to a dictionary to override the default cuts for dusty AGB stars
@@ -153,11 +153,12 @@ def star_type_probability(
         return star_prob
 
 
-def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5):
+def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5, max_Av=99):
     """
     Calculate the probability that each star is an extinguished O star:
     * initial mass >= 10 Msun
     * A_V >= 0.5 mag
+    There's a max A_V option to avoid possible high-Av artifacts.
 
     Some useful references for O/B stars
     https://ui.adsabs.harvard.edu/abs/2019A%26A...625A.104R/abstract
@@ -177,6 +178,9 @@ def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5):
 
     min_Av : float (default=0.5)
         minimum Av (magnitudes)
+
+    max_Av : float (default=99)
+        maximum Av (magnitudes)
 
     Returns
     -------
@@ -202,7 +206,9 @@ def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5):
     av_bins = av_bins.reshape(-1)
     mass_bins = mass_bins.reshape(-1)
 
-    keep = np.where((mass_bins >= min_M_ini) & (av_bins >= min_Av))[0]
+    keep = np.where(
+        (mass_bins >= min_M_ini) & (av_bins >= min_Av) & (av_bins <= max_Av)
+    )[0]
 
     return np.sum(prob_data[:,keep], axis=1)
 

--- a/docs/analysis_tools.rst
+++ b/docs/analysis_tools.rst
@@ -17,8 +17,9 @@ added.  When there are cuts along two parameters, the 2D PDFs are utilized.  If
 
 * Extinguished high mass stars (`star_type_probability.ext_O_star`): Stars above
   a certain mass (default `M_ini` > 10 solar masses) with some minimum
-  foreground dust column (default `Av` > 0.5 magnitudes).  These are candidates
-  for follow-up UV spectroscopy for extinction curves.
+  foreground dust column (default `Av` > 0.5 magnitudes).  You may also wish to
+  set a maximum `Av` to avoid artifacts (such as the dusty AGB stars).  These
+  stars are candidates for follow-up UV spectroscopy for extinction curves.
 * Dusty AGB stars (`star_type_probability.dusty_agb`): As described in
   :doc:`Known Issues <beast_issues>`, the BEAST does not include models for
   dusty AGB stars, and many of them are incorrectly fit as heavily extinguished
@@ -36,7 +37,7 @@ Below, we show an example for extinction curve candidates in phat_small.
           'beast_example_phat_pdf1d.fits',
           'beast_example_phat_pdf2d.fits',
           output_filebase=None,
-          ext_O_star_params={'min_M_ini':10, 'min_Av':0.5}
+          ext_O_star_params={'min_M_ini':10, 'min_Av':0.5, 'max_Av':5}
       )
   >>> # stars with >80% likelihood of being extinguished massive stars
   >>> np.where(star_prob['ext_O_star'] > 0.8)[0] #doctest: +SKIP


### PR DESCRIPTION
Currently, the code that identifies extinguished O stars lets you set a minimum mass and minimum A_V.  However, as I discovered while working on an HST proposal, there are a fair number of VERY high A_V stars that are selected this way (presumably the dusty AGB failure mode?).  So I added an optional maximum A_V input.  Docs are also updated accordingly.