### PR TITLE
Fix for ambiguous filters in remove_filters

### DIFF
--- a/beast/tools/read_beast_data.py
+++ b/beast/tools/read_beast_data.py
@@ -144,7 +144,7 @@ def read_sed_data(
         grid_param_list = list(sed_hdf["grid"][()].dtype.names)
         # return that if the user is so inclined
         if return_params:
-            return grid_param_list + ["seds", "lamb"]
+            return grid_param_list + ["seds", "lamb", "filters"]
         if param_list == "all":
             param_list = grid_param_list
 
@@ -156,6 +156,8 @@ def read_sed_data(
             # wavelengths of the filters -or- SED photometry values
             elif (param == "lamb") or (param == "seds"):
                 sed_data[param] = sed_hdf[param][()]
+            elif param == "filters":
+                sed_data[param] = sed_hdf["grid"].attrs["filters"].decode().split(" ")
             else:
                 raise ValueError("parameter {0} not found in SED grid".format(param))
 

--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -90,7 +90,7 @@ def remove_filters_from_files(
 
     # if rm_filters not set, extract the filter names that are present
     if rm_filters is None:
-        cat_filters = [f[:-5].upper() for f in cat.colnames if f[-4:].lower() == 'rate']
+        cat_filters = [f[:-5].upper() for f in cat.colnames if f[-4:].lower() == "rate"]
 
     # if beast_filt is set, make a list of the short versions
     if beast_filt is not None:
@@ -146,7 +146,6 @@ def remove_filters_from_files(
                             if cfilter in grid_col:
                                 rgridcols.append(grid_col)
 
-
             # --------------------------
             # if the removed filters are determined from the catalog file
             if rm_filters is None:
@@ -177,8 +176,6 @@ def remove_filters_from_files(
                         if cfilter in grid_col:
                             rgridcols.append(grid_col)
 
-
-
         # delete column(s)
         nseds = np.delete(g0.seds, rindxs, 1)
         nlamb = np.delete(g0.lamb, rindxs, 0)
@@ -197,7 +194,7 @@ def remove_filters_from_files(
         elif outbase is not None:
             g.writeHDF("{}_seds.grid.hd5".format(outbase))
         else:
-            raise ValueError('Need to set either outbase or physgrid_outfile')
+            raise ValueError("Need to set either outbase or physgrid_outfile")
 
     # if obsgrid set, process the observation model
     if obsgrid is not None:
@@ -225,26 +222,26 @@ if __name__ == "__main__":  # pragma: no cover
         "--physgrid",
         type=str,
         default=None,
-        help="If set, remove filters from this physics model grid file"
+        help="If set, remove filters from this physics model grid file",
     )
     parser.add_argument(
         "--obsgrid",
         type=str,
         default=None,
-        help="If set, remove filters from this observation/noisemodel grid file"
+        help="If set, remove filters from this observation/noisemodel grid file",
     )
     parser.add_argument(
         "--outbase",
         type=str,
         default=None,
-        help="Path+file to prepend to all output file names"
+        help="Path+file to prepend to all output file names",
     )
     parser.add_argument(
         "--physgrid_outfile",
         type=str,
         default=None,
         help="""Path+name of the output physics model grid. Takes precendence
-        over the default file name constructed from outbase."""
+        over the default file name constructed from outbase.""",
     )
     parser.add_argument(
         "--rm_filters",
@@ -253,7 +250,7 @@ if __name__ == "__main__":  # pragma: no cover
         default=None,
         help="""If set, these are the filters to remove from all of the files.
         If not set, only the filters present in catfile will be retained in
-        physgrid and/or obsgrid."""
+        physgrid and/or obsgrid.""",
     )
     args = parser.parse_args()
 

--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -125,15 +125,12 @@ def remove_filters_from_files(
                         if csfilter in beast_filt_short:
 
                             # if it's the same instrument, delete it
+                            # (if it's not the same instrument, keep it)
                             if beast_filt[beast_filt_short.index(csfilter)] == cfilter:
                                 rindxs.append(filters.index(cfilter))
                                 for grid_col in g0.grid.colnames:
                                     if cfilter in grid_col:
                                         rgridcols.append(grid_col)
-
-                            # if it's not the same instrument, keep it
-                            else:
-                                continue
 
                         # if the current filter isn't in the BEAST ref list, delete it
                         else:
@@ -158,29 +155,20 @@ def remove_filters_from_files(
                 if csfilter in cat_filters:
 
                     # if there's a list of BEAST instrument+filter references
+                    # (if there isn't a list of BEAST refs, keep it)
                     if beast_filt is not None:
 
                         # if the current filter is in the list of BEAST references
+                        # (if the current filter isn't in the BEAST ref list, keep it)
                         if csfilter in beast_filt_short:
 
-                            # if it's the same instrument, keep it
-                            if beast_filt[beast_filt_short.index(csfilter)] == cfilter:
-                                continue
-
                             # if it's not the same instrument, delete it
-                            else:
+                            # (if it's the same instrument, keep it)
+                            if beast_filt[beast_filt_short.index(csfilter)] != cfilter:
                                 rindxs.append(filters.index(cfilter))
                                 for grid_col in g0.grid.colnames:
                                     if cfilter in grid_col:
                                         rgridcols.append(grid_col)
-
-                        # if the current filter isn't in the BEAST ref list, keep it
-                        else:
-                            continue
-
-                    # if there isn't a list of BEAST refs, keep it
-                    else:
-                        continue
 
                 # if the current filter isn't in the catalog filters, delete it
                 else:

--- a/beast/tools/tests/test_remove_filters.py
+++ b/beast/tools/tests/test_remove_filters.py
@@ -31,9 +31,7 @@ def test_remove_filters():
 
     # download the needed files
     obs_fname = download_rename("b15_4band_det_27_A.fits")
-    #seds_fname = download_rename("beast_example_phat_seds_extrafilter.hd5")
-    prefix = '/astro/dust_kg3/lhagen/stsci/beast-examples_lea-hagen/phat_small/test_remfilt/'
-    seds_fname = prefix + "test_remfilt_seds.grid.hd5"
+    seds_fname = download_rename("beast_example_phat_seds_extrafilter.hd5")
 
     # name to use for the output grid
     temp_physgrid_file = 'temp_newgrid.hd5'

--- a/beast/tools/tests/test_remove_filters.py
+++ b/beast/tools/tests/test_remove_filters.py
@@ -3,6 +3,7 @@ from beast.tests.helpers import download_rename
 from astropy.tests.helper import remote_data
 import os
 
+
 @remote_data
 def test_remove_filters():
     """
@@ -33,8 +34,7 @@ def test_remove_filters():
     seds_fname = download_rename("beast_example_phat_seds_extrafilter.hd5")
 
     # name to use for the output grid
-    temp_physgrid_file = 'temp_newgrid.hd5'
-
+    temp_physgrid_file = "temp_newgrid.hd5"
 
     # ==== case 1A ====
 
@@ -43,25 +43,26 @@ def test_remove_filters():
         obs_fname,
         physgrid=seds_fname,
         physgrid_outfile=temp_physgrid_file,
-        #beast_filt=['HST_ACS_WFC_F475W'],
+        # beast_filt=['HST_ACS_WFC_F475W'],
     )
 
     # check that the proper filters are retained
     expected_filters = [
-        'HST_WFC3_F275W',
-        'HST_WFC3_F336W',
-        'HST_ACS_WFC_F475W',
-        'HST_WFC3_F475W',
-        'HST_ACS_WFC_F814W',
-        'HST_WFC3_F110W',
-        'HST_WFC3_F160W'
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
+        "HST_ACS_WFC_F475W",
+        "HST_WFC3_F475W",
+        "HST_ACS_WFC_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
     ]
-    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
-    assert set(temp['filters']) == set(expected_filters), "remove_filters case 1A doesn't match"
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=["filters"])
+    assert set(temp["filters"]) == set(
+        expected_filters
+    ), "remove_filters case 1A doesn't match"
 
     # remove temp file
     os.remove(temp_physgrid_file)
-
 
     # ==== case 1B ====
 
@@ -70,25 +71,26 @@ def test_remove_filters():
         obs_fname,
         physgrid=seds_fname,
         physgrid_outfile=temp_physgrid_file,
-        beast_filt=['HST_ACS_WFC_F475W'],
+        beast_filt=["HST_ACS_WFC_F475W"],
     )
 
     # check that the proper filters are retained
     expected_filters = [
-        'HST_WFC3_F275W',
-        'HST_WFC3_F336W',
-        'HST_ACS_WFC_F475W',
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
+        "HST_ACS_WFC_F475W",
         #'HST_WFC3_F475W',
-        'HST_ACS_WFC_F814W',
-        'HST_WFC3_F110W',
-        'HST_WFC3_F160W'
+        "HST_ACS_WFC_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
     ]
-    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
-    assert set(temp['filters']) == set(expected_filters), "remove_filters case 1B doesn't match"
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=["filters"])
+    assert set(temp["filters"]) == set(
+        expected_filters
+    ), "remove_filters case 1B doesn't match"
 
     # remove temp file
     os.remove(temp_physgrid_file)
-
 
     # ==== case 2A ====
 
@@ -97,26 +99,27 @@ def test_remove_filters():
         obs_fname,
         physgrid=seds_fname,
         physgrid_outfile=temp_physgrid_file,
-        rm_filters=['F475W'],
-        #beast_filt=['HST_WFC3_F475W'],
+        rm_filters=["F475W"],
+        # beast_filt=['HST_WFC3_F475W'],
     )
 
     # check that the proper filters are retained
     expected_filters = [
-        'HST_WFC3_F275W',
-        'HST_WFC3_F336W',
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
         #'HST_ACS_WFC_F475W',
         #'HST_WFC3_F475W',
-        'HST_ACS_WFC_F814W',
-        'HST_WFC3_F110W',
-        'HST_WFC3_F160W'
+        "HST_ACS_WFC_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
     ]
-    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
-    assert set(temp['filters']) == set(expected_filters), "remove_filters case 2A doesn't match"
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=["filters"])
+    assert set(temp["filters"]) == set(
+        expected_filters
+    ), "remove_filters case 2A doesn't match"
 
     # remove temp file
     os.remove(temp_physgrid_file)
-
 
     # ==== case 2B ====
 
@@ -125,22 +128,24 @@ def test_remove_filters():
         obs_fname,
         physgrid=seds_fname,
         physgrid_outfile=temp_physgrid_file,
-        rm_filters=['F475W'],
-        beast_filt=['HST_WFC3_F475W'],
+        rm_filters=["F475W"],
+        beast_filt=["HST_WFC3_F475W"],
     )
 
     # check that the proper filters are retained
     expected_filters = [
-        'HST_WFC3_F275W',
-        'HST_WFC3_F336W',
-        'HST_ACS_WFC_F475W',
+        "HST_WFC3_F275W",
+        "HST_WFC3_F336W",
+        "HST_ACS_WFC_F475W",
         #'HST_WFC3_F475W',
-        'HST_ACS_WFC_F814W',
-        'HST_WFC3_F110W',
-        'HST_WFC3_F160W'
+        "HST_ACS_WFC_F814W",
+        "HST_WFC3_F110W",
+        "HST_WFC3_F160W",
     ]
-    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
-    assert set(temp['filters']) == set(expected_filters), "remove_filters case 2B doesn't match"
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=["filters"])
+    assert set(temp["filters"]) == set(
+        expected_filters
+    ), "remove_filters case 2B doesn't match"
 
     # remove temp file
     os.remove(temp_physgrid_file)

--- a/beast/tools/tests/test_remove_filters.py
+++ b/beast/tools/tests/test_remove_filters.py
@@ -1,0 +1,149 @@
+from beast.tools import remove_filters, read_beast_data
+from beast.tests.helpers import download_rename
+from astropy.tests.helper import remote_data
+from astropy.table import Table
+import os
+
+@remote_data
+def test_remove_filters():
+    """
+    Test for remove_filters.py
+
+    The SED grid for this test has two entries for F475W: HST_ACS_WFC_F475W and
+    HST_WFC3_F475W (the actual F475W observations are with ACS). This tests four
+    combinations of running remove_filters:
+
+    1. Use the catalog to choose which filters in the SED grid to keep
+        A. without using beast_filt keyword: the code doesn't know what F475W in
+           the catalog means, so it won't delete either F475W entry from the
+           grid
+        B. using beast_filt='HST_ACS_WFC_F475W': the code knows that when it
+           sees F475W in the catalog, it means ACS, so it should remove
+           HST_WFC3_F475W from the grid
+
+    2. Use the rm_filters='F475W' keyword to choose filter removal
+        A. without using beast_filt keyword: any time the code sees F475W in the
+           grid, it will delete it
+        B. using beast_filt='HST_WFC3_F475W': the code knows that F475W in
+           rm_filters means WFC3, so it will only delete the F475W WFC3 entry in
+           the grid
+    """
+
+    # download the needed files
+    obs_fname = download_rename("b15_4band_det_27_A.fits")
+    #seds_fname = download_rename("beast_example_phat_seds_extrafilter.hd5")
+    prefix = '/astro/dust_kg3/lhagen/stsci/beast-examples_lea-hagen/phat_small/test_remfilt/'
+    seds_fname = prefix + "test_remfilt_seds.grid.hd5"
+
+    # name to use for the output grid
+    temp_physgrid_file = 'temp_newgrid.hd5'
+
+
+    # ==== case 1A ====
+
+    # run filter removal
+    remove_filters.remove_filters_from_files(
+        obs_fname,
+        physgrid=seds_fname,
+        physgrid_outfile=temp_physgrid_file,
+        #beast_filt=['HST_ACS_WFC_F475W'],
+    )
+
+    # check that the proper filters are retained
+    expected_filters = [
+        'HST_WFC3_F275W',
+        'HST_WFC3_F336W',
+        'HST_ACS_WFC_F475W',
+        'HST_WFC3_F475W',
+        'HST_ACS_WFC_F814W',
+        'HST_WFC3_F110W',
+        'HST_WFC3_F160W'
+    ]
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
+    assert set(temp['filters']) == set(expected_filters), "remove_filters case 1A doesn't match"
+
+    # remove temp file
+    os.remove(temp_physgrid_file)
+
+
+    # ==== case 1B ====
+
+    # run filter removal
+    remove_filters.remove_filters_from_files(
+        obs_fname,
+        physgrid=seds_fname,
+        physgrid_outfile=temp_physgrid_file,
+        beast_filt=['HST_ACS_WFC_F475W'],
+    )
+
+    # check that the proper filters are retained
+    expected_filters = [
+        'HST_WFC3_F275W',
+        'HST_WFC3_F336W',
+        'HST_ACS_WFC_F475W',
+        #'HST_WFC3_F475W',
+        'HST_ACS_WFC_F814W',
+        'HST_WFC3_F110W',
+        'HST_WFC3_F160W'
+    ]
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
+    assert set(temp['filters']) == set(expected_filters), "remove_filters case 1B doesn't match"
+
+    # remove temp file
+    os.remove(temp_physgrid_file)
+
+
+    # ==== case 2A ====
+
+    # run filter removal
+    remove_filters.remove_filters_from_files(
+        obs_fname,
+        physgrid=seds_fname,
+        physgrid_outfile=temp_physgrid_file,
+        rm_filters=['F475W'],
+        #beast_filt=['HST_WFC3_F475W'],
+    )
+
+    # check that the proper filters are retained
+    expected_filters = [
+        'HST_WFC3_F275W',
+        'HST_WFC3_F336W',
+        #'HST_ACS_WFC_F475W',
+        #'HST_WFC3_F475W',
+        'HST_ACS_WFC_F814W',
+        'HST_WFC3_F110W',
+        'HST_WFC3_F160W'
+    ]
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
+    assert set(temp['filters']) == set(expected_filters), "remove_filters case 2A doesn't match"
+
+    # remove temp file
+    os.remove(temp_physgrid_file)
+
+
+    # ==== case 2B ====
+
+    # run filter removal
+    remove_filters.remove_filters_from_files(
+        obs_fname,
+        physgrid=seds_fname,
+        physgrid_outfile=temp_physgrid_file,
+        rm_filters=['F475W'],
+        beast_filt=['HST_WFC3_F475W'],
+    )
+
+    # check that the proper filters are retained
+    expected_filters = [
+        'HST_WFC3_F275W',
+        'HST_WFC3_F336W',
+        'HST_ACS_WFC_F475W',
+        #'HST_WFC3_F475W',
+        'HST_ACS_WFC_F814W',
+        'HST_WFC3_F110W',
+        'HST_WFC3_F160W'
+    ]
+    temp = read_beast_data.read_sed_data(temp_physgrid_file, param_list=['filters'])
+    assert set(temp['filters']) == set(expected_filters), "remove_filters case 2B doesn't match"
+
+    # remove temp file
+    os.remove(temp_physgrid_file)

--- a/beast/tools/tests/test_remove_filters.py
+++ b/beast/tools/tests/test_remove_filters.py
@@ -1,7 +1,6 @@
 from beast.tools import remove_filters, read_beast_data
 from beast.tests.helpers import download_rename
 from astropy.tests.helper import remote_data
-from astropy.table import Table
 import os
 
 @remote_data


### PR DESCRIPTION
I've added an optional input to `remove_filters` to specify the BEAST filter associated with the short filter name.  Also, I simplified the code a bit so that instead of having some lists with info appended and some lists with info deleted, it now just does deleting.

I still need to confirm that it works and add docs (and tests!).

Closes #527

Partially addresses #531 