### PR TITLE
Update/fix development installation docs

### DIFF
--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -242,7 +242,7 @@ fork's master repository up-to-date with the following steps:
      $ git fetch upstream
 
 - If there are any differences, then merge the official master branch (upstream)
-with your fork's master (you may need to write a commit message):
+  with your fork's master (you may need to write a commit message):
 
   .. code-block:: console
 

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -42,27 +42,42 @@ project is:
 Development Install
 ===================
 
-It is much easier to perform development if any changes you make to the code are
-immediately reflected in how the ``beast`` runs (in contrast to needed to perform a
-new install each team). This can be achieved by using a development install.
+It is much easier to develop the code if any changes you make are immediately
+reflected in how the ``beast`` runs (in contrast to performing a new install each
+team). This can be achieved by using a development install. First, create a fork
+of the official ``beast`` repository, and clone it to your local drive:
 
-This is most easily achieved via a pip development install. Navigate to the
-directory in your your ``beast`` repository that contains `setup.py`, and run:
+.. code-block:: console
 
-  .. code-block:: console
+   $ git clone https://github.com/YourName/beast.git
 
-     $ mv beast beast-official
-     $ git clone https://github.com/YourName/beast.git
-     $ mv beast beast-YourName
-     $ mv beast-official beast
+Optionally, you can rename this cloned copy:
 
-- Set the value of the fork's 'upstream' to the official distribution so you
-  can incorporate changes made by others to your development fork. In the clone
-  of your fork, run the following:
+.. code-block:: console
 
-  .. code-block:: console
+   $ git clone https://github.com/YourName/beast.git beast-YourName
 
-     $ git remote add upstream https://github.com/BEAST-Fitting/beast.git
+Set the value of the fork's 'upstream' to the official distribution so you
+can incorporate changes made by others to your development fork. In the clone
+of your fork, run the following:
+
+.. code-block:: console
+
+   $ git remote add upstream https://github.com/BEAST-Fitting/beast.git
+
+In order to run a development installation, navigate to the directory in your
+``beast`` repository that contains `setup.py`, and run:
+
+.. code-block:: console
+
+   $ pip install -e .
+
+Alternatively, you can perform a development install directly though Python
+with:
+
+.. code-block:: console
+
+   $ python setup.py develop
 
 Adding Branches
 ===============
@@ -102,26 +117,6 @@ Adding Branches
   .. code-block:: console
 
      $ git checkout master
-
-
-Development Install
-==============================
-
-To perform development, and see your changes reflected immediately in your
-installed copy of the BEAST, you can perform a development install. This can
-either be performed via a pip development install, by navigating to the
-directory that contains `setup.py` and running:
-
-  .. code-block:: console
-
-     $ pip install -e .
-
-Alternatively, you can perform a development install directly though Python
-with:
-
-  .. code-block:: console
-
-     $ python setup.py develop
 
 
 Making Changes

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -84,7 +84,7 @@ Adding Branches
 ===============
 
 - Make sure you are in the directory for your fork of the beast. You will be on
-  branch 'master' by default.
+  branch `master` by default.
 
 - Create and switch to a branch (here named 'beast-dev1'; generally it's good
   practice to give branches names related to their purpose)
@@ -113,7 +113,7 @@ Adding Branches
 
      $ git push origin beast-dev1
 
-- To revert back to your fork's master branch:
+- To revert back to your fork's `master` branch:
 
   .. code-block:: console
 
@@ -217,7 +217,7 @@ should send the pull requests.
 
 Pull requests can be submitted at https://github.com/BEAST-Fitting/beast/pulls.
 If you push any commits to your origin repository in a development branch
-(beast-dev1), then a "Compare & pull request" button should appear at the
+(`beast-dev1`), then a "Compare & pull request" button should appear at the
 top of this site. Briefly describe the changes/additions you made in the comments
 section and submit the pull request.
 
@@ -227,9 +227,9 @@ Staying up-to-date
 
 The ``beast`` project's official repository will be updated from time to time
 to accommodate bug fixes, improvements and new features. You can keep your
-fork's master repository up-to-date with the following steps:
+fork's `master` repository up-to-date with the following steps:
 
-- Switch to your fork's master branch:
+- Switch to your fork's `master` branch:
 
   .. code-block:: console
 
@@ -241,8 +241,8 @@ fork's master repository up-to-date with the following steps:
 
      $ git fetch upstream
 
-- If there are any differences, then merge the official master branch (upstream)
-  with your fork's master (you may need to write a commit message):
+- If there are any differences, then merge the official `master` branch (upstream)
+  with your fork's `master` (you may need to write a commit message):
 
   .. code-block:: console
 

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -217,10 +217,42 @@ should send the pull requests.
 
 Pull requests can be submitted at https://github.com/BEAST-Fitting/beast/pulls.
 If you push any commits to your origin repository in a development branch
-(`beast-dev1`), then a "Compare & pull request" button should appear at the
+(beast-dev1), then a "Compare & pull request" button should appear at the
 top of this site. Briefly describe the changes/additions you made in the comments
 section and submit the pull request.
 
+
+Staying up-to-date
+==================
+
+The ``beast`` project's official repository will be updated from time to time
+to accommodate bug fixes, improvements and new features. You can keep your
+fork's master repository up-to-date with the following steps:
+
+- Switch to your fork's master branch:
+
+  .. code-block:: console
+
+     $ git checkout master
+
+- Fetch the project's up-to-date distribution:
+
+  .. code-block:: console
+
+     $ git fetch upstream
+
+- If there are any differences, then merge the official master branch (upstream)
+with your fork's master (you may need to write a commit message):
+
+  .. code-block:: console
+
+     $ git merge upstream/master
+
+- Sync this change with your origin repository:
+
+  .. code-block:: console
+
+     $ git push origin master
 
 
 BEAST on Slack

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -42,10 +42,9 @@ project is:
 Development Install
 ===================
 
-It is much easier to develop the code if any changes you make are immediately
-reflected in how the ``beast`` runs (in contrast to performing a new install each
-team). This can be achieved by using a development install. First, create a fork
-of the official ``beast`` repository, and clone it to your local drive:
+If you plan on modifying the ``beast`` in addition to running the code, it may
+be useful to create a development installation. First, create a fork of the
+official ``beast`` repository and clone it:
 
 .. code-block:: console
 
@@ -154,14 +153,13 @@ and `beast-dev1`).
 
 - Commit messages should be short but descriptive.
 
-- To see the status of or commit changes of a single file:
+- To see the status of your changed files:
 
   .. code-block:: console
 
-     $ git status PathToFile/filename
-     $ git commit PathToFile/filename
+     $ git status
 
-- To undo all changes made to a file since last commit:
+- To undo all changes made to a specific file since the last commit:
 
   .. code-block:: console
 
@@ -195,7 +193,7 @@ Make sure the documentation can be created.
 
      $ python setup.py build_docs
 
-The resulting HTML files are placed in `docs/_build/html` subdirectory, and
+The resulting HTML files are placed in the `docs/_build/html` subdirectory, and
 can be viewed in a web browser.
 
 
@@ -252,7 +250,7 @@ Visualizing Repository Commits
 ==============================
 
 The commits to the ``beast`` repository can be visualized using `gource`.  This
-creates a movie showing the time evolution of the code and who make the
+creates a movie showing the time evolution of the code and who made the
 changes.
 
 Version created 22 Jan 2018:  <http://stsci.edu/~kgordon/beast/beast_repo.mp4>

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -71,7 +71,7 @@ In order to run a development installation, navigate to the directory in your
 
    $ pip install -e .
 
-Alternatively, you can perform a development install directly though Python
+Alternatively, you can perform a development install directly through Python
 with:
 
 .. code-block:: console
@@ -158,6 +158,12 @@ and `beast-dev1`).
   .. code-block:: console
 
      $ git status
+
+- To view any differences between a file and the last committed version:
+
+  .. code-block:: console
+
+     $ git diff PathToFile/filename
 
 - To undo all changes made to a specific file since the last commit:
 

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -86,22 +86,14 @@ Adding Branches
 - Make sure you are in the directory for your fork of the beast. You will be on
   branch `master` by default.
 
-- Create and switch to a branch (here named `beast-dev1`; generally it's good
-  practice to give branches names related to their purpose)
+- Create and switch to a branch (here named `beast-dev1`):
 
   .. code-block:: console
 
      $ git checkout -b beast-dev1
 
-- Instead, if you want to create first a branch and then switch to it:
-
-  .. code-block:: console
-
-     $ git branch beast-dev1
-     $ git checkout beast-dev1
-
-- To see a list of all branches of the fork, with '*' indicating which branch you are
-  currently working on:
+- To see a list of all branches of the fork, with '*' indicating which branch
+  you are currently working on:
 
   .. code-block:: console
 
@@ -124,11 +116,11 @@ Making Changes
 ==============
 
 It is recommended that branches have a single purpose; for example, if you are working
-on adding a test suite, on improving the fitting algorithm and on speeding up some task,
-those should be in separate branches (e.g.) `add-test-suite`, `improve-fitting-algorithm`
-and `beast-dev1`.
+on adding a test suite, improving the fitting algorithm, and speeding up some task,
+those should be in separate branches (e.g. `add-test-suite`, `improve-fitting-algorithm`
+and `beast-dev1`).
 
-- Anywhere below 'beast-YourName', switch to the branch you wish to work off of:
+- Switch to the branch you wish to work off of:
 
   .. code-block:: console
 
@@ -175,7 +167,7 @@ and `beast-dev1`.
 
      $ git checkout PathToFile/filename
 
-- To sync changes made to the branch locally with your GitHub repo:
+- To sync changes made to the branch locally with your GitHub repository:
 
   .. code-block:: console
 
@@ -210,16 +202,12 @@ can be viewed in a web browser.
 Submitting a Pull Request
 =========================
 
-Once you have changes that you'd like to contribute back to the project or share
-with collaborators, you can open a pull request. It is a good idea to check with
-the projects or your collaborators which branch of their BEAST repository you
-should send the pull requests.
-
-Pull requests can be submitted at https://github.com/BEAST-Fitting/beast/pulls.
-If you push any commits to your origin repository in a development branch
-(`beast-dev1`), then a "Compare & pull request" button should appear at the
-top of this site. Briefly describe the changes/additions you made in the comments
-section and submit the pull request.
+Once you have changes that you'd like to contribute back to the upstream branch,
+you can open a pull request for review. Pull requests can be submitted at
+https://github.com/BEAST-Fitting/beast/pulls. If you push any commits to your
+origin repository in a development branch (`beast-dev1`), then a "Compare &
+pull request" button should appear at the top of this site. Briefly describe the
+changes/additions you made in the comments section and submit the pull request.
 
 
 Staying up-to-date
@@ -241,8 +229,7 @@ fork's `master` repository up-to-date with the following steps:
 
      $ git fetch upstream
 
-- If there are any differences, then merge the official `master` branch (upstream)
-  with your fork's `master` (you may need to write a commit message):
+- Merge the official (upstream) `master` branch with your fork's `master` branch:
 
   .. code-block:: console
 

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -79,6 +79,7 @@ with:
 
    $ python setup.py develop
 
+
 Adding Branches
 ===============
 
@@ -208,6 +209,7 @@ can be viewed in a web browser.
 
 Submitting a Pull Request
 =========================
+
 Once you have changes that you'd like to contribute back to the project or share
 with collaborators, you can open a pull request. It is a good idea to check with
 the projects or your collaborators which branch of their BEAST repository you
@@ -218,6 +220,7 @@ If you push any commits to your origin repository in a development branch
 (`beast-dev1`), then a "Compare & pull request" button should appear at the
 top of this site. Briefly describe the changes/additions you made in the comments
 section and submit the pull request.
+
 
 
 BEAST on Slack

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -86,7 +86,7 @@ Adding Branches
 - Make sure you are in the directory for your fork of the beast. You will be on
   branch `master` by default.
 
-- Create and switch to a branch (here named 'beast-dev1'; generally it's good
+- Create and switch to a branch (here named `beast-dev1`; generally it's good
   practice to give branches names related to their purpose)
 
   .. code-block:: console

--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -206,8 +206,19 @@ The resulting HTML files are placed in `docs/_build/html` subdirectory, and
 can be viewed in a web browser.
 
 
-Collaborating and Contributing
-==============================
+Submitting a Pull Request
+=========================
+Once you have changes that you'd like to contribute back to the project or share
+with collaborators, you can open a pull request. It is a good idea to check with
+the projects or your collaborators which branch of their BEAST repository you
+should send the pull requests.
+
+Pull requests can be submitted at https://github.com/BEAST-Fitting/beast/pulls.
+If you push any commits to your origin repository in a development branch
+(`beast-dev1`), then a "Compare & pull request" button should appear at the
+top of this site. Briefly describe the changes/additions you made in the comments
+section and submit the pull request.
+
 
 BEAST on Slack
 ==============


### PR DESCRIPTION
Fixes #532 and #529.

This PR updates the text for the BEAST development install guide. At some point, the installation instructions were removed and then partially restored; now they are more coherent and streamlined. I've also included short summaries on how to submit a pull request (collaborating/contributing) and how to fetch the upstream master branch (staying up to date). 

`build_docs` passed locally for this document.