### PR TITLE
Test for star_type_probability

### DIFF
--- a/beast/tools/star_type_probability.py
+++ b/beast/tools/star_type_probability.py
@@ -199,7 +199,8 @@ def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5, max_Av=99):
         mass_bins = pdf2d_bins['M_ini+Av'][0,:,:]
     else:
         print("2D PDFs don't contain M_ini and Av data")
-        return None
+        tot_stars = pdf2d_data[pdf2d_data.keys()[0]].shape[0]
+        return [None] * tot_stars
 
     # reshape the arrays
     prob_data = prob_data.reshape(prob_data.shape[0], -1)
@@ -252,7 +253,8 @@ def dusty_agb(pdf2d_data, pdf2d_bins, min_Av=7, min_logT=3.7, max_logT=4.2):
         logT_bins = pdf2d_bins['logT+Av'][0,:,:]
     else:
         print("2D PDFs don't contain Av and logT (T_eff) data")
-        return None
+        tot_stars = pdf2d_data[pdf2d_data.keys()[0]].shape[0]
+        return [None] * tot_stars
 
     # reshape the arrays
     prob_data = prob_data.reshape(prob_data.shape[0], -1)

--- a/beast/tools/star_type_probability.py
+++ b/beast/tools/star_type_probability.py
@@ -199,8 +199,8 @@ def ext_O_star(pdf2d_data, pdf2d_bins, min_M_ini=10, min_Av=0.5, max_Av=99):
         mass_bins = pdf2d_bins['M_ini+Av'][0,:,:]
     else:
         print("2D PDFs don't contain M_ini and Av data")
-        tot_stars = pdf2d_data[pdf2d_data.keys()[0]].shape[0]
-        return [None] * tot_stars
+        tot_stars = pdf2d_data[list(pdf2d_data)[0]].shape[0]
+        return [np.nan] * tot_stars
 
     # reshape the arrays
     prob_data = prob_data.reshape(prob_data.shape[0], -1)
@@ -253,8 +253,8 @@ def dusty_agb(pdf2d_data, pdf2d_bins, min_Av=7, min_logT=3.7, max_logT=4.2):
         logT_bins = pdf2d_bins['logT+Av'][0,:,:]
     else:
         print("2D PDFs don't contain Av and logT (T_eff) data")
-        tot_stars = pdf2d_data[pdf2d_data.keys()[0]].shape[0]
-        return [None] * tot_stars
+        tot_stars = pdf2d_data[list(pdf2d_data)[0]].shape[0]
+        return [np.nan] * tot_stars
 
     # reshape the arrays
     prob_data = prob_data.reshape(prob_data.shape[0], -1)

--- a/beast/tools/tests/test_star_type_probability.py
+++ b/beast/tools/tests/test_star_type_probability.py
@@ -4,7 +4,7 @@ from astropy.tests.helper import remote_data
 from astropy.table import Table
 
 @remote_data
-def test_star_type_probability():
+def test_star_type_probability_all_params():
     """
     Test for star_type_probability.py
     """
@@ -13,6 +13,32 @@ def test_star_type_probability():
     pdf1d_fname = download_rename("beast_example_phat_pdf1d.fits")
     pdf2d_fname = download_rename("beast_example_phat_pdf2d.fits")
     star_prob_fname = download_rename("beast_example_phat_startype.fits")
+
+    # run star_type_probability
+    star_prob = star_type_probability.star_type_probability(
+        pdf1d_fname,
+        pdf2d_fname,
+        output_filebase = None,
+        ext_O_star_params = {'min_M_ini':10, 'min_Av':0.5, 'max_Av':5}
+    )
+
+    # expected output table
+    expected_star_prob = Table.read(star_prob_fname)
+
+    # compare to new table
+    compare_tables(expected_star_prob, Table(star_prob))
+
+@remote_data
+def test_star_type_probability_no_Av():
+    """
+    Test for star_type_probability.py
+    """
+
+    # download the needed files
+    pdf1d_fname = download_rename("beast_example_phat_pdf1d.fits")
+    pdf2d_fname = download_rename("beast_example_phat_pdf2d_no_Av.fits")
+    star_prob_fname = download_rename("beast_example_phat_startype_no_Av.fits")
+
 
     # run star_type_probability
     star_prob = star_type_probability.star_type_probability(

--- a/beast/tools/tests/test_star_type_probability.py
+++ b/beast/tools/tests/test_star_type_probability.py
@@ -1,0 +1,36 @@
+from beast.tools import star_type_probability
+from beast.tests.helpers import download_rename, compare_tables
+from astropy.tests.helper import remote_data
+from astropy.table import Table
+
+@remote_data
+def test_compare_spec_type_inFOV():
+    """
+    Test for compare_spec_type.  The spectrally-typed stars aren't real sources,
+    they're just invented for the purposes of documenting/testing the code.
+
+    In this version, the stars are in the imaging field of view.
+    """
+
+    # download the needed files
+    #pdf1d_fname = download_rename("beast_example_phat_pdf1d.fits")
+    #pdf2d_fname = download_rename("beast_example_phat_pdf2d.fits")
+    #star_prob_fname = download_rename("beast_example_phat_startype.fits")
+    prefix = '/astro/dust_kg3/lhagen/stsci/beast-examples_lea-hagen/phat_small/beast_example_phat/'
+    pdf1d_fname = prefix+"beast_example_phat_pdf1d.fits"
+    pdf2d_fname = prefix+"beast_example_phat_pdf2d.fits"
+    star_prob_fname = prefix+"beast_example_phat_startype.fits"
+
+    # run star_type_probability
+    star_prob = star_type_probability.star_type_probability(
+        pdf1d_fname,
+        pdf2d_fname,
+        output_filebase = None,
+        ext_O_star_params = {'min_M_ini':10, 'min_Av':0.5, 'max_Av':5}
+    )
+
+    # expected output table
+    expected_star_prob = Table.read(star_prob_fname)
+
+    # compare to new table
+    compare_tables(expected_star_prob, Table(star_prob))

--- a/beast/tools/tests/test_star_type_probability.py
+++ b/beast/tools/tests/test_star_type_probability.py
@@ -4,22 +4,15 @@ from astropy.tests.helper import remote_data
 from astropy.table import Table
 
 @remote_data
-def test_compare_spec_type_inFOV():
+def test_star_type_probability():
     """
-    Test for compare_spec_type.  The spectrally-typed stars aren't real sources,
-    they're just invented for the purposes of documenting/testing the code.
-
-    In this version, the stars are in the imaging field of view.
+    Test for star_type_probability.py
     """
 
     # download the needed files
-    #pdf1d_fname = download_rename("beast_example_phat_pdf1d.fits")
-    #pdf2d_fname = download_rename("beast_example_phat_pdf2d.fits")
-    #star_prob_fname = download_rename("beast_example_phat_startype.fits")
-    prefix = '/astro/dust_kg3/lhagen/stsci/beast-examples_lea-hagen/phat_small/beast_example_phat/'
-    pdf1d_fname = prefix+"beast_example_phat_pdf1d.fits"
-    pdf2d_fname = prefix+"beast_example_phat_pdf2d.fits"
-    star_prob_fname = prefix+"beast_example_phat_startype.fits"
+    pdf1d_fname = download_rename("beast_example_phat_pdf1d.fits")
+    pdf2d_fname = download_rename("beast_example_phat_pdf2d.fits")
+    star_prob_fname = download_rename("beast_example_phat_startype.fits")
 
     # run star_type_probability
     star_prob = star_type_probability.star_type_probability(

--- a/docs/analysis_tools.rst
+++ b/docs/analysis_tools.rst
@@ -13,7 +13,8 @@ likely to be high mass stars.
 
 There are two types of stars currently implemented, though more can easily be
 added.  When there are cuts along two parameters, the 2D PDFs are utilized.  If
-2D PDFs of the required parameters don't exist, the star type will be skipped.
+2D PDFs of the required parameters don't exist, the probability of that star
+type will be `NaN`.
 
 * Extinguished high mass stars (`star_type_probability.ext_O_star`): Stars above
   a certain mass (default `M_ini` > 10 solar masses) with some minimum


### PR DESCRIPTION
This adds a test for `star_type_probability.py`.  Funny enough, as part of doing this, I found a bug - when the required 2D PDF didn't exist, it returned None (instead of a list of None), so the results could be returned as a dictionary, but not saved as a table in a fits file.

This will require two files to be added to the remote data folder: `beast_example_phat_pdf2d.fits` and `beast_example_phat_startype.fits`.  @karllark, they add up to ~8 MB, so I'll email you their paths in my directory.

Partially addresses #531 
