### PR TITLE
remove logL cut and irrelevant comments

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -133,15 +133,9 @@ def pick_models_toothpick_style(
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
 
-    idxs = np.where(modelsedgrid.grid["logL"] > -9)[0]
-    sedsMags_cut = sedsMags[idxs]
-
-    # Note that i speak of fluxes, but I've recently modified this to
-    # work with mags instead
-
     # Set up a number of flux bins for each filter
-    maxes = np.amax(sedsMags_cut, axis=0)
-    mins = np.amin(sedsMags_cut, axis=0)
+    maxes = np.amax(sedsMags, axis=0)
+    mins = np.amin(sedsMags, axis=0)
 
     bin_edges = np.zeros((N_fluxes + 1, Nf))  # indexed on [fluxbin, nfilters]
     for f in range(Nf):

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -134,7 +134,7 @@ def pick_models_toothpick_style(
     Nf = sedsMags.shape[1]
 
     # Check if logL=-9.999 model points sliently sneak through
-    if min(modelsedgrid.grid["logL") < -9:
+    if min(modelsedgrid.grid["logL"]) < -9:
         warnings.warn('There are logL=-9.999 model points in the SED grid!')
         print('Excluding those SED models from selecting input ASTs')
         idxs = np.where(modelsedgrid.grid["logL"] > -9)[0]

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -1,5 +1,5 @@
 import os
-
+import warnings
 import numpy as np
 from astropy.io import ascii
 from astropy.table import Table
@@ -132,6 +132,13 @@ def pick_models_toothpick_style(
 
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
     Nf = sedsMags.shape[1]
+
+    # Check if logL=-9.999 model points sliently sneak through
+    if min(modelsedgrid.grid["logL") < -9:
+        warnings.warn('There are logL=-9.999 model points in the SED grid!')
+        print('Excluding those SED models from selecting input ASTs')
+        idxs = np.where(modelsedgrid.grid["logL"] > -9)[0]
+        sedsMags = sedsMags[idxs]
 
     # Set up a number of flux bins for each filter
     maxes = np.amax(sedsMags, axis=0)


### PR DESCRIPTION
logL = -9.999 are now dealt when generating the spec grid. Thus, there is no need to make logL cut when generating input ASTs. See #486 and #491 