### PR TITLE
save SED grid index for selected ASTs

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -227,6 +227,7 @@ def pick_models_toothpick_style(
         grid_dict = {}
         for key in list(modelsedgrid.grid.keys()):
             grid_dict[key] = modelsedgrid.grid[key][chosen_idxs]
+        grid_dict['sedgrid_indx'] = chosen_idxs
         ast_params = Table(grid_dict)
         ast_params.write(outfile_params, overwrite=True)
 

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -173,7 +173,7 @@ line will start with ``0 1 X Y``, which are the first four columns required by
 DOLPHOT to define the input star position.
 
 The code will also optionally output a fits file, `[project]/[project]_ASTparams.fits`,
-which has the physical parameters associated with each of the artificial stars.  It
+which has the physical parameters associated with each of the artificial stars as well as their indices in the spec and sed grids. It
 will have either
 approximately `ast_n_flux_bins * ast_n_per_flux_bin` lines or
 `<number of ages> * ast_models_selected_per_age` lines, and has the same


### PR DESCRIPTION
Save SED grid index for selected ASTs in the output "*_ASTparams.fits" file to track down which SED models were selected as input ASTs. This makes it possible to exclude these SEDs when supplementing an existing input ASTs. Related to Issue #496 