### PR TITLE
get_noisemodelcat now returns a dictonary

### DIFF
--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -89,19 +89,19 @@ def trim_models(
     #   that *none* were recovered and this implies
     #   that no model with these values would be recovered and thus the
     #   probability should always be zero
-    model_unc = sedgrid_noisemodel.root.error[:]
+    model_unc = sedgrid_noisemodel["error"]
     above_ast = model_unc > 0
     sum_above_ast = np.sum(above_ast, axis=1)
     indxs, = np.where(sum_above_ast >= n_detected)
 
     # cache the noisemodel values
-    model_bias = sedgrid_noisemodel.root.bias[:]
-    model_unc = np.fabs(sedgrid_noisemodel.root.error[:])
-    model_compl = sedgrid_noisemodel.root.completeness[:]
+    model_bias = sedgrid_noisemodel["bias"]
+    model_unc = np.fabs(sedgrid_noisemodel["error"])
+    model_compl = sedgrid_noisemodel["completeness"]
     if trunchen:
-        model_q_norm = sedgrid_noisemodel.root.q_norm[:]
-        model_icov_diag = sedgrid_noisemodel.root.icov_diag[:]
-        model_icov_offdiag = sedgrid_noisemodel.root.icov_offdiag[:]
+        model_q_norm = sedgrid_noisemodel["q_norm"]
+        model_icov_diag = sedgrid_noisemodel["icov_diag"]
+        model_icov_offdiag = sedgrid_noisemodel["icov_offdiag"]
 
     if len(indxs) <= 0:
         raise ValueError("no models are brighter than the minimum ASTs run")

--- a/beast/observationmodel/noisemodel/generic_noisemodel.py
+++ b/beast/observationmodel/noisemodel/generic_noisemodel.py
@@ -11,6 +11,7 @@ can be achieved using the trunchen method.  The trunchen method
 requires significantly more complicated ASTs and many more of them.
 """
 import numpy as np
+import h5py
 import tables
 
 from beast.observationmodel.noisemodel import toothpick
@@ -134,7 +135,22 @@ def get_noisemodelcat(filename):
 
     Returns
     -------
-    table: pytables.Table
-        table containing the elements of the noise model
+    ntable : dict
+        dictonary containing the elements of the noise model
     """
-    return tables.open_file(filename)
+    nfile = h5py.File(filename, 'r')
+
+    # create a dictonary of the elements
+    ntable = {}
+    for ckey in nfile.keys():
+        ntable[ckey] = np.array(nfile[ckey])
+
+    nfile.close()
+
+    # check that at least the 3 basic elements are included
+    expected_elements = ["error", "bias", "completeness"]
+    for cexp in expected_elements:
+        if cexp not in ntable.keys():
+            raise ValueError(f"{cexp} values not found in noisemodel")
+
+    return ntable

--- a/beast/observationmodel/noisemodel/tests/test_generic_noisemodel.py
+++ b/beast/observationmodel/noisemodel/tests/test_generic_noisemodel.py
@@ -1,0 +1,19 @@
+from astropy.tests.helper import remote_data
+
+from beast.tests.helpers import download_rename
+from beast.observationmodel.noisemodel.generic_noisemodel import get_noisemodelcat
+
+
+@remote_data
+def test_get_noisemodelcat():
+    noise_fname = download_rename("beast_example_phat_noisemodel.grid.hd5")
+    ntable = get_noisemodelcat(noise_fname)
+
+    # check that at least the 3 basic elements are included
+    expected_elements = ["error", "bias", "completeness"]
+    for cexp in expected_elements:
+        assert cexp in ntable.keys(), f"{cexp} values not found in noisemodel"
+
+
+if __name__ == "__main__":
+    test_get_noisemodelcat()

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -221,9 +221,9 @@ def gen_SimObs_from_sedgrid(
     print("Completeness from %s" % sedgrid.filters[filter_k])
 
     # cache the noisemodel values
-    model_bias = sedgrid_noisemodel.root.bias[:]
-    model_unc = np.fabs(sedgrid_noisemodel.root.error[:])
-    model_compl = sedgrid_noisemodel.root.completeness[:]
+    model_bias = sedgrid_noisemodel["bias"]
+    model_unc = np.fabs(sedgrid_noisemodel["error"])
+    model_compl = sedgrid_noisemodel["completeness"]
 
     # the combined prior and grid weights
     # using both as the grid weight needed to account for the finite size

--- a/beast/plotting/plot_completeness.py
+++ b/beast/plotting/plot_completeness.py
@@ -65,7 +65,7 @@ def plot_completeness(
         # read in the noise model
         noisegrid = noisemodel.get_noisemodelcat(str(noise_model))
         # get the completeness
-        model_compl = noisegrid.root.completeness[:]
+        model_compl = noisegrid["completeness"]
         # close the file to save memory
         noisegrid.close()
 

--- a/beast/plotting/plot_noisemodel.py
+++ b/beast/plotting/plot_noisemodel.py
@@ -65,8 +65,8 @@ def plot_noisemodel(
         noisemodel_vals = noisemodel.get_noisemodelcat(nfile)
 
         # extract error and bias
-        noise_err = noisemodel_vals.root.error[:]
-        noise_bias = noisemodel_vals.root.bias[:]
+        noise_err = noisemodel_vals["error"]
+        noise_bias = noisemodel_vals["bias"]
 
         # plot things
         for f, filt in enumerate(filter_list):

--- a/beast/tools/remove_filters.py
+++ b/beast/tools/remove_filters.py
@@ -84,7 +84,6 @@ def remove_filters_from_files(
     if rm_filters is None:
         cat_filters = [f[:-5] for f in cat.colnames if f[-4:].lower() == 'rate']
 
-
     # if physgrid set, process the SED grid
     if physgrid is not None:
 
@@ -145,21 +144,20 @@ def remove_filters_from_files(
         else:
             raise ValueError('Need to set either outbase or physgrid_outfile')
 
-
     # if obsgrid set, process the observation model
     if obsgrid is not None:
         obsgrid = noisemodel.get_noisemodelcat(obsgrid)
         with tables.open_file("{}_noisemodel.grid.hd5".format(outbase), "w") as outfile:
             outfile.create_array(
-                outfile.root, "bias", np.delete(obsgrid.root.bias, rindxs, 1)
+                outfile.root, "bias", np.delete(obsgrid["bias"], rindxs, 1)
             )
             outfile.create_array(
-                outfile.root, "error", np.delete(obsgrid.root.error, rindxs, 1)
+                outfile.root, "error", np.delete(obsgrid["error"], rindxs, 1)
             )
             outfile.create_array(
                 outfile.root,
                 "completeness",
-                np.delete(obsgrid.root.completeness, rindxs, 1),
+                np.delete(obsgrid["completeness"], rindxs, 1),
             )
 
 

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -357,7 +357,6 @@ if __name__ == "__main__":  # pragma: no cover
     if 'None' in args.pdf2d_param_list:
         args.pdf2d_param_list = None
 
-
     run_fitting(
         use_sd=args.use_sd,
         nsubs=args.nsubs,

--- a/beast/tools/subgridding_tools.py
+++ b/beast/tools/subgridding_tools.py
@@ -161,7 +161,7 @@ def subgrid_info(grid_fname, noise_fname=None):
         # The following is also in fit.py, so we're kind of doing double
         # work here, but it's necessary if we want to know the proper
         # ranges for these values.
-        full_model_flux = seds[:] + noisemodel.root.bias[:]
+        full_model_flux = seds[:] + noisemodel["bias"]
         logtempseds = np.array(full_model_flux)
         full_model_flux = (
             np.sign(logtempseds)

--- a/beast/tools/tests/test_subgridding_tools.py
+++ b/beast/tools/tests/test_subgridding_tools.py
@@ -125,15 +125,15 @@ def test_merge_pdf1d_stats():
 
     noisemodel_vals = get_noisemodelcat(noise_trim_fname)
     slices = subgridding_tools.uniform_slices(
-        len(noisemodel_vals.root.bias), num_subgrids
+        len(noisemodel_vals["bias"]), num_subgrids
     )
     for i, slc in enumerate(slices):
         outname = noise_trim_fname.replace(".hd5", "sub{}.hd5".format(i))
         with tables.open_file(outname, "w") as outfile:
-            outfile.create_array(outfile.root, "bias", noisemodel_vals.root.bias[slc])
-            outfile.create_array(outfile.root, "error", noisemodel_vals.root.error[slc])
+            outfile.create_array(outfile.root, "bias", noisemodel_vals["bias"][slc])
+            outfile.create_array(outfile.root, "error", noisemodel_vals["error"][slc])
             outfile.create_array(
-                outfile.root, "completeness", noisemodel_vals.root.completeness[slc]
+                outfile.root, "completeness", noisemodel_vals["completeness"][slc]
             )
         sub_noise_trim_fnames.append(outname)
 


### PR DESCRIPTION
Change get_noisemodelcat to return a dictionary instead of an open pytables hdf5 file object. 
This fixes the unclosed files bug (closes #64).

This required changes to a few files to remove the specific pytables hdf5 interface to the noisemodel data.  Now the interface is a standard python dictionary.

Added a simple test for get_noisemodelcat.