### PR TITLE
Updated fitting docstrings

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -767,7 +767,7 @@ def Q_all_memory(
 
                 # save the lnps
                 if lnp_outname is not None:
-                    save_lnp(lnp_outname, save_lnp_vals, resume)
+                    save_lnp(lnp_outname, save_lnp_vals)
                     save_lnp_vals = []
 
     # do the final save of everything (or the last set for the lnp values)
@@ -800,7 +800,7 @@ def Q_all_memory(
 
     # save the lnps
     if lnp_outname is not None:
-        save_lnp(lnp_outname, save_lnp_vals, resume)
+        save_lnp(lnp_outname, save_lnp_vals)
 
 
 def IAU_names_and_extra_info(obsdata, surveyname="PHAT", extraInfo=False):

--- a/beast/fitting/pdf1d.py
+++ b/beast/fitting/pdf1d.py
@@ -7,21 +7,18 @@ import numpy as np
 class pdf1d:
     def __init__(self, gridvals, nbins, logspacing=False, minval=None, maxval=None):
         """
-        Create an object which can be used to efficiently generate a 1D pdf for an observed object
+        Create an object which can be used to efficiently generate a 1D pdf
+        for an observed object
 
         Parameters
         ----------
-
-        gridvals: array-like
-            values of the quantity for all the grid points
-
-        nbins: int
+        gridvals : ndarray
+            1D `float` array with the values of the quantity for all the grid points
+        nbins : int
             number of bins to use for the 1D pdf
-
-        logspacing: bool
+        logspacing : bool, optional
             whether to use logarithmic spacing for the bins
-
-        minval, maxval: float (optional)
+        minval, maxval : float, optional
             override the range for the bins. this can be useful to make
             sure that the pdfs for different runs have the same bins
         """
@@ -86,6 +83,24 @@ class pdf1d:
             self.pdf_bin_indxs = pdf_bin_indxs
 
     def gen1d(self, gindxs, weights):
+        """
+        Compute the 1D posterior PDFs based on the nD probabilities
+
+        Parameters
+        ----------
+        gindxs : ndarray
+            1D `int` array with the indxs of the weights in the full model grid
+        weights : ndarray
+            1D `float` array with the fit proabilities (likelihood*prior)
+            at each grid point
+
+        Returns
+        -------
+        bin_vals : ndarray
+            1D `float` array giving the values at the bin centers
+        vals_1d : ndarray
+            1D `float` array giving the bin pPDF values
+        """
 
         if self.bad:
             return (self.bin_vals, np.zeros((self.nbins)))

--- a/beast/fitting/pdf1d.py
+++ b/beast/fitting/pdf1d.py
@@ -91,7 +91,7 @@ class pdf1d:
         gindxs : ndarray
             1D `int` array with the indxs of the weights in the full model grid
         weights : ndarray
-            1D `float` array with the fit proabilities (likelihood*prior)
+            1D `float` array with the fit probabilities (likelihood*prior)
             at each grid point
 
         Returns

--- a/beast/fitting/pdf2d.py
+++ b/beast/fitting/pdf2d.py
@@ -128,7 +128,7 @@ class pdf2d:
         gindxs : ndarray
             1D `int` array with the indxs of the weights in the full model grid
         weights : ndarray
-            1D `float` array with the fit proabilities (likelihood*prior)
+            1D `float` array with the fit probabilities (likelihood*prior)
             at each grid point
 
         Returns

--- a/beast/fitting/pdf2d.py
+++ b/beast/fitting/pdf2d.py
@@ -19,21 +19,18 @@ class pdf2d:
         maxval_p2=None,
     ):
         """
-        Create an object which can be used to efficiently generate a 1D pdf for an observed object
+        Create an object which can be used to efficiently generate a 2D pdf
+        for an observed object
 
         Parameters
         ----------
-
-        gridvals_p1, gridvals_p2: array-like
-            values of the quantity for all the grid points
-
-        nbins_p1, nbins_p2: int
-            number of bins to use for each dimension of the 2D PDF
-
-        logspacing_p1, logspacing_p2: bool
-            whether to use logarithmic spacing for the bins of each dimension
-
-        minval_p1, maxval_p1, minval_p2, maxval_p2: float (optional)
+        gridvals_p1, gridvals_p2 : ndarray
+            1D `float` array with the values of the quantity for all the grid points
+        nbins_p1, nbins_p2 : int
+            number of bins to use for the 1D pdf
+        logspacing_p1, logspacing_p2 : bool, optional
+            whether to use logarithmic spacing for the bins
+        minval_p1, maxval_p1, minval_p2, maxval_p2 : float, optional
             override the range for the bins. this can be useful to make
             sure that the pdfs for different runs have the same bins
         """
@@ -41,7 +38,7 @@ class pdf2d:
         # copy values over
         self.nbins_p1 = nbins_p1
         self.nbins_p2 = nbins_p2
-        self.n_gridvals = len(gridvals_p1) # same as len(gridvals_p2)
+        self.n_gridvals = len(gridvals_p1)  # same as len(gridvals_p2)
         self.logspacing_p1 = logspacing_p1
         self.logspacing_p2 = logspacing_p2
 
@@ -67,20 +64,28 @@ class pdf2d:
 
         # set bin widths
         if self.nbins_p1 > 1:
-            self.bin_delta_p1 = (self.max_val_p1 - self.min_val_p1) / (self.nbins_p1 - 1)
+            self.bin_delta_p1 = (self.max_val_p1 - self.min_val_p1) / (
+                self.nbins_p1 - 1
+            )
         else:
             self.bin_delta_p1 = 1
         if self.nbins_p2 > 1:
-            self.bin_delta_p2 = (self.max_val_p2 - self.min_val_p2) / (self.nbins_p2 - 1)
+            self.bin_delta_p2 = (self.max_val_p2 - self.min_val_p2) / (
+                self.nbins_p2 - 1
+            )
         else:
             self.bin_delta_p2 = 1
 
         # set values for the bin middles/edges
-        self.bin_vals_p1 = self.min_val_p1 + np.arange(self.nbins_p1) * self.bin_delta_p1
+        self.bin_vals_p1 = (
+            self.min_val_p1 + np.arange(self.nbins_p1) * self.bin_delta_p1
+        )
         self.bin_edges_p1 = (
             self.min_val_p1 + (np.arange(self.nbins_p1 + 1) - 0.5) * self.bin_delta_p1
         )
-        self.bin_vals_p2 = self.min_val_p2 + np.arange(self.nbins_p2) * self.bin_delta_p2
+        self.bin_vals_p2 = (
+            self.min_val_p2 + np.arange(self.nbins_p2) * self.bin_delta_p2
+        )
         self.bin_edges_p2 = (
             self.min_val_p2 + (np.arange(self.nbins_p2 + 1) - 0.5) * self.bin_delta_p2
         )
@@ -97,7 +102,7 @@ class pdf2d:
         for i in range(self.nbins_p1):
             for j in range(self.nbins_p2):
                 # find the indicies for the current bin
-                cur_bin_indxs, = np.where(
+                (cur_bin_indxs,) = np.where(
                     (pdf_bin_num_p1 == (i + 1)) & (pdf_bin_num_p2 == (j + 1))
                 )
                 # save them
@@ -114,8 +119,23 @@ class pdf2d:
 
         self.pdf_bin_indxs = pdf_bin_indxs
 
-
     def gen2d(self, gindxs, weights):
+        """
+        Compute the 2D posterior PDFs based on the nD probabilities
+
+        Parameters
+        ----------
+        gindxs : ndarray
+            1D `int` array with the indxs of the weights in the full model grid
+        weights : ndarray
+            1D `float` array with the fit proabilities (likelihood*prior)
+            at each grid point
+
+        Returns
+        -------
+        vals_2d : ndarray
+            2D `float` array giving the bin pPDF values
+        """
 
         _tgrid = np.zeros(self.n_gridvals)
         _tgrid[gindxs] = weights
@@ -123,6 +143,6 @@ class pdf2d:
         for i in range(self.nbins_p1):
             for j in range(self.nbins_p2):
                 if len(self.pdf_bin_indxs[i][j]) > 0:
-                    _vals_2d[i,j] = np.sum(_tgrid[self.pdf_bin_indxs[i][j]])
+                    _vals_2d[i, j] = np.sum(_tgrid[self.pdf_bin_indxs[i][j]])
 
         return _vals_2d

--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -29,33 +29,25 @@ def trim_models(
     ----------
     sedgrid: grid.SEDgrid instance
         model grid
-
     sedgrid_noisemodel: beast noisemodel instance
         noise model data
-
     obsdata: Observation object instance
         observation catalog
-
     sed_outname: str
         name for output sed file
-
     noisemodel_outname: str
         name for output noisemodel file
-
-    sigma_fac: float
+    sigma_fac: float, optional
         factor for trimming the upper and lower range of grid so that
         the model range cuts off sigma_fac above and below the brightest
         and faintest models, respectively (default: 3.)
-
-    n_detected: int
+    n_detected: int, optional
         minimum number of bands where ASTs yielded a detection for
         a given model, if fewer detections than n_detected this model
         gets eliminated (default: 4)
-
-    inFlux: boolean
+    inFlux: boolean, optional
         if true data are in fluxes (default: True)
-
-    trunchen: boolean
+    trunchen: boolean, optional
         if true use the trunchen noise model (default: False)
     """
     # Store the brigtest and faintest fluxes in each band (for data and asts)

--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -27,27 +27,27 @@ def trim_models(
 
     Parameters
     ----------
-    sedgrid: grid.SEDgrid instance
+    sedgrid : grid.SEDgrid instance
         model grid
-    sedgrid_noisemodel: beast noisemodel instance
+    sedgrid_noisemodel : beast noisemodel instance
         noise model data
-    obsdata: Observation object instance
+    obsdata : Observation object instance
         observation catalog
-    sed_outname: str
+    sed_outname : str
         name for output sed file
-    noisemodel_outname: str
+    noisemodel_outname : str
         name for output noisemodel file
-    sigma_fac: float, optional
+    sigma_fac : float, optional
         factor for trimming the upper and lower range of grid so that
         the model range cuts off sigma_fac above and below the brightest
         and faintest models, respectively (default: 3.)
-    n_detected: int, optional
+    n_detected : int, optional
         minimum number of bands where ASTs yielded a detection for
         a given model, if fewer detections than n_detected this model
         gets eliminated (default: 4)
-    inFlux: boolean, optional
+    inFlux : boolean, optional
         if true data are in fluxes (default: True)
-    trunchen: boolean, optional
+    trunchen : boolean, optional
         if true use the trunchen noise model (default: False)
     """
     # Store the brigtest and faintest fluxes in each band (for data and asts)

--- a/beast/fitting/trim_grid.py
+++ b/beast/fitting/trim_grid.py
@@ -45,9 +45,9 @@ def trim_models(
         minimum number of bands where ASTs yielded a detection for
         a given model, if fewer detections than n_detected this model
         gets eliminated (default: 4)
-    inFlux : boolean, optional
+    inFlux : bool, optional
         if true data are in fluxes (default: True)
-    trunchen : boolean, optional
+    trunchen : bool, optional
         if true use the trunchen noise model (default: False)
     """
     # Store the brigtest and faintest fluxes in each band (for data and asts)

--- a/docs/fitting_api.rst
+++ b/docs/fitting_api.rst
@@ -2,10 +2,10 @@
 Fitting Module
 **************
 
-.. .. automodapi:: beast.fitting.fit
+.. automodapi:: beast.fitting.fit
 
 .. automodapi:: beast.fitting.pdf1d
-		
+
+.. automodapi:: beast.fitting.pdf2d
+
 .. automodapi:: beast.fitting.trim_grid
-   
-   


### PR DESCRIPTION
Updated the docstrings for the fitting subdirectory.  Used the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html) suggestions.

Also ran `black` on all the fitting code to remove PEP8 issues.

Docstings for all the routines now pass the API auto formatting so also updated the fitting API doc section.

Partially addresses (#80).