### PR TITLE
spectral grid test - remove isochrones with logL < -9

### DIFF
--- a/beast/physicsmodel/stars/tests/test_spectral_grid.py
+++ b/beast/physicsmodel/stars/tests/test_spectral_grid.py
@@ -28,6 +28,9 @@ def test_make_kurucz_tlusty_spectral_grid():
     # read in the cached isochrones
     oiso = ezIsoch(iso_fname)
 
+    # remove the isochrone points with logL=-9.999
+    oiso = ezIsoch(oiso.selectWhere("*", "logL > -9"))
+
     # define the distance
     distances = [24.47]
     distance_unit = units.mag

--- a/beast/physicsmodel/stars/tests/test_spectral_grid.py
+++ b/beast/physicsmodel/stars/tests/test_spectral_grid.py
@@ -29,7 +29,7 @@ def test_make_kurucz_tlusty_spectral_grid():
     oiso = ezIsoch(iso_fname)
 
     # remove the isochrone points with logL=-9.999
-    oiso = ezIsoch(oiso.selectWhere("*", "logL > -9"))
+    oiso.data = oiso[oiso["logL"] > -9]
 
     # define the distance
     distances = [24.47]


### PR DESCRIPTION
As discussed in #554, the tests didn't remove isochrones with `logL < -9` (#486, #491, #500), so this ensures the tests match what we expect.