### PR TITLE
Small fix to use_rate keyword in create_obsmodel.py

### DIFF
--- a/beast/tools/run/create_obsmodel.py
+++ b/beast/tools/run/create_obsmodel.py
@@ -111,7 +111,7 @@ def create_obsmodel(use_sd=True, nsubs=1, nprocs=1, subset=[None, None], use_rat
         if use_sd:
 
             input_list = [
-                (sedfile, curr_sd)
+                (sedfile, curr_sd, use_rate)
                 for sedfile in modelsedgridfiles
                 for curr_sd in sd_list
             ]
@@ -121,7 +121,7 @@ def create_obsmodel(use_sd=True, nsubs=1, nprocs=1, subset=[None, None], use_rat
         # if we're not splitting by source density
         else:
 
-            input_list = [(sedfile, None) for sedfile in modelsedgridfiles]
+            input_list = [(sedfile, None, use_rate) for sedfile in modelsedgridfiles]
 
             parallel_wrapper(gen_obsmodel, input_list, nprocs=nprocs)
 


### PR DESCRIPTION
As part of reviewing #553, I ran phat_small with 2 subgrids.  I discovered that the `use_rate` keyword wasn't propagated through `create_obsmodel.py` in the `nsubs>1` case.  (That's probably because `use_rate` only exists for phat_small, which doesn't have rate info, and we've never run phat_small with subgrids before.)

This should be added to both v2.0 and v1.4.