### PR TITLE
Increase number of PDF bins

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -338,7 +338,7 @@ def Q_all_memory(
     gridbackend : str or grid.GridBackend
         backend to use to load the grid if necessary (memory, cache, hdf)
         (see beast.core.grid)
-    max_nbins : int
+    max_nbins : int (default=100)
         maxiumum number of bins to use for the 1D likelihood calculations
     save_every_npts : int
         set to save the files below (if set) every n stars
@@ -885,6 +885,7 @@ def summary_table_memory(
     save_every_npts=None,
     lnp_npts=None,
     resume=False,
+    max_nbins=100,
     stats_outname=None,
     pdf1d_outname=None,
     pdf2d_outname=None,
@@ -921,6 +922,8 @@ def summary_table_memory(
     use_full_cov_matrix : bool
         set to use the full covariance matrix if it is present in the
         noise model file
+    max_nbins : int (default=100)
+        maxiumum number of bins to use for the 1D likelihood calculations
     stats_outname : str
         set to output the stats file into a FITS file with extensions
     pdf1d_outname : str
@@ -989,6 +992,7 @@ def summary_table_memory(
         threshold=threshold,
         save_every_npts=save_every_npts,
         lnp_npts=lnp_npts,
+        max_nbins=max_nbins,
         stats_outname=stats_outname,
         pdf1d_outname=pdf1d_outname,
         pdf2d_outname=pdf2d_outname,

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -302,7 +302,7 @@ def Q_all_memory(
     qnames_in,
     p=[16.0, 50.0, 84.0],
     gridbackend="cache",
-    max_nbins=50,
+    max_nbins=100,
     stats_outname=None,
     pdf1d_outname=None,
     pdf2d_outname=None,

--- a/beast/fitting/tests/test_fit_grid.py
+++ b/beast/fitting/tests/test_fit_grid.py
@@ -149,6 +149,7 @@ def test_fit_grid():
         threshold=-10.0,
         save_every_npts=100,
         lnp_npts=60,
+        max_nbins=50,
         stats_outname=stats_fname,
         pdf1d_outname=pdf1d_fname,
         lnp_outname=lnp_fname,

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -26,6 +26,7 @@ def run_fitting(
     choose_sd_sub=None,
     choose_subgrid=None,
     pdf2d_param_list=['Av', 'Rv', 'f_A', 'M_ini', 'logA', 'Z', 'distance'],
+    pdf_max_nbins=100,
     resume=False,
 ):
     """
@@ -60,6 +61,9 @@ def run_fitting(
 
     pdf2d_param_list : list of strings or None
         If set, do 2D PDFs of these parameters.  If None, don't make 2D PDFs.
+
+    pdf_max_nbins : int (default=100)
+        Maxiumum number of bins to use for the 1D and 2D PDFs
 
     resume : boolean (default=False)
         choose whether to resume existing run or start over
@@ -279,6 +283,7 @@ def fit_submodel(
             threshold=-10.0,
             save_every_npts=100,
             lnp_npts=500,
+            max_nbins=pdf_max_nbins,
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
             pdf2d_outname=pdf2d_file,
@@ -300,6 +305,7 @@ def fit_submodel(
             threshold=-10.0,
             save_every_npts=100,
             lnp_npts=500,
+            max_nbins=pdf_max_nbins,
             stats_outname=stats_file,
             pdf1d_outname=pdf_file,
             pdf2d_outname=pdf2d_file,


### PR DESCRIPTION
Per #570, increasing the max number of bins from 50 to 100.  Happy to change this to 200 (or some other number) if preferred.  This change should be added to both v1.4 and v2.0.

I expect that this will change the stats (slightly) and PDFs for non-gridded parameters (mass, luminosity, temperature, etc), so the tests will probably fail.  We'll have to coordinate updating files with #558 and #559.

Closes #570.