### PR TITLE
Supplement the existing input ASTs

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -429,11 +429,9 @@ def supplement_ast(
 
     if existingASTfile is not None and os.path.isfile(existingASTfile):
         print(
-            "{} exists. Will attempt to load SEDs for ASTs from there \
+             "{} exists. Will attempt to load SEDs for ASTs from there \
              and remove those SEDs from the SED grid".format(
-             existingASTfile
-             )
-        )
+                 existingASTfile))
 
         t = Table.read(existingASTfile, format="fits")
         sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)
@@ -448,12 +446,13 @@ def supplement_ast(
             idx_filter = [i for i, iflt in enumerate(filters) if key in iflt]
             bright_cut = mag_cuts[key][0]
             faint_cut = mag_cuts[key][1]
-            tmp_cond = np.logical_and(sedsMags[:,idx_filter] >= bright_cut,
-                                      sedsMags[:,idx_filter] <= faint_cut
+            tmp_cond = np.logical_and(sedsMags[:, idx_filter] >= bright_cut,
+                                      sedsMags[:, idx_filter] <= faint_cut
                                       )
+
             cond = np.logical_or(cond, tmp_cond.ravel())
 
-        sedsMags = sedsMags[cond,:]
+        sedsMags = sedsMags[cond, :]
         sedsIndx = sedsIndx[cond]
 
     # Randomly select models

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -425,7 +425,6 @@ def supplement_ast(
     sedsMags = -2.5 * np.log10(modelsedgrid.seds[:] / vega_flux)
 
     Nseds = sedsMags.shape[0]
-    Nf = sedsMags.shape[1]
     sedsIndx = np.arange(Nseds)
 
     if existingASTfile is not None and os.path.isfile(existingASTfile):

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -438,6 +438,7 @@ def supplement_ast(
         t = Table.read(outfile, format="fits")
         sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)
         sedsIndx = np.delete(sedsIndx, t["sedgrid_indx"])
+        Nseds = sedsMags.shape[0]
 
     # Apply selection conditions if supplied
     if mag_cuts is not None:

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -430,9 +430,9 @@ def supplement_ast(
 
     if existingASTfile is not None and os.path.isfile(existingASTfile):
         print(
-             "{} exists. Will attempt to load SEDs for ASTs from there \
-             and remove those SEDs from the SED grid".format(
-                 existingASTfile))
+            "{} exists. Will attempt to load SEDs for ASTs from there \
+            and remove those SEDs from the SED grid".format(
+                existingASTfile))
 
         t = Table.read(existingASTfile, format="fits")
         sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -380,7 +380,8 @@ def supplement_ast(
     Creates an additional fake star catalog from a BEAST model grid
     that fulfills the customized conditions to supplement input ASTs.
     If the existing input AST parameter file is given, already selected
-    models will be excluded from this process.
+    models will be excluded from this process. The input artificial
+    stars are picked randomly from the remaining models.
 
     Parameters
     ----------

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -432,10 +432,10 @@ def supplement_ast(
             "{} exists. Will attempt to load SEDs for ASTs from there \
              and remove those SEDs from the SED grid".format(
              existingASTfile
-            )
+             )
         )
 
-        t = Table.read(outfile, format="fits")
+        t = Table.read(existingASTfile, format="fits")
         sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)
         sedsIndx = np.delete(sedsIndx, t["sedgrid_indx"])
         Nseds = sedsMags.shape[0]
@@ -459,7 +459,7 @@ def supplement_ast(
     # Randomly select models
     # Supplementing ASTs does not need to follow
     # the toothpick-way selection
-    chosen_idxs = random.choices(np.arange(len(sedsIndx)), k=nAST)
+    chosen_idxs = np.random.choices(np.arange(len(sedsIndx)), k=nAST)
     sedsIndx = sedsIndx[chosen_idxs]
 
     # Gather the selected model seds in a table
@@ -481,6 +481,5 @@ def supplement_ast(
         grid_dict['sedgrid_indx'] = sedsIndx
         ast_params = Table(grid_dict)
         ast_params.write(outASTfile_params, overwrite=True)
-
 
     return sedsMags

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -30,8 +30,8 @@ def make_ast_inputs(pick_method, beast_settings_info):
     pick_method : string (default = "flux_bin_method")
         If not specified, use the flux bin method to select SEDs as default.
         If set to "random_seds", randomly select SEDs from the model grid.
-        If set to "suppl_seds", supplement input ASTs on top of the existing
-        input ASTs.
+        If set to "suppl_seds", supplement the existing input ASTs by randomly
+        selecting additional SEDs from the list of non-selected models.
 
     """
 

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -138,7 +138,6 @@ def make_ast_inputs(beast_settings_info, pick_method):
                 mag_cuts=mag_cuts,
             )
 
-
     # if the SED file does exist, read them in
     else:
         print("Reading existing AST SEDs")
@@ -208,16 +207,16 @@ if __name__ == "__main__":  # pragma: no cover
     args = parser.parse_args()
 
     if args.random_seds:
-        make_ast_inputs(beast_settings_info=args.beast_settings_file,
-                "random_seds")
+        make_ast_inputs("random_seds",
+                        beast_settings_info=args.beast_settings_file)
 
     if args.suppl_seds:
-        make_ast_inputs(beast_settings_info=args.beast_settings_file,
-                "suppl_seds")
+        make_ast_inputs("suppl_seds",
+                        beast_settings_info=args.beast_settings_file)
 
     else:
-        make_ast_inputs(beast_settings_info=args.beast_settings_file,
-                "flux_bin_method")
+        make_ast_inputs("flux_bin_method",
+                        beast_settings_info=args.beast_settings_file)
 
     # print help if no arguments
     if not any(vars(args).values()):

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -208,21 +208,21 @@ if __name__ == "__main__":  # pragma: no cover
 
     if args.random_seds:
         make_ast_inputs(
-                        beast_settings_info=args.beast_settings_file,
-                        pick_method="random_seds"
-                        )
+            beast_settings_info=args.beast_settings_file,
+            pick_method="random_seds"
+        )
 
     if args.suppl_seds:
         make_ast_inputs(
-                        beast_settings_info=args.beast_settings_file,
-                        pick_method="suppl_seds"
-                        )
+            beast_settings_info=args.beast_settings_file,
+            pick_method="suppl_seds"
+        )
 
     else:
         make_ast_inputs(
-                        beast_settings_info=args.beast_settings_file,
-                        pick_method="flux_bin_method"
-                        )
+            beast_settings_info=args.beast_settings_file,
+            pick_method="flux_bin_method"
+        )
 
     # print help if no arguments
     if not any(vars(args).values()):

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -17,7 +17,7 @@ from beast.observationmodel.ast import make_ast_xy_list
 from beast.tools import beast_settings
 
 
-def make_ast_inputs(pick_method,beast_settings_info):
+def make_ast_inputs(pick_method, beast_settings_info):
     """
     Make the list of artificial stars to be run through the photometry pipeline
 
@@ -124,9 +124,9 @@ def make_ast_inputs(pick_method,beast_settings_info):
 
             print("Supplementing ASTs")
 
-            nAST = datamodel.ast_N_supplement
-            existingASTfile = datamodel.ast_existing_file
-            mag_cuts = datamodel.ast_suppl_maglimit
+            nAST = settings.ast_N_supplement
+            existingASTfile = settings.ast_existing_file
+            mag_cuts = settings.ast_suppl_maglimit
 
             chosen_seds = supplement_ast(
                 modelsedgrid_filename,

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -130,7 +130,7 @@ def make_ast_inputs(beast_settings_info, pick_method):
 
             chosen_seds = supplement_ast(
                 modelsedgrid_filename,
-                datamodel.filters,
+                settings.filters,
                 nAST=nAST,
                 existingASTfile=existingASTfile,
                 outASTfile=outfile_seds,

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -17,7 +17,7 @@ from beast.observationmodel.ast import make_ast_xy_list
 from beast.tools import beast_settings
 
 
-def make_ast_inputs(beast_settings_info, pick_method):
+def make_ast_inputs(pick_method,beast_settings_info):
     """
     Make the list of artificial stars to be run through the photometry pipeline
 

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -17,7 +17,7 @@ from beast.observationmodel.ast import make_ast_xy_list
 from beast.tools import beast_settings
 
 
-def make_ast_inputs(pick_method, beast_settings_info):
+def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
     """
     Make the list of artificial stars to be run through the photometry pipeline
 
@@ -28,7 +28,7 @@ def make_ast_inputs(pick_method, beast_settings_info):
         if class: beast.tools.beast_settings.beast_settings instance
 
     pick_method : string (default = "flux_bin_method")
-        If not specified, use the flux bin method to select SEDs as default.
+        By default, use the flux bin method to select SEDs.
         If set to "random_seds", randomly select SEDs from the model grid.
         If set to "suppl_seds", supplement the existing input ASTs by randomly
         selecting additional SEDs from the list of non-selected models.
@@ -207,16 +207,22 @@ if __name__ == "__main__":  # pragma: no cover
     args = parser.parse_args()
 
     if args.random_seds:
-        make_ast_inputs("random_seds",
-                        beast_settings_info=args.beast_settings_file)
+        make_ast_inputs(
+                        beast_settings_info=args.beast_settings_file,
+                        pick_method="random_seds"
+                        )
 
     if args.suppl_seds:
-        make_ast_inputs("suppl_seds",
-                        beast_settings_info=args.beast_settings_file)
+        make_ast_inputs(
+                        beast_settings_info=args.beast_settings_file,
+                        pick_method="suppl_seds"
+                        )
 
     else:
-        make_ast_inputs("flux_bin_method",
-                        beast_settings_info=args.beast_settings_file)
+        make_ast_inputs(
+                        beast_settings_info=args.beast_settings_file,
+                        pick_method="flux_bin_method"
+                        )
 
     # print help if no arguments
     if not any(vars(args).values()):

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -31,6 +31,11 @@ which the artificial SEDs can be chosen.
    results in uneven constraints on the noise model, since there will be very few
    stars that probe the brightest or faintest parts of the model grid.
 
+If the user needs to supplement their existing input ASTs in particular areas of
+the color-magnitude diagrams set by bright and faint magnitudes in each filter,
+the user can use '--suppl_seds' option when generating additional input ASTs. By
+default, new input ASTs will be randomly selected within the given magnitude ranges.
+
 
 Functions
 =========
@@ -49,6 +54,9 @@ These functions are found in ``beast.observationmodel.ast.make_ast_input_list``.
 
 - `mag_limits`: Determines the magnitude limits for the models in each filter in
   the photometry file.
+
+- 'supplement_ast': Supplement the existing input ASTs that fulfill the user
+  defined magnitude limits.
 
 
 Picking positions
@@ -83,6 +91,7 @@ Parameters used by the flux bin method of selecting SEDs
   Minimum number of model SEDs that need to fall into each bin (if
   `pick_models_toothpick_style` is used)
 
+
 Parameters used by the random SED selection method
 --------------------------------------------------
 
@@ -103,6 +112,29 @@ Parameters used by the random SED selection method
 - `ast_models_selected_per_age` : integer (Default = 70)
 
   Number of models to pick per age
+
+
+  Parameters used by the supplementing AST method
+  --------------------------------------------------
+  - 'ast_supplement' : bool
+
+    If True, supplement the existing input ASTs
+
+  - 'ast_N_supplement' : integer (Default = 1000)
+
+    Number of unique model SEDs to select. These selected unique SEDs will be
+    repeated over N number of source density bins. In total, the user will supplement
+    ast_N_supplement x ast_N_bins
+
+  - 'ast_existing_file' : string (optional)
+
+    If the name of the existing input AST parameter file is supplied, additional
+    ASTs will be selected by excluding the SED models listed in that file.
+
+  - 'ast_suppl_maglimit' : dictionary (optional)
+
+    If supplied, these magnitude limits will be applied to the SED model grids
+    when selecting additional ASTs.
 
 
 Parameters used for selecting SED positions

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -114,27 +114,27 @@ Parameters used by the random SED selection method
   Number of models to pick per age
 
 
-  Parameters used by the supplementing AST method
-  --------------------------------------------------
-  - 'ast_supplement' : bool
+Parameters used by the supplementing AST method
+-----------------------------------------------
+- `ast_supplement` : bool
+  
+  If True, supplement the existing input ASTs
 
-    If True, supplement the existing input ASTs
+- `ast_N_supplement` : integer (Default = 1000)
 
-  - 'ast_N_supplement' : integer (Default = 1000)
+  Number of unique model SEDs to select. These selected unique SEDs will be
+  repeated over N number of source density bins. In total, the user will supplement
+  ast_N_supplement x ast_N_bins
 
-    Number of unique model SEDs to select. These selected unique SEDs will be
-    repeated over N number of source density bins. In total, the user will supplement
-    ast_N_supplement x ast_N_bins
+- `ast_existing_file` : string (optional)
 
-  - 'ast_existing_file' : string (optional)
+  If the name of the existing input AST parameter file is supplied, additional
+  ASTs will be selected by excluding the SED models listed in that file.
 
-    If the name of the existing input AST parameter file is supplied, additional
-    ASTs will be selected by excluding the SED models listed in that file.
+- `ast_suppl_maglimit` : dictionary (optional)
 
-  - 'ast_suppl_maglimit' : dictionary (optional)
-
-    If supplied, these magnitude limits will be applied to the SED model grids
-    when selecting additional ASTs.
+  If supplied, these magnitude limits will be applied to the SED model grids
+  when selecting additional ASTs.
 
 
 Parameters used for selecting SED positions

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -55,7 +55,7 @@ These functions are found in ``beast.observationmodel.ast.make_ast_input_list``.
 - `mag_limits`: Determines the magnitude limits for the models in each filter in
   the photometry file.
 
-- 'supplement_ast': Supplement the existing input ASTs that fulfill the user
+- `supplement_ast`: Supplement the existing input ASTs that fulfill the user
   defined magnitude limits.
 
 

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -153,6 +153,13 @@ physics model grid.
 
      $ python -m beast.tools.run.make_ast_inputs beast_settings.txt --random_seds
 
+In case the user needs to supplement the existing input ASTs, it is possible
+to select additional model SEDs.
+
+  .. code-block:: console
+
+     $ python -m beast.tools.run.make_ast_inputs --suppl_seds
+
 How the sources are placed in the image is determined by the ast_source_density_table
 variable in `beast_settings.txt`
 


### PR DESCRIPTION
I added a new functionality to supplement the existing input ASTs. This pull request resolves the issue #496. This functionality can be used if the user needs additional ASTs in specific magnitude ranges of individual bands or from unselected SED models. When the SED model parameter file for the existing input AST is provided, the SED models in the existing input AST list will be excluded. 

Closes #496.