### PR TITLE
Add tool to calculate observation depths

### DIFF
--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -33,6 +33,7 @@ from beast.fitting import fit
 from beast.tools import (
     get_libfiles,
     beast_settings,
+    calculate_depth,
     subgridding_tools,
     star_type_probability,
 )
@@ -848,6 +849,28 @@ class TestRegressionSuite:
 
         # compare to new table
         compare_tables(expected_star_prob, Table(star_prob))
+
+    def test_calculate_depth(self):
+        """
+        Test for calculate_depth.py
+        """
+        # calculate depth for 50% and 75% completeness
+        depth = calculate_depth.calculate_depth(
+            self.seds_fname_cache,
+            self.noise_fname_cache,
+            completeness_value=[0.5, 0.75],
+        )
+        # expected results
+        expected_dict = {
+            "HST_WFC3_F275W": [25.000309202589012, 24.80610510139205],
+            "HST_WFC3_F336W": [24.65974845352875, 24.338061586936263],
+            "HST_ACS_WFC_F475W": [np.nan, np.nan],
+            "HST_ACS_WFC_F814W": [np.nan, 24.368742437736692],
+            "HST_WFC3_F110W": [np.nan, np.nan],
+            "HST_WFC3_F160W": [21.99298441116123, 21.504534701422067],
+        }
+        # compare them
+        compare_tables(Table(expected_dict), Table(depth))
 
     # ###################################################################
     # tools.run tests

--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -33,7 +33,7 @@ from beast.fitting import fit
 from beast.tools import (
     get_libfiles,
     beast_settings,
-    calculate_depth,
+    calc_depth_from_completeness,
     subgridding_tools,
     star_type_probability,
 )
@@ -850,15 +850,16 @@ class TestRegressionSuite:
         # compare to new table
         compare_tables(expected_star_prob, Table(star_prob))
 
-    def test_calculate_depth(self):
+    def test_calc_depth_from_completeness(self):
         """
         Test for calculate_depth.py
         """
         # calculate depth for 50% and 75% completeness
-        depth = calculate_depth.calculate_depth(
+        depth = calc_depth_from_completeness.calc_depth(
             self.seds_fname_cache,
             self.noise_fname_cache,
             completeness_value=[0.5, 0.75],
+            vega_mag=True,
         )
         # expected results
         expected_dict = {

--- a/beast/tools/calc_depth_from_completeness.py
+++ b/beast/tools/calc_depth_from_completeness.py
@@ -67,7 +67,6 @@ def calc_depth(
             sed_grid = modelsedgrid.seds
         # get list of filters
         filter_list = modelsedgrid.filters
-        n_filter = len(filter_list)
 
         # read in the noise model
         noisegrid = noisemodel.get_noisemodelcat(str(noise_model))
@@ -77,7 +76,7 @@ def calc_depth(
         # put it all into a table
         table_dict = {filt: sed_grid[:, f] for f, filt in enumerate(filter_list)}
         table_dict.update(
-            {filt+"_compl": model_compl[:, f] for f, filt in enumerate(filter_list)}
+            {filt + "_compl": model_compl[:, f] for f, filt in enumerate(filter_list)}
         )
 
         # append to the list
@@ -90,17 +89,16 @@ def calc_depth(
     if vega_mag:
         _, vega_flux, _ = Vega(source=vega_fname).getFlux(filter_list)
 
-
     # ------ Calculate depth
 
     # initialize dictionary to hold results
-    depth_dict = {filt:[] for filt in filter_list}
+    depth_dict = {filt: [] for filt in filter_list}
 
     # grab numbers for each filter
     for f, filt in enumerate(filter_list):
 
         use_sed = compl_table[filt]
-        use_comp = compl_table[filt+"_compl"]
+        use_comp = compl_table[filt + "_compl"]
 
         # get sorted versions of data
         sort_ind = np.argsort(use_sed)
@@ -122,7 +120,7 @@ def calc_depth(
             comp_flux = sort_sed[first_ind]
             # save it
             if vega_mag:
-                depth_dict[filt].append(-2.5 * np.log10(comp_flux/vega_flux[f]))
+                depth_dict[filt].append(-2.5 * np.log10(comp_flux / vega_flux[f]))
             else:
                 depth_dict[filt].append(comp_flux)
 

--- a/beast/tools/calc_depth_from_completeness.py
+++ b/beast/tools/calc_depth_from_completeness.py
@@ -5,7 +5,7 @@ import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
 from beast.observationmodel.vega import Vega
 
 
-def calculate_depth(
+def calc_depth(
     physgrid_list,
     noise_model_list,
     completeness_value=0.5,
@@ -125,8 +125,6 @@ def calculate_depth(
                 depth_dict[filt].append(-2.5 * np.log10(comp_flux/vega_flux[f]))
             else:
                 depth_dict[filt].append(comp_flux)
-            if 'F475W' in filt:
-                import pdb; pdb.set_trace()
 
     # return the results
     return depth_dict

--- a/beast/tools/calculate_depth.py
+++ b/beast/tools/calculate_depth.py
@@ -1,0 +1,132 @@
+import numpy as np
+from astropy.table import Table, vstack
+from beast.physicsmodel.grid import SEDGrid
+import beast.observationmodel.noisemodel.generic_noisemodel as noisemodel
+from beast.observationmodel.vega import Vega
+
+
+def calculate_depth(
+    physgrid_list,
+    noise_model_list,
+    completeness_value=0.5,
+    vega_mag=True,
+    vega_fname=None,
+):
+    """
+    Calculate the observation depth of a field using the completeness.  Some
+    fields have low completeness at both faint and bright fluxes; this finds
+    the faintest flux at which the completeness exceeds the given value(s).
+
+    Parameters
+    ----------
+    physgrid_list : string or list of strings
+        Name of the physics model file.  If there are multiple physics model
+        grids (i.e., if there are subgrids), list them all here.
+
+    noise_model_list : string or list of strings
+        Name of the noise model file.  If there are multiple files for
+        physgrid_list (because of subgrids), list the noise model file
+        associated with each physics model file.
+
+    completeness_value : float or list of floats
+        The completeness(es) at which to evaluate the depth. Completeness is
+        defined in the range 0.0 to 1.0.
+
+    vega_mag : boolean (default=True)
+        If True, return results in Vega mags. Otherwise returns flux in
+        erg/s/cm^2/A.
+
+    vega_fname : string
+        filename for the vega info (useful for testing)
+
+
+    Returns
+    -------
+    depth_dict : dictionary
+        keys are the filters present in the grid, each value is the flux or Vega
+        mag for each of the requested completeness values
+
+    """
+
+    # ------ Reading in data
+
+    # If there are subgrids, we can't read them all into memory.  Therefore,
+    # we'll go through each one and just grab the relevant parts.
+    compl_table_list = []
+
+    # make a table for each physics model + noise model
+    for physgrid, noise_model in zip(
+        np.atleast_1d(physgrid_list), np.atleast_1d(noise_model_list)
+    ):
+
+        # get the physics model grid - includes priors
+        modelsedgrid = SEDGrid(str(physgrid))
+        if hasattr(modelsedgrid.seds, "read"):
+            sed_grid = modelsedgrid.seds.read()
+        else:
+            sed_grid = modelsedgrid.seds
+        # get list of filters
+        filter_list = modelsedgrid.filters
+        n_filter = len(filter_list)
+
+        # read in the noise model
+        noisegrid = noisemodel.get_noisemodelcat(str(noise_model))
+        # get the completeness
+        model_compl = noisegrid["completeness"]
+
+        # put it all into a table
+        table_dict = {filt: sed_grid[:, f] for f, filt in enumerate(filter_list)}
+        table_dict.update(
+            {filt+"_compl": model_compl[:, f] for f, filt in enumerate(filter_list)}
+        )
+
+        # append to the list
+        compl_table_list.append(Table(table_dict))
+
+    # stack all the tables into one
+    compl_table = vstack(compl_table_list)
+
+    # if chosen, get the vega fluxes for the filters
+    if vega_mag:
+        _, vega_flux, _ = Vega(source=vega_fname).getFlux(filter_list)
+
+
+    # ------ Calculate depth
+
+    # initialize dictionary to hold results
+    depth_dict = {filt:[] for filt in filter_list}
+
+    # grab numbers for each filter
+    for f, filt in enumerate(filter_list):
+
+        use_sed = compl_table[filt]
+        use_comp = compl_table[filt+"_compl"]
+
+        # get sorted versions of data
+        sort_ind = np.argsort(use_sed)
+        sort_sed = use_sed[sort_ind]
+        sort_comp = use_comp[sort_ind]
+
+        # grab depths
+        for compl in np.atleast_1d(completeness_value):
+
+            # first check whether the noise model even covers this completeness
+            # (in case there weren't sufficient ASTs)
+            if (compl < np.min(sort_comp)) or (compl > np.max(sort_comp)):
+                depth_dict[filt].append(np.nan)
+                continue
+
+            # find first instance of completeness > N
+            first_ind = np.where(sort_comp > compl)[0][0]
+            # corresponding flux
+            comp_flux = sort_sed[first_ind]
+            # save it
+            if vega_mag:
+                depth_dict[filt].append(-2.5 * np.log10(comp_flux/vega_flux[f]))
+            else:
+                depth_dict[filt].append(comp_flux)
+            if 'F475W' in filt:
+                import pdb; pdb.set_trace()
+
+    # return the results
+    return depth_dict

--- a/docs/other_tools.rst
+++ b/docs/other_tools.rst
@@ -23,3 +23,31 @@ and save it to disk:
   >>>
   >>> # Convert the HDF5 file to a FITS file (yay!) and save it to disk
   >>> convert_hdf5_to_fits.st_file(file_name = phot_file) #doctest: +SKIP
+
+
+Observation Depth
+-----------------
+
+The noise model contains completeness information for each filter.  The
+`calculate_depth` tool uses that to find the Vega magnitude (or flux in
+erg/s/cm^2/A) at which a given completeness is reached.  This is useful for
+evaluating the depth of your observations.
+
+.. code-block:: python
+
+  >>> from beast.tools import calculate_depth #doctest: +SKIP
+  >>>
+  >>> # Find the 50% and 75% completeness for phat_small example
+  >>> depth = calculate_depth.calculate_depth(  #doctest: +SKIP
+          'beast_example_phat_seds.grid.hd5',
+          'beast_example_phat_noisemodel.grid.hd5',
+          completeness_value=[0.5, 0.75]
+      )
+  >>> # Depth in F275W (Vega mag)
+  >>> depth['HST_WFC3_F275W'] #doctest: +SKIP
+  [25.000309202589012, 24.80610510139205]
+  >>>
+  >>> # Depth in F814W (Vega mag)
+  >>> # NaNs show that ASTs don't go deep enough to evaluate 50% completeness
+  >>> depth['HST_ACS_WFC_F814W'] #doctest: +SKIP
+  [nan, 24.368742437736692]

--- a/docs/other_tools.rst
+++ b/docs/other_tools.rst
@@ -3,6 +3,7 @@ BEAST Miscellaneous Tools
 #########################
 
 The following miscellaneous tools are useful for handling data formats and
+doing assorted data characterization.
 
 .. _other_beast_tools:
 
@@ -41,7 +42,8 @@ evaluating the depth of your observations.
   >>> depth = calculate_depth.calculate_depth(  #doctest: +SKIP
           'beast_example_phat_seds.grid.hd5',
           'beast_example_phat_noisemodel.grid.hd5',
-          completeness_value=[0.5, 0.75]
+          completeness_value=[0.5, 0.75],
+          vega_mag=True
       )
   >>> # Depth in F275W (Vega mag)
   >>> depth['HST_WFC3_F275W'] #doctest: +SKIP

--- a/docs/other_tools.rst
+++ b/docs/other_tools.rst
@@ -30,16 +30,16 @@ Observation Depth
 -----------------
 
 The noise model contains completeness information for each filter.  The
-`calculate_depth` tool uses that to find the Vega magnitude (or flux in
-erg/s/cm^2/A) at which a given completeness is reached.  This is useful for
+`calc_depth_from_completeness` tool uses that to find the Vega magnitude (or flux
+in erg/s/cm^2/A) at which a given completeness is reached.  This is useful for
 evaluating the depth of your observations.
 
 .. code-block:: python
 
-  >>> from beast.tools import calculate_depth #doctest: +SKIP
+  >>> from beast.tools import calc_depth_from_completeness #doctest: +SKIP
   >>>
   >>> # Find the 50% and 75% completeness for phat_small example
-  >>> depth = calculate_depth.calculate_depth(  #doctest: +SKIP
+  >>> depth = calc_depth_from_completeness.calc_depth(  #doctest: +SKIP
           'beast_example_phat_seds.grid.hd5',
           'beast_example_phat_noisemodel.grid.hd5',
           completeness_value=[0.5, 0.75],


### PR DESCRIPTION
This adds the tool `calculate_depth`, which will find either the flux or Vega mag corresponding to the requested completeness(es).  If the ASTs (and therefore the noise model) don't cover a given completeness, it returns a `NaN`.  Docs and a test are included.

@karllark I included an input for `vega_fname`, since I saw it in some other code that said it was useful for testing, but I'm not actually sure if it's necessary.

```
>>> from beast.tools import calculate_depth
>>> calculate_depth.calculate_depth(
          'beast_example_phat_seds.grid.hd5',
          'beast_example_phat_noisemodel.grid.hd5',
          completeness_value=[0.5, 0.75],
          vega_mag=True
    )
{"HST_WFC3_F275W": [25.000309202589012, 24.80610510139205],
    "HST_WFC3_F336W": [24.65974845352875, 24.338061586936263],
    "HST_ACS_WFC_F475W": [np.nan, np.nan],
    "HST_ACS_WFC_F814W": [np.nan, 24.368742437736692],
    "HST_WFC3_F110W": [np.nan, np.nan],
    "HST_WFC3_F160W": [21.99298441116123, 21.504534701422067]}
```