### PR TITLE
adding input flux/rate/vega to simulation output table

### DIFF
--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -293,12 +293,10 @@ def gen_SimObs_from_sedgrid(
 
         bname = filter.split(sep="_")[-1].upper()
         fluxname = f"{bname}_FLUX"
-        ot[fluxname] = Column(simflux)
-
         colname = f"{bname}_RATE"
-        ot[colname] = Column(ot[fluxname] / vega_flux[k])
-
         magname = f"{bname}_VEGA"
+        ot[fluxname] = Column(simflux)
+        ot[colname] = Column(ot[fluxname] / vega_flux[k])
         pindxs = ot[colname] > 0.0
         nindxs = ot[colname] <= 0.0
         ot[magname] = Column(ot[colname])

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -288,6 +288,7 @@ def gen_SimObs_from_sedgrid(
     # simulated data
     for k, filter in enumerate(sedgrid.filters):
         simflux_wbias = flux[sim_indx, k] + model_bias[sim_indx, k]
+
         simflux = np.random.normal(loc=simflux_wbias, scale=model_unc[sim_indx, k])
 
         bname = filter.split(sep="_")[-1].upper()
@@ -303,6 +304,22 @@ def gen_SimObs_from_sedgrid(
         ot[magname] = Column(ot[colname])
         ot[magname][pindxs] = -2.5 * np.log10(ot[colname][pindxs])
         ot[magname][nindxs] = -99.999
+
+        # add in the physical model values in a form similar to
+        # the output simulated (physics+obs models) values
+        # useful if using the simulated data to interpolate ASTs
+        #   (e.g. for MATCH)
+        fluxname = f"{bname}_INPUT_FLUX"
+        ratename = f"{bname}_INPUT_RATE"
+        magname = f"{bname}_INPUT_VEGA"
+        ot[fluxname] = Column(flux[sim_indx, k])
+        ot[ratename] = Column(ot[fluxname] / vega_flux[k])
+        pindxs = ot[ratename] > 0.0
+        nindxs = ot[ratename] <= 0.0
+        ot[magname] = Column(ot[ratename])
+        ot[magname][pindxs] = -2.5 * np.log10(ot[ratename][pindxs])
+        ot[magname][nindxs] = -99.999
+
     # model parmaeters
     for qname in qnames:
         ot[qname] = Column(sedgrid[qname][sim_indx])

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -54,6 +54,9 @@ def simulate_obs(
     nsim = int(nsim)
     samples_per_grid = int(np.ceil(nsim / n_phys))
 
+    if ranseed is not None:
+        ranseed = int(ranseed)
+
     # list to hold all simulation tables
     simtable_list = []
 
@@ -74,7 +77,7 @@ def simulate_obs(
             noisegrid,
             nsim=samples_per_grid,
             weight_to_use=weight_to_use,
-            ranseed=int(ranseed),
+            ranseed=ranseed,
         )
 
         # append to the list

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -11,7 +11,13 @@ This is done using the
 `beast.observationmodel.observations.gen_SimObs_from_sedgrid` function.
 The script
 `tools/simulate_obs.py` can be run directly or using the `beast simulate_obs`
-command once the beast has been installed.  The module
+command once the beast has been installed.
+Simulations require already created BEAST physics and observation model grids.
+The physics model grid includes the ensemble parameters as these are the same
+as the BEAST :ref:`beast_priors`.
+If a different ensemble model is needed (e.g., with a different SFH), then a
+new physics model (and possible observations model) will be needed.
+The module
 uses already created BEAST physics and observation model grids
 by sampling the full nD prior function that is part of the physics
 model grid.  The observation model grid provides the information on
@@ -42,6 +48,8 @@ as `band_flux` in physical units (ergs cm^-2 s^-1 A^-1),
 `band_rate` as normalized Vega fluxes (`band_flux`/vega_flux to match how
 the observed data are given), and `band_vega` as vega magnitudes with zero and
 negative fluxes given as -99.999.
+The physicsgrid values without noise/bias are given as `band_input_flux`,
+`band_input_rate`, and `band_input_vega`.
 
 When creating simulated observations, using the standard IMF mass prior will
 skew your catalog to lower-mass stars.  If you wish to have similar weights for

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ doctest_plus = enabled
 text_file_format = rst
 addopts = --doctest-rst
 norecursedirs =
-    measure_extinction/docs/_build/*
-    measure_extinction/docs/api/*
+    beast/docs/_build/*
+    beast/docs/api/*
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Adds in the input flux/rate/vega(mag) to the simulation output.  

This supports the use of the simulations as a way to interpolate the ASTs to generate a larger list of ASTs (useful for MATCH).