### PR TITLE
fix plot_cmd.py savefig keyword

### DIFF
--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -19,7 +19,7 @@ def plot_cmd(
     mag1_filter="F475W",
     mag2_filter="F814W",
     mag3_filter="F475W",
-    savefig=False,
+    savefig=None,
     show_plot=True,
 ):
     """
@@ -28,17 +28,17 @@ def plot_cmd(
 
     Parameters
     ----------
-    fitsfile:           str
+    fitsfile : str
         input fitsfile (includes full path to file); format = .fits
-    mag1_filter:        str
-        1st color filter; default = 'F475W'
-    mag2_filter:        str
-        2nd color filter; default = 'F814W'
-    mag3_filter:        str
-        magnitude; default = 'F475W'
-    savefig:            boolean
-        save figure; default = False
-    show_plot:          boolean
+    mag1_filter : str (default='F475W')
+        1st color filter
+    mag2_filter : str (default='F814W')
+        2nd color filter
+    mag3_filter : str (default='F475W')
+        magnitude
+    savefig : str or None (default=None)
+        to save the figure, set this to the file extension (e.g., 'png', 'pdf')
+    show_plot : boolean
         True, show the plot (to screen or a file)
         False, return the fig
     """
@@ -111,7 +111,10 @@ if __name__ == "__main__":  # pragma: no cover
         help="Choose filter for the magnitude",
     )
     parser.add_argument(
-        "--savefig", action="store", default="True", help="Save figure or plot it",
+        "--savefig",
+        action="store",
+        default=None,
+        help="To save the figure, set this to the file extension (e.g., 'png', 'pdf')",
     )
 
     args = parser.parse_args()

--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -19,7 +19,7 @@ def plot_cmd(
     mag1_filter="F475W",
     mag2_filter="F814W",
     mag3_filter="F475W",
-    save_fig=None,
+    savefig=None,
     show_plot=True,
 ):
     """
@@ -36,7 +36,7 @@ def plot_cmd(
         2nd color filter
     mag3_filter : str (default='F475W')
         magnitude
-    save_fig : str or None (default=None)
+    savefig : str or None (default=None)
         to save the figure, set this to the file extension (e.g., 'png', 'pdf')
     show_plot : boolean
         True, show the plot (to screen or a file)
@@ -80,8 +80,8 @@ def plot_cmd(
 
     # save or show fig
     if show_plot:
-        if save_fig:
-            fig.savefig("{}.{}".format(basename, save_fig))
+        if savefig:
+            fig.savefig("{}.{}".format(basename, savefig))
         else:
             plt.show()
     else:
@@ -110,12 +110,6 @@ if __name__ == "__main__":  # pragma: no cover
         default="F475W",
         help="Choose filter for the magnitude",
     )
-    parser.add_argument(
-        "--save_fig",
-        action="store",
-        default=None,
-        help="To save the figure, set this to the file extension (e.g., 'png', 'pdf')",
-    )
 
     args = parser.parse_args()
 
@@ -125,5 +119,5 @@ if __name__ == "__main__":  # pragma: no cover
         mag1_filter=args.mag1,
         mag2_filter=args.mag2,
         mag3_filter=args.mag3,
-        save_fig=args.save_fig,
+        savefig=args.savefig,
     )

--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -19,7 +19,7 @@ def plot_cmd(
     mag1_filter="F475W",
     mag2_filter="F814W",
     mag3_filter="F475W",
-    savefig=None,
+    savefig=False,
     show_plot=True,
 ):
     """
@@ -36,7 +36,7 @@ def plot_cmd(
         2nd color filter
     mag3_filter : str (default='F475W')
         magnitude
-    savefig : str or None (default=None)
+    savefig : str (default=False)
         to save the figure, set this to the file extension (e.g., 'png', 'pdf')
     show_plot : boolean
         True, show the plot (to screen or a file)

--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -19,7 +19,7 @@ def plot_cmd(
     mag1_filter="F475W",
     mag2_filter="F814W",
     mag3_filter="F475W",
-    savefig=None,
+    save_fig=None,
     show_plot=True,
 ):
     """
@@ -36,7 +36,7 @@ def plot_cmd(
         2nd color filter
     mag3_filter : str (default='F475W')
         magnitude
-    savefig : str or None (default=None)
+    save_fig : str or None (default=None)
         to save the figure, set this to the file extension (e.g., 'png', 'pdf')
     show_plot : boolean
         True, show the plot (to screen or a file)
@@ -80,8 +80,8 @@ def plot_cmd(
 
     # save or show fig
     if show_plot:
-        if savefig:
-            fig.savefig("{}.{}".format(basename, savefig))
+        if save_fig:
+            fig.savefig("{}.{}".format(basename, save_fig))
         else:
             plt.show()
     else:
@@ -111,7 +111,7 @@ if __name__ == "__main__":  # pragma: no cover
         help="Choose filter for the magnitude",
     )
     parser.add_argument(
-        "--savefig",
+        "--save_fig",
         action="store",
         default=None,
         help="To save the figure, set this to the file extension (e.g., 'png', 'pdf')",
@@ -125,5 +125,5 @@ if __name__ == "__main__":  # pragma: no cover
         mag1_filter=args.mag1,
         mag2_filter=args.mag2,
         mag3_filter=args.mag3,
-        savefig=args.savefig,
+        save_fig=args.save_fig,
     )

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -72,7 +72,7 @@ sample call from the command line may be:
 where `outfile.fits` may be the output from `simulate_obs`.
 `mag1`-`mag2` is the color, and `mag3` the magnitude.  If you would like to save
 (rather than simply display) the figure, include ``--save_fig png`` (or another
-preferred file extension), and the figure with be saved as `outfile_plot.png` in
+preferred file extension), and the figure will be saved as `outfile_plot.png` in
 the directory of `outfile.fits`.
 
 **************

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -71,7 +71,7 @@ sample call from the command line may be:
 
 where `outfile.fits` may be the output from `simulate_obs`.
 `mag1`-`mag2` is the color, and `mag3` the magnitude.  If you would like to save
-(rather than simply display) the figure, include ``--save_fig png`` (or another
+(rather than simply display) the figure, include ``--savefig png`` (or another
 preferred file extension), and the figure will be saved as `outfile_plot.png` in
 the directory of `outfile.fits`.
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -70,9 +70,10 @@ sample call from the command line may be:
    $ beast plot_cmd outfile.fits --mag1 F475W --mag2 F814W --mag3 F475W
 
 where `outfile.fits` may be the output from `simulate_obs`.
-`mag1`-`mag2` is the color, and `mag3` the magnitude.
-By default the figure is saved as `outfile_plot.png` in the directory
-of `outfile.fits`.
+`mag1`-`mag2` is the color, and `mag3` the magnitude.  If you would like to save
+(rather than simply display) the figure, include ``--save_fig png`` (or another
+preferred file extension), and the figure with be saved as `outfile_plot.png` in
+the directory of `outfile.fits`.
 
 **************
 Remove Filters


### PR DESCRIPTION
While chatting with @kmcquinn about `plot_cmd`, we ran into a problem with the `savefig` keyword.  Renaming it to `save_fig` solves the problem - apparently argparse was somehow convinced that the keyword was already defined elsewhere.  I also clarified the usage of the keyword in the docstring and in the docs.