### PR TITLE
splitting catalogs by source density: add keyword for minimum number of sub-files

### DIFF
--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -211,14 +211,16 @@ that don't have full imaging coverage, and to create ds9 region files:
 
 
 The observed catalog should be split into separate files for each source
-density.  In addition, each source density catalog is split into a set of
-sub files to have at most 'n_per_file' sources.  The sources are sorted by
-the 'sort_col' flux before splitting to put sources with similar brightness
-together.  This splitting into sub files sorted by flux allows for trimming
-the BEAST physics+observation model, removing objects that are too bright
-or too faint to fit any of the sources in the file.  In addition, this
-allows for running the BEAST fitting in parallel with each sub file
-on a different core.
+density.  In addition, each source density catalog can be split into a set of
+sub-files to have at most 'n_per_file' sources (or, if there are very few stars
+in a source density bin, at least 'min_n_subfile' sub-files).  The sources are
+sorted by the 'sort_col' flux before splitting to put sources with similar
+brightness together.  This splitting into sub files sorted by flux allows for
+trimming the BEAST physics+observation model, removing objects that are too
+bright or too faint to fit any of the sources in the file; more sub-files mean a
+narrower range of flux in each one, so more is trimmed and fitting is faster.
+In addition, this allows for running the BEAST fitting in parallel with each
+sub-file on a different core.
 
 Command to split both the catalog and AST files by source density:
 
@@ -226,7 +228,7 @@ Command to split both the catalog and AST files by source density:
 
     $ python -m beast.tools.split_catalog_using_map.py phot_catalog_cut.fits \
           ast_catalog_cut.fits phot_catalog_sourceden_map.hd5 --bin_width 1 \
-          --n_per_file 6250 --sort_col F475W_RATE
+          --n_per_file 6250 --min_n_subfile 3 --sort_col F475W_RATE
 
 
 *****************


### PR DESCRIPTION
As I'm doing production runs, I've come across a problem in which source densities with a small number of stars don't get split into multiple subfiles, and therefore don't get trimmed much and take forever to fit.  So I added an optional keyword to `split_catalog_using_map`, `min_n_subfile`, which tells the minimum number of subfiles to make.

As an example, let's say that some field's SD bin 0-1 has 20,000 stars and bin 1-2 has 300 stars.  I've been using `n_per_file=1000`, which splits bin 0-1 into 20 subfiles and doesn't split bin 1-2.  This works great to make the fitting quick for bin 0-1, but bin 1-2 still takes a very long time, since it hasn't been broken up by flux.  Now, I can set `min_n_subfile=10`: bin 0-1 already has 20 subfiles, so nothing changes there, but now bin 1-2 gets sorted by flux and split into 10 subfiles.

I've updated the docs to add the new keyword.