### PR TITLE
Adjustment to graphical model

### DIFF
--- a/beast/plotting/plot_graphic_model.py
+++ b/beast/plotting/plot_graphic_model.py
@@ -69,7 +69,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "GC": ("Instrinsic\nDust", "ID"),
         "Obs": ("Observation Model", "<&mu;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>), &sigma;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>)>"),
         "Like": ("Observed Band Fluxes", "Observed Band Fluxes"),
-        "AST": ("Artifical Star Test Parameters", "b(m), &sigma;(m)"),
+        "AST": ("Artifical Star Test Parameters", "b(m<sub>i</sub>), &sigma;(m<sub>i</sub>)"),
     }
 
     edges = {

--- a/beast/plotting/plot_graphic_model.py
+++ b/beast/plotting/plot_graphic_model.py
@@ -69,7 +69,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "GC": ("Instrinsic\nDust", "ID"),
         "Obs": ("Observation Model", "<&mu;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>), &sigma;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>)>"),
         "Like": ("Observed Band Fluxes", "Observed Band Fluxes"),
-        "AST": ("Artifical Star Tests", "ASTs"),
+        "AST": ("Artifical Star Test Parameters", "b(m), &sigma;(m)"),
     }
 
     edges = {
@@ -91,7 +91,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "FC": ("Av", "Rv", "fA"),
         "GC": ("Av", "Rv", "fA"),
         "Obs": "Like",
-        "BF": ("Like", "AST"),
+        "BF": ("Like", "Obs"),
         "AST": "Obs",
     }
 

--- a/beast/plotting/plot_graphic_model.py
+++ b/beast/plotting/plot_graphic_model.py
@@ -69,7 +69,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "GC": ("Instrinsic\nDust", "ID"),
         "Obs": ("Observation Model", "<&mu;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>), &sigma;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>)>"),
         "Like": ("Observed Band Fluxes", "Observed Band Fluxes"),
-        "AST": ("Artifical Star Test Parameters", "b(m<sub>i</sub>), &sigma;(m<sub>i</sub>)"),
+        "AST": ("Artifical Star Test Parameters", "<b(m<sub>i</sub>), &sigma;(m<sub>i</sub>)>"),
     }
 
     edges = {
@@ -97,7 +97,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
 
     beast = create_graphic_model(nodes, edges, gtype)
 
-    beast.render(f"beast-graphic-{type}", format=savefig)
+    beast.render(f"beast-graphic-{gtype}", format=savefig)
 
 
 if __name__ == "__main__":

--- a/beast/plotting/plot_graphic_model.py
+++ b/beast/plotting/plot_graphic_model.py
@@ -69,7 +69,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "GC": ("Instrinsic\nDust", "ID"),
         "Obs": ("Observation Model", "<&mu;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>), &sigma;<sub>i</sub>(F<sup>Mod</sup><sub>i</sub>)>"),
         "Like": ("Observed Band Fluxes", "Observed Band Fluxes"),
-        "AST": ("Artifical Star Test Parameters", "<b(m<sub>i</sub>), &sigma;(m<sub>i</sub>)>"),
+        "AST": ("Artifical Star Test Parameters", "<&mu;(&Theta;), &sigma;(&Theta;)>"),
     }
 
     edges = {

--- a/beast/plotting/plot_graphic_model.py
+++ b/beast/plotting/plot_graphic_model.py
@@ -91,7 +91,7 @@ def plot_graphic_model(gtype="text", savefig="png"):
         "FC": ("Av", "Rv", "fA"),
         "GC": ("Av", "Rv", "fA"),
         "Obs": "Like",
-        "BF": ("Like", "Obs"),
+        "BF": "Obs",
         "AST": "Obs",
     }
 


### PR DESCRIPTION
A relatively minor tweak to the graphical model.

I could be wrong in my interpretation of the model here, but I would have said the artificial start tests are not parameters in the model per se, but rather the *results* of the artificial star tests are inputs into the observation model, and the combination of the fluxes and the AST results *is* the observation model.  So then the likelihood is only a result of the observation model.

I also made the change that the ASTs don't depend on the observed fluxes because I would have said that ASTs are whatever they are regardless of the assumption for a *particular star*.  But I could be missing some subtlety so could back that out.

One step further might be to drop the "observation model" entirely as it's sort of implicit that that's where the observed fluxes come from.  But I think even if it's slightly repetitive it's nice that it's clear here.