### PR TITLE
removing NaNs from ast results

### DIFF
--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -156,6 +156,13 @@ class MultiFilterASTs(NoiseModel):
             if name_prefix[-1] != "_":
                 name_prefix += "_"
 
+        # check if any NaNs are present, remove if they are
+        if np.any(np.isnan(magflux_in)):
+            gvals = np.isfinite(magflux_in) & np.isfinite(magflux_out)
+            magflux_in = magflux_in[gvals]
+            magflux_out = magflux_out[gvals]
+            print("removing NaNs")
+
         # convert the AST output from magnitudes to fluxes if needed
         #  this is designated by setting the completeness_mag_cut to a
         #  negative number

--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -157,6 +157,8 @@ class MultiFilterASTs(NoiseModel):
                 name_prefix += "_"
 
         # check if any NaNs are present, remove if they are
+        # NaNs can be present due to the AST pipeline or in cases where
+        # there is missing data (e.g., chip gaps)
         if np.any(np.isnan(magflux_in)):
             gvals = np.isfinite(magflux_in) & np.isfinite(magflux_out)
             magflux_in = magflux_in[gvals]

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -82,7 +82,7 @@ def run_fitting(
         )
 
     # keep track of time
-    start_time = time.clock()
+    start_time = time.perf_counter()
 
     # --------------------
     # make lists of file names
@@ -208,7 +208,7 @@ def run_fitting(
     parallel_wrapper(fit_submodel, input_list, nprocs=nprocs)
 
     # see how long it took!
-    new_time = time.clock()
+    new_time = time.perf_counter()
     print("time to fit: ", (new_time - start_time) / 60.0, " min")
 
 


### PR DESCRIPTION
There shouldn't be NaNs in the AST results, but sometimes there are.  Change so that these are filtered out in the toothpick obsmodel construction.

Also fixed a time deprecation.   We were using a very deprecated (since python 3.3) time function.  Found as I'm now using python 3.8.