### PR TITLE
Edits to supplementing BEAST-optimized ASTs

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -215,12 +215,7 @@ def pick_models_toothpick_style(
             print(bin_count)
 
     # Gather the selected model seds in a table
-    sedsMags_table = {}
-    for k, filter_name in enumerate(filters):
-        sedsMags_table[filter_name] = sedsMags[chosen_idxs, k]
-    sedsMags_table["sedgrid_indx"] = chosen_idxs
-
-    sedsMags = Table(sedsMags_table)
+    sedsMags = Table(sedsMags[chosen_idxs, :], names=filters)
 
     if outfile is not None:
         ascii.write(
@@ -444,10 +439,9 @@ def supplement_ast(
                 existingASTfile
             )
         )
-
-        t = Table.read(existingASTfile, format="ascii")
-        sedsMags = np.delete(sedsMags, np.array(t["sedgrid_indx"], dtype=int), axis=0)
-        sedsIndx = np.delete(sedsIndx, np.array(t["sedgrid_indx"], dtype=int))
+        t = Table.read(existingASTfile, format="fits")
+        sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)
+        sedsIndx = np.delete(sedsIndx, t["sedgrid_indx"])
         Nseds = sedsMags.shape[0]
 
     # Apply selection conditions if supplied

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -439,6 +439,7 @@ def supplement_ast(
                 existingASTfile
             )
         )
+        print("existing AST file", existingASTfile)
         t = Table.read(existingASTfile, format="fits")
         sedsMags = np.delete(sedsMags, t["sedgrid_indx"], axis=0)
         sedsIndx = np.delete(sedsIndx, t["sedgrid_indx"])
@@ -481,7 +482,7 @@ def supplement_ast(
     # Randomly select models
     # Supplementing ASTs does not need to follow
     # the toothpick-way selection
-    chosen_idxs = np.random.choice(np.arange(len(sedsIndx)), nAST)
+    chosen_idxs = np.random.choice(len(sedsIndx), nAST)
     sedsIndx = sedsIndx[chosen_idxs]
 
     # Gather the selected model seds in a table

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -216,8 +216,8 @@ def pick_models_toothpick_style(
 
     # Gather the selected model seds in a table
     sedsMags_table = {}
-    for k, filter in enumerate(filters):
-        sedsMags_table[filter] = sedsMags[chosen_idxs, k]
+    for k, filter_name in enumerate(filters):
+        sedsMags_table[filter_name] = sedsMags[chosen_idxs, k]
     sedsMags_table["sedgrid_indx"] = chosen_idxs
 
     sedsMags = Table(sedsMags_table)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -216,8 +216,8 @@ def pick_models_toothpick_style(
 
     # Gather the selected model seds in a table
     sedsMags_table = {}
-    for k in range(len(filters)):
-        sedsMags_table[filters[k]] = sedsMags[chosen_idxs, k]
+    for k, filter in enumerate(filters):
+        sedsMags_table[filter] = sedsMags[chosen_idxs, k]
     sedsMags_table["sedgrid_indx"] = chosen_idxs
 
     sedsMags = Table(sedsMags_table)

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -222,8 +222,6 @@ def pick_models_toothpick_style(
 
     sedsMags = Table(sedsMags_table)
 
-    print(sedsMags)
-
     if outfile is not None:
         ascii.write(
             sedsMags,
@@ -438,7 +436,6 @@ def supplement_ast(
 
     Nseds = sedsMags.shape[0]
     sedsIndx = np.arange(Nseds)
-    print(Nseds)
 
     if existingASTfile is not None and os.path.isfile(existingASTfile):
         print(

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -127,6 +127,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
             nAST = settings.ast_N_supplement
             existingASTfile = settings.ast_existing_file
             mag_cuts = settings.ast_suppl_maglimit
+            color_cuts = settings.ast_suppl_colorlimit
 
             chosen_seds = supplement_ast(
                 modelsedgrid_filename,
@@ -136,6 +137,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 outASTfile=outfile_seds,
                 outASTfile_params=outfile_params,
                 mag_cuts=mag_cuts,
+                color_cuts=color_cuts,
             )
 
     # if the SED file does exist, read them in
@@ -154,6 +156,8 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
         print("Assigning positions to artifical stars")
 
         outfile = "./{0}/{0}_inputAST.txt".format(settings.project)
+        if pick_method == "suppl_seds":
+            outfile = "./{0}/{0}_inputAST_suppl.txt".format(settings.project)
 
         # if we're replicating SEDs across source density or background bins
         if settings.ast_density_table is not None:
@@ -187,9 +191,7 @@ if __name__ == "__main__":  # pragma: no cover
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "beast_settings_file",
-        type=str,
-        help="file name with beast settings",
+        "beast_settings_file", type=str, help="file name with beast settings",
     )
     parser.add_argument(
         "--random_seds",
@@ -208,20 +210,17 @@ if __name__ == "__main__":  # pragma: no cover
 
     if args.random_seds:
         make_ast_inputs(
-            beast_settings_info=args.beast_settings_file,
-            pick_method="random_seds"
+            beast_settings_info=args.beast_settings_file, pick_method="random_seds"
         )
 
     if args.suppl_seds:
         make_ast_inputs(
-            beast_settings_info=args.beast_settings_file,
-            pick_method="suppl_seds"
+            beast_settings_info=args.beast_settings_file, pick_method="suppl_seds"
         )
 
     else:
         make_ast_inputs(
-            beast_settings_info=args.beast_settings_file,
-            pick_method="flux_bin_method"
+            beast_settings_info=args.beast_settings_file, pick_method="flux_bin_method"
         )
 
     # print help if no arguments


### PR DESCRIPTION
I made some edits to augment the existing code for supplementing ASTs to the nominal BEAST-optimized set (for MATCH-based applications). This includes:
- adding a column to the output table from pick_models_toothpick_style to record the index of the SEDs used (so they're not duplicated in the supplements)
- adding the ability to impose color cuts in addition to magnitude cuts for the randomly-sampled ASTs

Looking forward to review by @galaxyumi ! :D