### PR TITLE
Add more options to use simulate_obs to properly simulate ASTs

### DIFF
--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -218,6 +218,7 @@ def gen_SimObs_from_sedgrid(
     nsim=100,
     compl_filter="F475W",
     complcut=None,
+    magcut=None,
     ranseed=None,
     vega_fname=None,
     weight_to_use="weight",
@@ -327,8 +328,8 @@ def gen_SimObs_from_sedgrid(
     # if magcut is provided, only use models brighter than the magnitude cut 
     # in addition to the non-zero completeness criterion
     if magcut is not None:
-        mag_compl_filter = -2.5 * np.log10(flux[:, filter_k] / vega_flux[filter_k])
-        goodobsmod = (goodobsmod) & (mag_compl_filter <= magcut)
+        fluxcut_compl_filter = 10 ** (-0.4 * magcut) * vega_flux[filter_k]
+        goodobsmod = (goodobsmod) & (flux[:,filter_k] >= fluxcut_compl_filter)
 
     # initialize the random number generator
     # initialize the random number generator

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -252,7 +252,7 @@ def gen_SimObs_from_sedgrid(
 
     complcut : float (defualt=None)
         completeness cut for only including model seds above the cut
-        raning from 0.0 to 1.0.
+        where the completeness cut ranges between 0 and 1.
 
     magcut : float (defualt=None)
         faint-end magnitude cut for only including model seds brighter
@@ -398,7 +398,7 @@ def gen_SimObs_from_sedgrid(
     else:  # total number of stars to simulate set by command line input
 
         if weight_to_use == "uniform":
-            # sample to get the indexes of the picked models
+            # sample to get the indices of the picked models
             sim_indx = rangen.choice(model_indx[goodobsmod], nsim)
 
         else:

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -255,8 +255,8 @@ def gen_SimObs_from_sedgrid(
         raning from 0.0 to 1.0.
 
     magcut : float (defualt=None)
-        faint-end magnitude cut for only including model seds brighter than 
-        the given magnitude in compl_filter.
+        faint-end magnitude cut for only including model seds brighter
+        than the given magnitude in compl_filter.
 
     ranseed : int
         used to set the seed to make the results reproducable,
@@ -320,18 +320,17 @@ def gen_SimObs_from_sedgrid(
         print("Completeness from %s" % sedgrid.filters[filter_k])
         model_compl = model_compl[:, filter_k]
 
-    # if complcut is provided, only use models above that completeness cut 
+    # if complcut is provided, only use models above that completeness cut
     # in addition to the non-zero completeness criterion
     if complcut is not None:
         goodobsmod = (goodobsmod) & (model_compl >= complcut)
 
-    # if magcut is provided, only use models brighter than the magnitude cut 
+    # if magcut is provided, only use models brighter than the magnitude cut
     # in addition to the non-zero completeness criterion
     if magcut is not None:
         fluxcut_compl_filter = 10 ** (-0.4 * magcut) * vega_flux[filter_k]
-        goodobsmod = (goodobsmod) & (flux[:,filter_k] >= fluxcut_compl_filter)
+        goodobsmod = (goodobsmod) & (flux[:, filter_k] >= fluxcut_compl_filter)
 
-    # initialize the random number generator
     # initialize the random number generator
     rangen = default_rng(ranseed)
 
@@ -410,7 +409,6 @@ def gen_SimObs_from_sedgrid(
             sim_indx = rangen.choice(model_indx[goodobsmod], size=nsim, p=gridweights)
 
         print(f"number of simulated stars = {nsim}")
-
 
     # setup the output table
     ot = Table()

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -17,6 +17,7 @@ def simulate_obs(
     nsim=100,
     compl_filter="F475W",
     complcut=None,
+    magcut=None,
     weight_to_use="weight",
     ranseed=None,
 ):
@@ -57,8 +58,13 @@ def simulate_obs(
         completeness cut for only including model seds above the cut
         raning from 0.0 to 1.0.
 
+    magcut : float (defualt=None)
+        faint-end magnitude cut for only including model seds brighter than 
+        the given magnitude in compl_filter.
+
     weight_to_use : string (default='weight')
-        Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
+        Set to either 'weight' (prior+grid), 'prior_weight', 'grid_weight',
+        or 'uniform' (this option is valid only when nsim is supplied) to
         choose the weighting for SED selection.
 
     ranseed : int
@@ -72,6 +78,9 @@ def simulate_obs(
 
     if complcut is not None:
         complcut = float(complcut)
+
+    if magcut is not None:
+        magcut = float(magcut)
 
     if ranseed is not None:
         ranseed = int(ranseed)
@@ -107,6 +116,7 @@ def simulate_obs(
             nsim=samples_per_grid,
             compl_filter=compl_filter,
             complcut=complcut,
+            magcut=magcut,
             weight_to_use=weight_to_use,
             ranseed=ranseed,
         )
@@ -159,6 +169,18 @@ if __name__ == "__main__":  # pragma: no cover
         help="filter for completeness, set to max for max of values from all filters",
     )
     parser.add_argument(
+        "--complcut", 
+        default=None, 
+        type=float, 
+        help="completeness cut for selecting seds above the completeness cut"
+    )
+    parser.add_argument(
+        "--magcut", 
+        default=None, 
+        type=float, 
+        help="magnitdue cut for selecting seds brighter than the magcut in compl_filter"
+    )
+    parser.add_argument(
         "--weight_to_use",
         default="weight",
         type=str,
@@ -171,12 +193,6 @@ if __name__ == "__main__":  # pragma: no cover
         type=int, 
         help="seed for random number generator"
     )
-    parser.add_argument(
-        "--complcut", 
-        default=None, 
-        type=float, 
-        help="completeness cut for only including seds with higher completeness"
-    )
     args = parser.parse_args()
 
     # run observation simulator
@@ -188,6 +204,7 @@ if __name__ == "__main__":  # pragma: no cover
         nsim=args.nsim,
         compl_filter=args.compl_filter,
         complcut=args.complcut,
+        magcut=args.magcut,
         weight_to_use=args.weight_to_use,
         ranseed=args.ranseed,
     )

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -70,6 +70,9 @@ def simulate_obs(
     nsim = int(nsim)
     samples_per_grid = int(np.ceil(nsim / n_phys))
 
+    if complcut is not None:
+        complcut = float(complcut)
+
     if ranseed is not None:
         ranseed = int(ranseed)
 

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -55,8 +55,8 @@ def simulate_obs(
         set to max to use the max value in all filters
 
     complcut : float (defualt=None)
-        completeness cut for only including model seds above the cut
-        raning from 0.0 to 1.0.
+        completeness cut for only including model seds above the given
+        completeness, where the cut ranges from 0 to 1.
 
     magcut : float (defualt=None)
         faint-end magnitude cut for only including model seds brighter

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -16,6 +16,7 @@ def simulate_obs(
     beastinfo_list=None,
     nsim=100,
     compl_filter="F475W",
+    complcut=None,
     weight_to_use="weight",
     ranseed=None,
 ):
@@ -52,13 +53,16 @@ def simulate_obs(
         filter to use for completeness (required for toothpick model)
         set to max to use the max value in all filters
 
+    complcut : float (defualt=None)
+        completeness cut for only including model seds above the cut
+        raning from 0.0 to 1.0.
+
     weight_to_use : string (default='weight')
         Set to either 'weight' (prior+grid), 'prior_weight', or 'grid_weight' to
         choose the weighting for SED selection.
 
     ranseed : int
         seed for random number generator
-
     """
     # numbers of samples to do
     # (ensure there are enough for even sampling of multiple model grids)
@@ -99,6 +103,7 @@ def simulate_obs(
             mass_prior_model=mass_prior_model,
             nsim=samples_per_grid,
             compl_filter=compl_filter,
+            complcut=complcut,
             weight_to_use=weight_to_use,
             ranseed=ranseed,
         )
@@ -158,7 +163,16 @@ if __name__ == "__main__":  # pragma: no cover
         'grid_weight' to choose the weighting for SED selection.""",
     )
     parser.add_argument(
-        "--ranseed", default=None, type=int, help="seed for random number generator"
+        "--ranseed", 
+        default=None, 
+        type=int, 
+        help="seed for random number generator"
+    )
+    parser.add_argument(
+        "--complcut", 
+        default=None, 
+        type=float, 
+        help="completeness cut for only including seds with higher completeness"
     )
     args = parser.parse_args()
 
@@ -170,6 +184,7 @@ if __name__ == "__main__":  # pragma: no cover
         beastinfo_list=args.beastinfo_list,
         nsim=args.nsim,
         compl_filter=args.compl_filter,
+        complcut=args.complcut,
         weight_to_use=args.weight_to_use,
         ranseed=args.ranseed,
     )

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -59,8 +59,8 @@ def simulate_obs(
         raning from 0.0 to 1.0.
 
     magcut : float (defualt=None)
-        faint-end magnitude cut for only including model seds brighter than 
-        the given magnitude in compl_filter.
+        faint-end magnitude cut for only including model seds brighter
+        than the given magnitude in compl_filter.
 
     weight_to_use : string (default='weight')
         Set to either 'weight' (prior+grid), 'prior_weight', 'grid_weight',
@@ -169,15 +169,15 @@ if __name__ == "__main__":  # pragma: no cover
         help="filter for completeness, set to max for max of values from all filters",
     )
     parser.add_argument(
-        "--complcut", 
-        default=None, 
-        type=float, 
+        "--complcut",
+        default=None,
+        type=float,
         help="completeness cut for selecting seds above the completeness cut"
     )
     parser.add_argument(
-        "--magcut", 
-        default=None, 
-        type=float, 
+        "--magcut",
+        default=None,
+        type=float,
         help="magnitdue cut for selecting seds brighter than the magcut in compl_filter"
     )
     parser.add_argument(
@@ -188,9 +188,9 @@ if __name__ == "__main__":  # pragma: no cover
         'grid_weight' to choose the weighting for SED selection.""",
     )
     parser.add_argument(
-        "--ranseed", 
-        default=None, 
-        type=int, 
+        "--ranseed",
+        default=None,
+        type=int,
         help="seed for random number generator"
     )
     args = parser.parse_args()

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -32,6 +32,14 @@ dividing by the average mass (mass prior model).  This number of stars is
 simulated at each age and then the completeness function is applied to remove
 all the simulated stars that would not be observed.
 
+The `beast simulate_obs` also can be used to just simulate extra ASTs. This is very
+powerful if you need more ASTs for generating MATCH-optimized ASTs in addition to what 
+you already have from the DOLPHOT ASTs. This means that you can avoid extensive/additional
+DOLPHOT ASTs as long as your initial/existing DOLPHOT ASTs properly cover the entire
+CMD space (i.e., meeting the minimum requirement by MATCH should be enough.) by
+providing the information on the flux uncertainties, biases, and the completeness
+for the additionally selected model SEDs.
+
 *********
 Toothpick
 *********
@@ -45,12 +53,25 @@ The filter to use for the completeness function is given by the
 Set `compl_filter=max` to use the max completeness value across all the filters.
 The SEDs are picked weighted by the product of the grid+prior weights
 and the completeness from the noisemodel.  The grid+prior weights can be replaced
-with either grid or prior weights by explicitly setting the `--weight_to_use`
-parameter.
+with either grid, prior, or uniform weights by explicitly setting the `--weight_to_use`
+parameter. With the uniform weight, the SEDs are randomly selected from the given
+physicsgrid, and this option is only valid when `nsim` is explicitly set and useful
+for simulating ASTs. 
 
 .. code-block:: console
 
    $ beast simulate_obs physicsgrid obsgrid outfile --nsim 200 --compl_filter=F475W
+
+There are two optional keyword argments specific to the AST simulations: `--complcut`
+and `--magcut`. `--complcut` allows you to exclude model SEDs below the supplied
+completeness cut in the `--compl_filter`. Note that the brightest models will be exlcuded
+as well because of the rapid drop in completeness at the bright end. `--magcut` allows
+you to exclude model SEDs fainter than the supplied magnitude in the `--compl_filter`.
+
+.. code-block:: console
+
+   $ beast simulate_obs physicsgrid obsgrid outfile --nsim 100000 --compl_filter=F475W \
+                        --magcut 30 --weight_to_use uniform
 
 The output file gives the simulated data in the observed data columns
 identified in the physicsgrid file along with all the model parameters

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -32,13 +32,15 @@ dividing by the average mass (mass prior model).  This number of stars is
 simulated at each age and then the completeness function is applied to remove
 all the simulated stars that would not be observed.
 
-The `beast simulate_obs` also can be used to just simulate extra ASTs. This is very
-powerful if you need more ASTs for generating MATCH-optimized ASTs in addition to what 
-you already have from the DOLPHOT ASTs. This means that you can avoid extensive/additional
-DOLPHOT ASTs as long as your initial/existing DOLPHOT ASTs properly cover the entire
-CMD space (i.e., meeting the minimum requirement by MATCH should be enough.) by
-providing the information on the flux uncertainties, biases, and the completeness
-for the additionally selected model SEDs.
+The `beast simulate_obs` also can be used to just simulate extra ASTs. This
+simulation is replacing generating additional input artifical stars and running
+those through a photomtery pipeline. Thus, it is very powerful if you need more
+ASTs for generating MATCH-satisfied ASTs in addition to what you already have
+from the real ASTs. This means that you can avoid extensive/additional real ASTs
+as long as your initial/existing real ASTs properly cover the entire CMD space,
+i.e., a combination of BEAST-optimzed ASTs supplemented by MATCH-friendly ASTs
+should be enough. This simulation provides the information on the flux uncertainties,
+biases, and the completeness for the additionally selected model SEDs.
 
 *********
 Toothpick


### PR DESCRIPTION
I added two more optional keyword parameters in 'simulate_obs': complcut for a completeness cut and magcut for a magnitude in the 'compl_filter'. Recommend to use one or the other. If these cuts are supplied, the selected model SEDs will be limited to those with completeness >= complcut or magnitude <= magcut in the 'compl_filter'. These can be particularly useful when simulating additional ASTs.  

I also added 'uniform' weight option for the 'weight_to_use' keyword parameter. This option is also useful when simulating ASTs by avoiding the skewness to lower-mass stars.

(Example) 
beast simulate_obs physicseds.grid.hd5 noisemodel.grid.hd5 output.fits --nsim 100000 --compl_filter F475W --magcut 30 --weight_to_use uniform