### PR TITLE
Add optional erosion to AST placement region

### DIFF
--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -211,7 +211,7 @@ def pick_positions_from_map(
         if radec_pos:
             coord_boundary_radec = erode_path(
                 Path(np.array([set_coord_boundary[0], set_coord_boundary[1]]).T),
-                erode_deg
+                erode_deg,
             )
 
     # if region_from_filters is set, define an additional boundary for ASTs

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -26,6 +26,7 @@ def pick_positions_from_map(
     Nrealize=1,
     set_coord_boundary=None,
     region_from_filters=None,
+    erode_boundary=None,
 ):
     """
     Spreads a set of fake stars across regions of similar values,
@@ -106,6 +107,12 @@ def pick_positions_from_map(
         properly if the region is a convex polygon.  A solution to these needs
         to be figured out at some point.
 
+    erode_boundary : None, or float (default=None)
+        If provided, this number of arcseconds will be eroded from the region
+        over which ASTs are generated.  This is applied to both the catalog
+        boundary and the values from set_coord_boundary.  If the input catalog
+        only has x/y (no RA/Dec), a refimage is required.
+
     Returns
     -------
     astropy Table: List of fake stars, with magnitudes and positions
@@ -165,6 +172,15 @@ def pick_positions_from_map(
         raise RuntimeError(
             "Your catalog does not supply X/Y or RA/DEC information to ensure ASTs are within catalog boundary"
         )
+
+    # if erode_boundary is set, try to make a pixel version to go with xy positions
+    erode_deg = None
+    erode_pix = None
+    if erode_boundary:
+        erode_deg = erode_boundary
+        if xy_pos and refimage:
+            erode_pix =
+
 
     # create path containing the positions
     catalog_boundary_xy = None

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -464,6 +464,7 @@ def pick_positions_from_map(
 
     return out_table
 
+
 def erode_path(path_object, erode_amount):
     """
     Returns the original Path object, but eroded by the defined amount.

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -175,6 +175,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 Nrealize=1,
                 set_coord_boundary=settings.ast_coord_boundary,
                 region_from_filters="all",
+                erode_boundary=settings.ast_erode_selection_region,
             )
         # if we're not using SD/background maps, SEDs will be distributed
         # based on catalog sources

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -47,8 +47,9 @@ input parameters from beast_settings.txt.
 * ``ast_density_table``: (optional; string) name of density table, containing either the source density map or the background density map. If supplied, the ASTs will be repeated for each density bin in the table (default = None).
 * ``ast_N_bins``: (optional; int) number of source or background bins that you want ASTs repeated over.
 * ``ast_pixel_distribution``: (optional; float) minimum pixel separation between AST position and catalog star used to determine the AST spatial distribution. Used if ast_with_positions is True.
-* ``ast_reference_image``: (optional; string)   name of the reference image used by DOLPHOT when running the measured photometry. Required if ast_with_positions is True and no X,Y information is present in the photometry catalog.
+* ``ast_reference_image``: (optional; string) name of the reference image used by DOLPHOT when running the measured photometry. Required if ast_with_positions is True and no X,Y information is present in the photometry catalog.
 * ``ast_coord_boundary``: (optional; list of two arrays) if supplied, these RA/Dec coordinates will be used to limit the region over which ASTs are generated (default = None).
+* ``ast_erode_selection_region``: (optional; float) To avoid placing ASTs near the edge of the image, set this to the number of arcseconds (default=0.5, which is ~10 pixels for WFC3/UVIS) to shrink the allowed AST placement region.  This is applied by doing an erosion to both ast_coord_boundary (if set) and a convex hull around the photometry catalog.
 * ``astfile``:  pathname to the AST files (single camera ASTs).
 * ``ast_colnames``:  names of columns for filters in the AST catalog (default is the basefilter list).
 * ``noisefile`` : pathname to the output noise model file.


### PR DESCRIPTION
This adds an additional option for placing ASTs in the image.  @cmurray-astro found in #613 that many of the invalid ASTs were due to placement along the edge of the image, so I've added the optional `ast_erode_selection_region` setting to shrink the region where ASTs are allowed to be placed.  The default is currently 0.5" (~10 pixels), and it can also be `None` for no region shrinking.  It gets applied in two ways:
* The AST code always creates a convex hull around the photometry catalog and only places ASTs inside of it.  It will erode that convex hull by 0.5" (i.e., remove the outer 0.5" of the region).
* If `ast_coord_boundary` is set, it will erode that by 0.5".  Since this boundary is generally the very outer extremity of the photometry catalog, it ensures no ASTs will be placed within 0.5" of the edge.

I've updated the docs, but still need to add a test.  Also, the reason it can't automatically merge is addressed in #653.

Addresses #613 (possibly closes?)