### PR TITLE
Documentation for how to specify mag and color cuts for supplemented ASTs

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -408,10 +408,52 @@ def supplement_ast(
         each model will be written to disk
 
     mag_cut: dictionary (optional, default=None)
-        Ditionary of bright and faint magnitude limits for given filters
+        Dictionary of bright and faint magnitude limits for given filters.
+        The way to specify the cuts is by updating the "ast_suppl_maglimit" key
+        in the beast_settings file. This is a dictionary that includes information
+        for the magnitude cuts as a function of the filters included in observation.
+
+        For example, for a field observed with HST_WFC3_F336W, HST_WFC3_F475W,
+        and HST_WFC3_F814W, to set a magnitude range limit of 16<HST_WFC3_F475W<28 mag,
+        and 15<HST_WFC3_F814W<27 mag you need to set the following within the beast_settings file:
+
+        # specify that the ast_supplement mode should be on
+        ast_supplement = True
+
+        # initialize and populate the dictionary of desired magnitude limits
+        ast_suppl_maglimits = {}
+        # the magntidue limits are defined by the filter and a list of the limits in magnitudes
+        ast_suppl_maglimits["HST_WFC3_F475W"] = [16,28]
+        ast_suppl_maglimits["HST_WFC3_F814W"] = [15,27]
+
+        # set the key word
+        ast_suppl_maglimit = ast_suppl_maglimits
 
     color_cut: dictionary (optional, default=None)
-        Ditionary of faint color limits for given filters
+        Dictionary of faint color limits for given filters.
+        The way to specify the cuts is by updating the "ast_suppl_colorlimit" key
+        in the beast_settings file. This is a dictionary that includes information
+        for the color cuts as a function of the filters included in observation.
+
+        For example, for a field observed with HST_WFC3_F336W, HST_WFC3_F475W,
+        and HST_WFC3_F814W, to set a color range limit of HST_WFC3_F475W-HST_WFC3_F814W<6,
+        HST_WFC3_F336W-HST_WFC3_F475W<5 and HST_WFC3_F336W-HST_WFC3_F814W<4, you need
+        to set the following within the beast_settings file:
+
+        # specify that the ast_supplement mode should be on
+        ast_supplement = True
+
+        # initialize the dictionary of desired magnitude limits
+        ast_suppl_colorlimits = {}
+
+        # the color limits are defined by the first filter in the color (e.g, X for X-Y),
+        # and the input is a list including the second filter (e.g., Y for X-Y) and the
+        # color limit in magnitudes
+        ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
+        ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
+
+        # set the key word
+        ast_suppl_colorlimit =  ast_suppl_colorlimits
 
     Returns
     -------

--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -430,7 +430,7 @@ def supplement_ast(
         ast_suppl_maglimit = ast_suppl_maglimits
 
     color_cut: dictionary (optional, default=None)
-        Dictionary of faint color limits for given filters.
+        Dictionary of red color limits for given filters.
         The way to specify the cuts is by updating the "ast_suppl_colorlimit" key
         in the beast_settings file. This is a dictionary that includes information
         for the color cuts as a function of the filters included in observation.
@@ -449,8 +449,8 @@ def supplement_ast(
         # the color limits are defined by the first filter in the color (e.g, X for X-Y),
         # and the input is a list including the second filter (e.g., Y for X-Y) and the
         # color limit in magnitudes
-        ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
-        ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
+        ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",6]]
+        ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",4]]
 
         # set the key word
         ast_suppl_colorlimit =  ast_suppl_colorlimits

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -179,8 +179,8 @@ Parameters used by the supplementing AST method
     # the color limits are defined by the first filter in the color (e.g, X for X-Y),
     # and the input is a list including the second filter (e.g., Y for X-Y) and the
     # color limit in magnitudes:
-    ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
-    ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
+    ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",6]]
+    ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",4]]
 
     # set the key word
     ast_suppl_colorlimit =  ast_suppl_colorlimits

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -117,7 +117,7 @@ Parameters used by the random SED selection method
 Parameters used by the supplementing AST method
 -----------------------------------------------
 - `ast_supplement` : bool
-  
+
   If True, supplement the existing input ASTs
 
 - `ast_N_supplement` : integer (Default = 1000)
@@ -134,7 +134,51 @@ Parameters used by the supplementing AST method
 - `ast_suppl_maglimit` : dictionary (optional)
 
   If supplied, these magnitude limits will be applied to the SED model grids
-  when selecting additional ASTs.
+  when selecting additional ASTs. This is a dictionary that includes information
+  for the magnitude cuts as a function of the filters included in observation.
+
+  For example, for a field observed with HST_WFC3_F475W and HST_WFC3_F814W,
+  to set a magnitude range limit of 16<HST_WFC3_F475W<28 mag,
+  and 15<HST_WFC3_F814W<27 mag you need to set the following within the beast_settings file:
+  .. code-block:: console
+    # initialize and populate the dictionary of desired magnitude limits
+    ast_suppl_maglimits = {}
+
+    # the magntidue limits are defined by the filter and a list of the limits in magnitudes
+    ast_suppl_maglimits["HST_WFC3_F475W"] = [16,28]
+    ast_suppl_maglimits["HST_WFC3_F814W"] = [15,27]
+
+    # set the key word
+    ast_suppl_maglimit = ast_suppl_maglimits
+
+  or, equivalently:
+  .. code-block:: console
+      ast_suppl_maglimit = {‘F475W’: (16,28), ‘F814W’: (15,27)}
+
+
+- `ast_suppl_colorlimit` : dictionary (optional)
+
+  If supplied, these color limits will be applied to the SED model grids
+  when selecting additional ASTs. This is a dictionary that includes information
+  for the color cuts as a function of the filters included in observation.
+
+  For example, for a field observed with HST_WFC3_F336W, HST_WFC3_F475W,
+  and HST_WFC3_F814W, to set a color range limit of HST_WFC3_F475W-HST_WFC3_F814W<6,
+  HST_WFC3_F336W-HST_WFC3_F475W<5 and HST_WFC3_F336W-HST_WFC3_F814W<4, you need
+  to set the following within the beast_settings file:
+
+  .. code-block:: console
+    # initialize the dictionary of desired magnitude limits
+    ast_suppl_colorlimits = {}
+
+    # the color limits are defined by the first filter in the color (e.g, X for X-Y),
+    # and the input is a list including the second filter (e.g., Y for X-Y) and the
+    # color limit in magnitudes
+    ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
+    ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
+
+    # set the key word
+    ast_suppl_colorlimit =  ast_suppl_colorlimits
 
 
 Parameters used for selecting SED positions

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -140,22 +140,23 @@ Parameters used by the supplementing AST method
   For example, for a field observed with HST_WFC3_F475W and HST_WFC3_F814W,
   to set a magnitude range limit of 16<HST_WFC3_F475W<28 mag,
   and 15<HST_WFC3_F814W<27 mag you need to set the following within the beast_settings file:
+
   .. code-block:: console
+
     # initialize and populate the dictionary of desired magnitude limits
-    
     ast_suppl_maglimits = {}
 
     # the magntidue limits are defined by the filter and a list of the limits in magnitudes
-
     ast_suppl_maglimits["HST_WFC3_F475W"] = [16,28]
     ast_suppl_maglimits["HST_WFC3_F814W"] = [15,27]
 
     # set the key word
-
     ast_suppl_maglimit = ast_suppl_maglimits
 
   or, equivalently:
+
   .. code-block:: console
+
       ast_suppl_maglimit = {‘F475W’: (16,28), ‘F814W’: (15,27)}
 
 
@@ -173,18 +174,15 @@ Parameters used by the supplementing AST method
   .. code-block:: console
 
     # initialize the dictionary of desired magnitude limits
-
     ast_suppl_colorlimits = {}
 
     # the color limits are defined by the first filter in the color (e.g, X for X-Y),
     # and the input is a list including the second filter (e.g., Y for X-Y) and the
     # color limit in magnitudes:
-
     ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
     ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
 
     # set the key word
-
     ast_suppl_colorlimit =  ast_suppl_colorlimits
 
 

--- a/docs/generating_asts.rst
+++ b/docs/generating_asts.rst
@@ -142,13 +142,16 @@ Parameters used by the supplementing AST method
   and 15<HST_WFC3_F814W<27 mag you need to set the following within the beast_settings file:
   .. code-block:: console
     # initialize and populate the dictionary of desired magnitude limits
+    
     ast_suppl_maglimits = {}
 
     # the magntidue limits are defined by the filter and a list of the limits in magnitudes
+
     ast_suppl_maglimits["HST_WFC3_F475W"] = [16,28]
     ast_suppl_maglimits["HST_WFC3_F814W"] = [15,27]
 
     # set the key word
+
     ast_suppl_maglimit = ast_suppl_maglimits
 
   or, equivalently:
@@ -168,16 +171,20 @@ Parameters used by the supplementing AST method
   to set the following within the beast_settings file:
 
   .. code-block:: console
+
     # initialize the dictionary of desired magnitude limits
+
     ast_suppl_colorlimits = {}
 
     # the color limits are defined by the first filter in the color (e.g, X for X-Y),
     # and the input is a list including the second filter (e.g., Y for X-Y) and the
-    # color limit in magnitudes
+    # color limit in magnitudes:
+
     ast_suppl_colorlimits["HST_WFC3_F475W"] = [["HST_WFC3_F814W",4]]
     ast_suppl_colorlimits["HST_WFC3_F336W"] = [["HST_WFC3_F475W",5], ["HST_WFC3_F814W",6]]
 
     # set the key word
+
     ast_suppl_colorlimit =  ast_suppl_colorlimits
 
 


### PR DESCRIPTION
In the docstring to the supplement_ast() function in make_ast_input_list.py, I added descriptions and examples of how to set the correct parameters in the beast_settings.txt file for making magnitude and color cuts to supplemented ASTs. I will also add this to the template beast_settings.txt file (which is stored in beast_examples).

@galaxyumi and @kmcquinn please let me know what you think! Based on your feedback, I can make this more user-friendly and/or intuitive, especially if you run into issues/bugs.
