### PR TITLE
Use asdf files for testing compare_spec_type and star_type_probability

### DIFF
--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -332,6 +332,7 @@ class TestRegressionSuite(unittest.TestCase):
         # output files
         stats_fname = tempfile.NamedTemporaryFile(suffix=".fits").name
         pdf1d_fname = tempfile.NamedTemporaryFile(suffix=".fits").name
+        pdf2d_fname = tempfile.NamedTemporaryFile(suffix=".fits").name
         lnp_fname = tempfile.NamedTemporaryFile(suffix=".hd5").name
 
         fit.summary_table_memory(
@@ -340,10 +341,12 @@ class TestRegressionSuite(unittest.TestCase):
             self.seds_trim_fname_cache,
             threshold=-10.0,
             save_every_npts=100,
-            lnp_npts=60,
+            lnp_npts=500,
             max_nbins=200,
             stats_outname=stats_fname,
             pdf1d_outname=pdf1d_fname,
+            pdf2d_outname=pdf2d_fname,
+            pdf2d_param_list=["Av", "M_ini", "logT"],
             lnp_outname=lnp_fname,
             surveyname=self.settings.surveyname,
         )
@@ -357,8 +360,9 @@ class TestRegressionSuite(unittest.TestCase):
         # lnp files not checked as they are randomly sparsely sampled
         #   hence will be different every time the fitting is run
 
-        # check that the pdf1d files are exactly the same
+        # check that the pdf1d/pdf2d files are exactly the same
         compare_fits(self.pdf1d_fname_cache, pdf1d_fname)
+        compare_fits(self.pdf2d_fname_cache, pdf2d_fname)
 
     # ###################################################################
     # AST tests
@@ -670,7 +674,7 @@ class TestRegressionSuite(unittest.TestCase):
                 sub_seds_trim_fnames[i],
                 threshold=-40.0,
                 save_every_npts=100,
-                lnp_npts=60,
+                lnp_npts=500,
                 stats_outname=subgrid_stats_fnames[i],
                 pdf1d_outname=subgrid_pdf1d_fnames[i],
                 lnp_outname=subgrid_lnp_fnames[i],
@@ -694,7 +698,7 @@ class TestRegressionSuite(unittest.TestCase):
             self.seds_trim_fname_cache,
             threshold=-40.0,
             save_every_npts=100,
-            lnp_npts=60,
+            lnp_npts=500,
             stats_outname=normal_stats,
             pdf1d_outname=normal_pdf1d,
             lnp_outname=normal_lnp,

--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -69,7 +69,7 @@ class TestRegressionSuite(unittest.TestCase):
 
         cls.dset = "metal"
         if cls.dset == "metal":
-            cls.basesubdir = "metal_small_4sep20/"
+            cls.basesubdir = "metal_small/"
             cls.basename = f"{cls.basesubdir}beast_metal_small"
             cls.obsname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst_samp.fits"
             cls.astname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst.fake.fits"
@@ -95,28 +95,28 @@ class TestRegressionSuite(unittest.TestCase):
         cls.priors_fname_cache = download_rename(
             f"{cls.basename}_spec_w_priors.grid.hd5"
         )
-        # priors_sub0_fname_cache = download_rename(
-        #     f"{basename}_subgrids_spec_w_priors.gridsub0.hd5"
-        # )
-        # priors_sub1_fname_cache = download_rename(
-        #     f"{basename}_subgrids_spec_w_priors.gridsub1.hd5"
-        # )
+        cls.priors_sub0_fname_cache = download_rename(
+             f"{cls.basename}_subgrids_spec_w_priors.gridsub0.hd5"
+        )
+        cls.priors_sub1_fname_cache = download_rename(
+             f"{cls.basename}_subgrids_spec_w_priors.gridsub1.hd5"
+        )
         # - SED grids
         cls.seds_fname_cache = download_rename(f"{cls.basename}_seds.grid.hd5")
-        # seds_sub0_fname_cache = download_rename(
-        #     f"{basename}_subgrids_seds.gridsub0.hd5"
-        # )
-        # seds_sub1_fname_cache = download_rename(
-        #    f"{basename}_subgrids_seds.gridsub1.hd5"
-        # )
+        cls.seds_sub0_fname_cache = download_rename(
+             f"{cls.basename}_subgrids_seds.gridsub0.hd5"
+        )
+        cls.seds_sub1_fname_cache = download_rename(
+            f"{cls.basename}_subgrids_seds.gridsub1.hd5"
+        )
         # - noise model
         cls.noise_fname_cache = download_rename(f"{cls.basename}_noisemodel.grid.hd5")
-        # noise_sub0_fname_cache = download_rename(
-        #    f"{basename}_subgrids_noisemodel.gridsub0.hd5"
-        # )
-        # noise_sub1_fname_cache = download_rename(
-        #    f"{basename}_subgrids_noisemodel.gridsub1.hd5"
-        # )
+        cls.noise_sub0_fname_cache = download_rename(
+            f"{cls.basename}_subgrids_noisemodel.gridsub0.hd5"
+        )
+        cls.noise_sub1_fname_cache = download_rename(
+            f"{cls.basename}_subgrids_noisemodel.gridsub1.hd5"
+        )
         # - trimmed files
         cls.noise_trim_fname_cache = download_rename(
             f"{cls.basename}_noisemodel_trim.grid.hd5"
@@ -765,7 +765,7 @@ class TestRegressionSuite(unittest.TestCase):
 
         # download cached file
         compare_spec_type_fname = download_rename(
-            f"{cls.basename}_compare_spec_type.asdf"
+            f"{self.basename}_compare_spec_type.asdf"
         )
         with asdf.open(compare_spec_type_fname) as af:
             compare_spec_type_info = copy.deepcopy(af.tree)
@@ -832,7 +832,7 @@ class TestRegressionSuite(unittest.TestCase):
         In this version, all required parameters are present.
         """
         # download cached file
-        star_prob_fname = download_rename(f"{cls.basename}_star_type_probability.asdf")
+        star_prob_fname = download_rename(f"{self.basename}_star_type_probability.asdf")
         with asdf.open(star_prob_fname) as af:
             star_prob_info = copy.deepcopy(af.tree)
 
@@ -844,7 +844,7 @@ class TestRegressionSuite(unittest.TestCase):
         )
 
         # expected output table
-        expected_star_prob = Table.read(star_prob_info["output"])
+        expected_star_prob = Table(star_prob_info["output"])
 
         # compare to new table
         compare_tables(expected_star_prob, Table(star_prob))
@@ -857,7 +857,7 @@ class TestRegressionSuite(unittest.TestCase):
         """
 
         # download cached file
-        star_prob_fname = download_rename(f"{cls.basename}_star_type_probability.asdf")
+        star_prob_fname = download_rename(f"{self.basename}_star_type_probability.asdf")
         with asdf.open(star_prob_fname) as af:
             star_prob_info = copy.deepcopy(af.tree)
 
@@ -884,7 +884,7 @@ class TestRegressionSuite(unittest.TestCase):
         star_prob = star_type_probability.star_type_probability(
             self.pdf1d_fname_cache,
             temp_pdf2d_fname,
-            **input,
+            **star_prob_info["input"],
         )
 
         # compare to expected table
@@ -951,7 +951,6 @@ class TestRegressionSuite(unittest.TestCase):
             f"./{self.settings.project}/{self.settings.project}_seds.grid.hd5",
         )
 
-    @pytest.mark.skip(reason="updated cached file needed")
     @pytest.mark.usefixtures("setup_create_physicsmodel")
     def test_create_physicsmodel_with_subgrid(self):
         """
@@ -1034,7 +1033,6 @@ class TestRegressionSuite(unittest.TestCase):
             "beast_example_phat/beast_example_phat_noisemodel.grid.hd5",
         )
 
-    @pytest.mark.skip(reason="updated cached file needed")
     @pytest.mark.usefixtures("setup_create_obsmodel")
     def test_create_obsmodel_with_subgrid(self):
         """

--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -96,15 +96,15 @@ class TestRegressionSuite(unittest.TestCase):
             f"{cls.basename}_spec_w_priors.grid.hd5"
         )
         cls.priors_sub0_fname_cache = download_rename(
-             f"{cls.basename}_subgrids_spec_w_priors.gridsub0.hd5"
+            f"{cls.basename}_subgrids_spec_w_priors.gridsub0.hd5"
         )
         cls.priors_sub1_fname_cache = download_rename(
-             f"{cls.basename}_subgrids_spec_w_priors.gridsub1.hd5"
+            f"{cls.basename}_subgrids_spec_w_priors.gridsub1.hd5"
         )
         # - SED grids
         cls.seds_fname_cache = download_rename(f"{cls.basename}_seds.grid.hd5")
         cls.seds_sub0_fname_cache = download_rename(
-             f"{cls.basename}_subgrids_seds.gridsub0.hd5"
+            f"{cls.basename}_subgrids_seds.gridsub0.hd5"
         )
         cls.seds_sub1_fname_cache = download_rename(
             f"{cls.basename}_subgrids_seds.gridsub1.hd5"
@@ -842,9 +842,7 @@ class TestRegressionSuite(unittest.TestCase):
 
         # run star_type_probability
         star_prob = star_type_probability.star_type_probability(
-            self.pdf1d_fname_cache,
-            self.pdf2d_fname_cache,
-            **star_prob_info["input"],
+            self.pdf1d_fname_cache, self.pdf2d_fname_cache, **star_prob_info["input"],
         )
 
         # expected output table
@@ -870,25 +868,23 @@ class TestRegressionSuite(unittest.TestCase):
         temp_hdu_list = []
         with fits.open(self.pdf2d_fname_cache) as hdu:
             for ext in hdu:
-                if 'Av+' in ext.name or '+Av' in ext.name:
+                if "Av+" in ext.name or "+Av" in ext.name:
                     continue
                 temp_hdu_list.append(ext)
             fits.HDUList(temp_hdu_list).writeto(temp_pdf2d_fname)
 
         # edit the expected output to have NaNs in columns that require A_V
         # (currently, that's all columns)
-        expected_star_prob = Table(star_prob_info['output'])
+        expected_star_prob = Table(star_prob_info["output"])
         for col in expected_star_prob.colnames:
-            if col == 'ext_O_star':
+            if col == "ext_O_star":
                 expected_star_prob[col] = np.nan
-            if col == 'dusty_agb':
+            if col == "dusty_agb":
                 expected_star_prob[col] = np.nan
 
         # run star_type_probability
         star_prob = star_type_probability.star_type_probability(
-            self.pdf1d_fname_cache,
-            temp_pdf2d_fname,
-            **star_prob_info["input"],
+            self.pdf1d_fname_cache, temp_pdf2d_fname, **star_prob_info["input"],
         )
 
         # compare to expected table

--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -131,7 +131,7 @@ class TestRegressionSuite(unittest.TestCase):
         cls.pdf2d_fname_cache = download_rename(f"{cls.basename}_pdf2d.fits")
 
         # create the beast_settings object
-        # (copied over from the phat_small example in beast-examples)
+        # (copied over from the metal_small example in beast-examples)
         cls.settings_fname_cache = download_rename(
             f"{cls.basesubdir}beast_settings.txt"
         )
@@ -142,7 +142,7 @@ class TestRegressionSuite(unittest.TestCase):
         # also make a version with 2 subgrids
         cls.settings_sg = copy.deepcopy(cls.settings)
         cls.settings_sg.n_subgrid = 2
-        cls.settings_sg.project = f"{cls.basename}_subgrids"
+        cls.settings_sg.project = f"{cls.settings.project}_subgrids"
 
     # ###################################################################
     # Standard BEAST fitting steps
@@ -917,6 +917,7 @@ class TestRegressionSuite(unittest.TestCase):
     # ###################################################################
     # tools.run tests
 
+    @pytest.mark.skip(reason="need to fix issue with folder teardown")
     @pytest.mark.usefixtures("setup_create_physicsmodel")
     def test_create_physicsmodel_no_subgrid(self):
         """
@@ -951,6 +952,7 @@ class TestRegressionSuite(unittest.TestCase):
             f"./{self.settings.project}/{self.settings.project}_seds.grid.hd5",
         )
 
+    @pytest.mark.skip(reason="need to fix issue with folder teardown")
     @pytest.mark.usefixtures("setup_create_physicsmodel")
     def test_create_physicsmodel_with_subgrid(self):
         """
@@ -969,7 +971,7 @@ class TestRegressionSuite(unittest.TestCase):
             self.iso_fname_cache, format="ascii.csv", comment="#", delimiter=",",
         )
         table_new = Table.read(
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_iso.csv",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_iso.csv",
             format="ascii.csv",
             comment="#",
             delimiter=",",
@@ -979,38 +981,38 @@ class TestRegressionSuite(unittest.TestCase):
         # - spectra with priors
         compare_hdf5(
             self.priors_fname_cache,
-            "./beast_example_phat_subgrids/beast_example_phat_subgrids_spec_w_priors.grid.hd5",
+            "./beast_metal_small_subgrids/beast_metal_small_subgrids_spec_w_priors.grid.hd5",
         )
         compare_hdf5(
             self.priors_sub0_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_spec_w_priors.gridsub0.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_spec_w_priors.gridsub0.hd5",
         )
         compare_hdf5(
             self.priors_sub1_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_spec_w_priors.gridsub1.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_spec_w_priors.gridsub1.hd5",
         )
 
         # - SEDs grid
         compare_hdf5(
             self.seds_sub0_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub0.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub0.hd5",
         )
         compare_hdf5(
             self.seds_sub1_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub1.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub1.hd5",
         )
 
         # - list of subgrids
-        with open("./beast_example_phat_subgrids/subgrid_fnames.txt") as f:
+        with open("./beast_metal_small_subgrids/subgrid_fnames.txt") as f:
             temp = f.read()
         subgrid_list = [x for x in temp.split("\n") if x != ""]
         expected_list = [
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub0.hd5",
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub1.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub0.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub1.hd5",
         ]
         assert subgrid_list == expected_list, "subgrid_fnames.txt has incorrect content"
 
-    @pytest.mark.skip(reason="updated cached file needed")
+    @pytest.mark.skip(reason="need to fix issue with folder teardown")
     @pytest.mark.usefixtures("setup_create_obsmodel")
     def test_create_obsmodel_no_subgrid(self):
         """
@@ -1030,9 +1032,10 @@ class TestRegressionSuite(unittest.TestCase):
         # check that files match
         compare_hdf5(
             self.noise_fname_cache,
-            "beast_example_phat/beast_example_phat_noisemodel.grid.hd5",
+            "beast_metal_small/beast_metal_small_noisemodel.grid.hd5",
         )
 
+    @pytest.mark.skip(reason="need to fix issue with folder teardown")
     @pytest.mark.usefixtures("setup_create_obsmodel")
     def test_create_obsmodel_with_subgrid(self):
         """
@@ -1052,11 +1055,11 @@ class TestRegressionSuite(unittest.TestCase):
         # check that files match
         compare_hdf5(
             self.noise_sub0_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_noisemodel.gridsub0.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_noisemodel.gridsub0.hd5",
         )
         compare_hdf5(
             self.noise_sub1_fname_cache,
-            "beast_example_phat_subgrids/beast_example_phat_subgrids_noisemodel.gridsub1.hd5",
+            "beast_metal_small_subgrids/beast_metal_small_subgrids_noisemodel.gridsub1.hd5",
         )
 
 
@@ -1120,11 +1123,11 @@ def setup_create_physicsmodel(request):
     yield
 
     # remove folders
-    bname = f"./{request.cls.settings.project}"
-    if os.path.isdir(bname):
-        shutil.rmtree(bname)
-    if os.path.isdir(f"{bname}_subgrids"):
-        shutil.rmtree(f"{bname}_subgrids")
+    basename = f"./{request.cls.settings.project}"
+    if os.path.isdir(basename):
+        shutil.rmtree(basename)
+    if os.path.isdir(f"{basename}_subgrids"):
+        shutil.rmtree(f"{basename}_subgrids")
 
 
 @pytest.fixture(scope="function")
@@ -1135,8 +1138,9 @@ def setup_create_obsmodel(request):
     """
     # print('setting up files for create_obsmodel')
     # create folders
-    os.mkdir("./beast_example_phat")
-    os.mkdir("./beast_example_phat_subgrids")
+    basename = f"./{request.cls.settings.project}"
+    os.mkdir(basename)
+    os.mkdir(f"{basename}_subgrids")
     # make symlinks to SED data
     source_list = [
         request.cls.seds_fname_cache,
@@ -1144,14 +1148,14 @@ def setup_create_obsmodel(request):
         request.cls.seds_sub1_fname_cache,
     ]
     dest_list = [
-        "./beast_example_phat/beast_example_phat_seds.grid.hd5",
-        "./beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub0.hd5",
-        "./beast_example_phat_subgrids/beast_example_phat_subgrids_seds.gridsub1.hd5",
+        "./beast_metal_small/beast_metal_small_seds.grid.hd5",
+        "./beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub0.hd5",
+        "./beast_metal_small_subgrids/beast_metal_small_subgrids_seds.gridsub1.hd5",
     ]
     for source, dest in zip(source_list, dest_list):
         os.symlink(os.path.abspath(source), os.path.abspath(dest))
     # make a subgrid file name list
-    with open("./beast_example_phat_subgrids/subgrid_fnames.txt", "w") as f:
+    with open("./beast_metal_small_subgrids/subgrid_fnames.txt", "w") as f:
         f.write(dest_list[1] + "\n" + dest_list[2] + "\n")
 
     # run tests
@@ -1159,7 +1163,7 @@ def setup_create_obsmodel(request):
 
     # remove folders/symlinks
     # print('teardown for create_obsmodel')
-    if os.path.isdir("./beast_example_phat"):
-        shutil.rmtree("./beast_example_phat")
-    if os.path.isdir("./beast_example_phat_subgrids"):
-        shutil.rmtree("./beast_example_phat_subgrids")
+    if os.path.isdir(basename):
+        shutil.rmtree(basename)
+    if os.path.isdir(f"{basename}_subgrids"):
+        shutil.rmtree(f"{basename}_subgrids")

--- a/beast/tools/compare_spec_type.py
+++ b/beast/tools/compare_spec_type.py
@@ -71,7 +71,7 @@ def compare_spec_type(
         ra=beast_phot[ra_col] * u.degree, dec=beast_phot[dec_col] * u.degree
     )
     # read in BEAST results
-    beast_stats = Table.read(beast_stats_file)
+    beast_stats = Table.read(beast_stats_file, hdu=1)
     beast_stats_catalog = SkyCoord(
         ra=beast_stats["RA"] * u.degree, dec=beast_stats["DEC"] * u.degree
     )


### PR DESCRIPTION
The `generate_files_for_tests` code in https://github.com/BEAST-Fitting/beast-examples/pull/16 creates asdf files for testing the `compare_spec_type` and `star_type_probability` tools.  This updates `test_regresscheck` to use those files.  @karllark, could you use `generate_files_for_tests` to update the cached metal_small files (assuming, of course, that it doesn't need any changes first)?  Then I'll be able to check if `test_regresscheck` is working as expected.

This PR also adds `hdu=1` to the stats file read-in for `compare_spec_type`.