### PR TITLE
Fixed a small bug in make_ast_inputs.py when using random_pick method

### DIFF
--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -98,7 +98,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 tmp_cuts = mag_cuts
                 min_mags = np.zeros(len(settings.filters))
                 for k, filtername in enumerate(obsdata.filters):
-                    sfiltername = obsdata.data.resolve_alias(filtername)
+                    sfiltername = obsdata.filter_aliases[filtername]
                     sfiltername = sfiltername.replace("rate", "vega")
                     sfiltername = sfiltername.replace("RATE", "VEGA")
                     (keep,) = np.where(obsdata[sfiltername] < 99.0)


### PR DESCRIPTION
This is a one-line bug fix that only affects pick_method='random_pick' in make_ast_inputs.py. obsdata.data no longer has a resolve_alias() method.