### PR TITLE
Adding custom source density binning option

### DIFF
--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -67,8 +67,8 @@ def pick_positions_from_map(
 
     N_bins: int
         The number of bins for the range of background density values.
-        The bins will be picked on a linear grid, ranging from the
-        minimum to the maximum value of the map. Then, each tile will be
+        The bins will be picked on a linear grid or log grid (according to bin_mode)
+        ranging from the minimum to the maximum value of the map. Then, each tile will be
         put in a bin, so that a set of tiles of the map is obtained for
         each range of source density/background values.
 
@@ -79,6 +79,11 @@ def pick_positions_from_map(
         minimum to the maximum value of the map. Then, each tile will be
         put in a bin, so that a set of tiles of the map is obtained for
         each range of source density/background values.
+
+    custom_bins: list (default=None)
+        Custom values of bin edges for source or background density values.
+        Each tile will be put into a bin, so that a set of tiles of the
+        map is obtained for each range of source density/background values.
 
     refimage: str
         Path to fits image that is used for the positions. If none is
@@ -262,8 +267,13 @@ def pick_positions_from_map(
     print(Npermodel, " repeats of each model in each map bin")
 
     bdm = density_map.BinnedDensityMap.create(
-        input_map, bin_mode=bin_mode, N_bins=N_bins, bin_width=bin_width
+        input_map,
+        bin_mode=bin_mode,
+        N_bins=N_bins,
+        bin_width=bin_width,
+        custom_bins=custom_bins,
     )
+
     tile_vals = bdm.tile_vals()
     max_val = np.amax(tile_vals)
     min_val = np.amin(tile_vals)

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -19,6 +19,7 @@ def pick_positions_from_map(
     bin_mode,
     N_bins,
     bin_width,
+    custom_bins,
     Npermodel,
     outfile=None,
     refimage=None,

--- a/beast/tools/density_map.py
+++ b/beast/tools/density_map.py
@@ -151,6 +151,12 @@ class BinnedDensityMap(DensityMap):
 
         if custom_bins is not None:
             bin_edges = custom_bins
+
+            # Find which bin each tile belongs to
+            # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
+            # We have purposely chosen our bin boundaries so that no points fall
+            # outside (or on the edge) of the [1,5] range
+            bins = np.digitize(binned_density_map.tile_data[input_column], bin_edges)
         else:
             if bin_mode == "linear":
                 # Create the extra column here
@@ -174,6 +180,14 @@ class BinnedDensityMap(DensityMap):
                         N_bins + 1,
                     )
 
+                    # Find which bin each tile belongs to
+                    # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
+                    # We have purposely chosen our bin boundaries so that no points fall
+                    # outside (or on the edge) of the [1,5] range
+                    bins = np.digitize(
+                        binned_density_map.tile_data[input_column], bin_edges
+                    )
+
                 if bin_width is not None:
                     tile_densities = binned_density_map.tile_data[input_column]
                     min_density = np.amin(tile_densities)
@@ -181,6 +195,14 @@ class BinnedDensityMap(DensityMap):
                     tot_bins = np.ceil((max_density - min_density) / bin_width)
                     bin_edges = min_density + np.arange(tot_bins + 1) * bin_width
                     print("bin edges: ", bin_edges)
+
+                    # Find which bin each tile belongs to
+                    # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
+                    # We have purposely chosen our bin boundaries so that no points fall
+                    # outside (or on the edge) of the [1,5] range
+                    bins = np.digitize(
+                        binned_density_map.tile_data[input_column], bin_edges
+                    )
 
             if bin_mode == "log":
                 # Create the extra column here
@@ -207,11 +229,13 @@ class BinnedDensityMap(DensityMap):
                     )
                     print("bin edges: ", bin_edges)
 
-        # Find which bin each tile belongs to
-        # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
-        # We have purposely chosen our bin boundaries so that no points fall
-        # outside (or on the edge) of the [1,5] range
-        bins = np.digitize(binned_density_map.tile_data[input_column], bin_edges)
+                    # Find which bin each tile belongs to
+                    # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
+                    # We have purposely chosen our bin boundaries so that no points fall
+                    # outside (or on the edge) of the [1,5] range
+                    bins = np.digitize(
+                        binned_density_map.tile_data[input_column], bin_edges
+                    )
 
         # Upgrade to this subclass, and return
         return BinnedDensityMap(binned_density_map.tile_data, bins)

--- a/beast/tools/density_map.py
+++ b/beast/tools/density_map.py
@@ -136,7 +136,9 @@ class BinnedDensityMap(DensityMap):
 
         self.bin_indices_used = np.sort(np.unique(bins))
 
-    def create(density_map, bin_mode="linear", N_bins=None, bin_width=None):
+    def create(
+        density_map, bin_mode="linear", N_bins=None, bin_width=None, custom_bins=None
+    ):
         """
         Creates a binned density map from a DensityMap file, or from an
         astropy table loaded from it. The tiles are grouped into
@@ -147,82 +149,69 @@ class BinnedDensityMap(DensityMap):
         # be file or table object)
         binned_density_map = DensityMap(density_map)
 
-        if bin_mode == "linear":
+        if custom_bins is not None:
+            bin_edges = custom_bins
+        else:
+            if bin_mode == "linear":
+                # Create the extra column here
+                if (N_bins is None) and (bin_width is None):
+                    bins = np.array(range(len(binned_density_map.tile_data)))
 
-            # Create the extra column here
-            if (N_bins is None) and (bin_width is None):
-                bins = np.array(range(len(binned_density_map.tile_data)))
+                if (N_bins is not None) and (bin_width is not None):
+                    raise Exception(
+                        "Both sd_Nbins and sd_binwidth are set in the beast_settings file. Please set only one!"
+                    )
 
-            if (N_bins is not None) and (bin_width is not None):
-                raise Exception(
-                    "Both sd_Nbins and sd_binwidth are set in the beast_settings file. Please set only one!"
-                )
+                if N_bins is not None:
+                    # Create the density bins
+                    # [min, ., ., ., max]
+                    tile_densities = binned_density_map.tile_data[input_column]
+                    min_density = np.amin(tile_densities)
+                    max_density = np.amax(tile_densities)
+                    bin_edges = np.linspace(
+                        min_density - 0.01 * abs(min_density),
+                        max_density + 0.01 * abs(max_density),
+                        N_bins + 1,
+                    )
 
-            if N_bins is not None:
-                # Create the density bins
-                # [min, ., ., ., max]
-                tile_densities = binned_density_map.tile_data[input_column]
-                min_density = np.amin(tile_densities)
-                max_density = np.amax(tile_densities)
-                bin_edges = np.linspace(
-                    min_density - 0.01 * abs(min_density),
-                    max_density + 0.01 * abs(max_density),
-                    N_bins + 1,
-                )
+                if bin_width is not None:
+                    tile_densities = binned_density_map.tile_data[input_column]
+                    min_density = np.amin(tile_densities)
+                    max_density = np.amax(tile_densities)
+                    tot_bins = np.ceil((max_density - min_density) / bin_width)
+                    bin_edges = min_density + np.arange(tot_bins + 1) * bin_width
+                    print("bin edges: ", bin_edges)
 
-                # Find which bin each tile belongs to
-                # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
-                # We have purposely chosen our bin boundaries so that no points fall
-                # outside (or on the edge) of the [1,5] range
-                bins = np.digitize(
-                    binned_density_map.tile_data[input_column], bin_edges
-                )
+            if bin_mode == "log":
+                # Create the extra column here
+                if N_bins is None:
+                    raise Exception(
+                        "Please make sure the number of source density bins (sd_Nbins) "
+                        "is properly set in the beast_settings file for log binning "
+                        "to proceed."
+                    )
 
-            if bin_width is not None:
-                tile_densities = binned_density_map.tile_data[input_column]
-                min_density = np.amin(tile_densities)
-                max_density = np.amax(tile_densities)
-                tot_bins = np.ceil((max_density - min_density) / bin_width)
-                bin_edges = min_density + np.arange(tot_bins + 1) * bin_width
-                print("bin edges: ", bin_edges)
+                elif N_bins is not None:
+                    # Create the density bins
+                    # [min, ., ., ., max]
+                    tile_densities = binned_density_map.tile_data[input_column]
+                    # print(tile_densities)
 
-                # Find which bin each tile belongs to
-                bins = np.digitize(
-                    binned_density_map.tile_data[input_column], bin_edges
-                )
+                    min_density = np.amin(tile_densities[tile_densities > 0.0])
+                    max_density = np.amax(tile_densities)
 
-        if bin_mode == "log":
-            # Create the extra column here
-            if N_bins is None:
-                raise Exception(
-                    "Please make sure the number of source density bins (sd_Nbins) "
-                    "is properly set in the beast_settings file for log binning "
-                    "to proceed."
-                )
+                    bin_edges = np.logspace(
+                        np.log10(min_density - 0.01 * abs(min_density)),
+                        np.log10(max_density + 0.01 * abs(max_density)),
+                        N_bins + 1,
+                    )
+                    print("bin edges: ", bin_edges)
 
-            elif N_bins is not None:
-                # Create the density bins
-                # [min, ., ., ., max]
-                tile_densities = binned_density_map.tile_data[input_column]
-                # print(tile_densities)
-
-                min_density = np.amin(tile_densities[tile_densities > 0.0])
-                max_density = np.amax(tile_densities)
-
-                bin_edges = np.logspace(
-                    np.log10(min_density - 0.01 * abs(min_density)),
-                    np.log10(max_density + 0.01 * abs(max_density)),
-                    N_bins + 1,
-                )
-                print("bin edges: ", bin_edges)
-
-                # Find which bin each tile belongs to
-                # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
-                # We have purposely chosen our bin boundaries so that no points fall
-                # outside (or on the edge) of the [1,5] range
-                bins = np.digitize(
-                    binned_density_map.tile_data[input_column], bin_edges
-                )
+        # Find which bin each tile belongs to
+        # e.g. one of these numbers: 0 [1, 2, 3, 4, 5] 6
+        # We have purposely chosen our bin boundaries so that no points fall
+        # outside (or on the edge) of the [1,5] range
+        bins = np.digitize(binned_density_map.tile_data[input_column], bin_edges)
 
         # Upgrade to this subclass, and return
         return BinnedDensityMap(binned_density_map.tile_data, bins)

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -168,6 +168,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 settings.sd_binmode,
                 settings.sd_Nbins,
                 settings.sd_binwidth,
+                settings.sd_custom,
                 settings.ast_realization_per_model,
                 outfile=outfile,
                 refimage=settings.ast_reference_image,
@@ -194,7 +195,9 @@ if __name__ == "__main__":  # pragma: no cover
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "beast_settings_file", type=str, help="file name with beast settings",
+        "beast_settings_file",
+        type=str,
+        help="file name with beast settings",
     )
     parser.add_argument(
         "--random_seds",

--- a/beast/tools/split_catalog_using_map.py
+++ b/beast/tools/split_catalog_using_map.py
@@ -74,7 +74,7 @@ def split_main(
     # Create a binned density map, so both the observed and the ast
     # catalog can be split using a consistent grouping (= binning) of
     # the tiles
-    if not settings.sd_Nbins and not settings.sd_binwidth:
+    if not settings.sd_Nbins and not settings.sd_binwidth and not settings.sd_custom:
         raise RuntimeError(
             "You need to specify the source density binning parameters in beast_settings_info"
         )
@@ -84,6 +84,7 @@ def split_main(
         bin_mode=settings.sd_binmode,
         N_bins=settings.sd_Nbins,
         bin_width=settings.sd_binwidth,
+        custom_bins=settings.sd_custom,
     )
 
     print("Splitting catalog")
@@ -209,7 +210,9 @@ def split_catalog_using_map(
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "beast_settings_info", type=str, help="file name with beast settings",
+        "beast_settings_info",
+        type=str,
+        help="file name with beast settings",
     )
     parser.add_argument("catfile", type=str, help="catalog FITS file")
     parser.add_argument("astfile", type=str, help="ast results fits file")

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -168,8 +168,9 @@ variable in `beast_settings.txt`
    all selected SEDs are randomly replicated within pixels of that bin. These bins
    are determined by the beast_settings parameters, and can have linear (default)
    or log spacing, where the user can determine the number or width of the bins
-   (set using sd_binmode, sd_binwidth and sd_Nbins in beast_settings). This same
-   binning scheme is used later to split the catalogs (next step).
+   (set using sd_binmode, sd_binwidth and sd_Nbins in beast_settings). Alternatively,
+   the user can input a custom list of bin edges, which will override the other binning settings.
+   This same binning scheme is used later to split the catalogs (next step).
 
 2. ast_source_density_table = None:
    Randomly choose a star from the photometry catalog, and place the
@@ -218,7 +219,9 @@ The observed catalog should be split into separate files for each source
 density bin. These bins are determined by the beast_settings parameters,
 and can have linear (default) or log spacing, where the user can determine
 the number or width of the bins (set using sd_binmode, sd_binwidth and sd_Nbins
-in beast_settings). In addition, each source density catalog can be split into a set of
+in beast_settings). Alternatively, the user can input a custom list of bin edges,
+which will override the other binning settings.
+In addition, each source density catalog can be split into a set of
 sub-files to have at most 'n_per_file' sources (or, if there are very few stars
 in a source density bin, at least 'min_n_subfile' sub-files).  The sources are
 sorted by the 'sort_col' flux before splitting to put sources with similar


### PR DESCRIPTION
First crack at adding option of assigning custom source density (or background density) bin edges via the beast_settings file. 

Currently, the way this works is tools/density_map looks for all of the source density binning parameters (sd_binmode (linear or log), sd_Nbins, sd_binwidth and sd_custom (the list of bin edges)). If custom_bins are set via sd_custom, all other source density binning parameters are superseded. However, if not custom, the code still expects all other binning parameters to have been set (i.e., any not in use should be set to None rather than omitted completely). I can update this to check if they're set or not, but figured we'd want to keep the parameters around for completeness? Wondering what the team's thoughts are!

Also, would be great if @christinawlindberg could review this PR!