### PR TITLE
Add info about using [options.package_data] in setup.cfg

### DIFF
--- a/docs/beast_development.rst
+++ b/docs/beast_development.rst
@@ -123,6 +123,11 @@ and `beast-dev1`).
 
      $ git add -A
 
+- If you add a file type in the `beast/` folder that's not typically included
+  (e.g., `.txt` or `.png`), you also need to list it in the ``[options.package_data]``
+  section in `setup.cfg`.  Even if the file exists in the repository, adding it
+  here is necessary for it to be included when the package is built.
+
 - To 'commit' all changes after adding desired files:
 
   .. code-block:: console


### PR DESCRIPTION
If non-standard files (as in, not `.py`) are added to the beast, they also need to be listed in setup.cfg.  Since @karllark has needed to explain that to me on multiple occasions (thanks Karl!), I decided to add it to the development docs.