### PR TITLE
allow best legend location; fix matplotlib 3.3 rqmt

### DIFF
--- a/beast/plotting/plot_indiv_fit.py
+++ b/beast/plotting/plot_indiv_fit.py
@@ -263,7 +263,7 @@ def plot_indiv_fit(filebase, starnum=0, savefig=False, plotfig=True):
         waves, mod_flux_nd[:, 1], mod_flux_nd[:, 2], color="y", alpha=0.1
     )
 
-    #can introduce a legend loc option if 'best' produces overlap
+    # can introduce a legend loc option if 'best' produces overlap
     sed_ax.legend(loc='best', fontsize=9)
 
     sed_ax.set_ylabel(r"Flux [ergs s$^{-1}$ cm$^{-2}$ $\AA^{-1}$]")

--- a/beast/plotting/plot_indiv_fit.py
+++ b/beast/plotting/plot_indiv_fit.py
@@ -263,11 +263,11 @@ def plot_indiv_fit(filebase, starnum=0, savefig=False, plotfig=True):
         waves, mod_flux_nd[:, 1], mod_flux_nd[:, 2], color="y", alpha=0.1
     )
 
-    # sed_ax.legend(loc='upper right', bbox_to_anchor=(1.25, 1.025), fontsize=8)
-    sed_ax.legend(loc="lower right", fontsize=9)
+    #can introduce a legend loc option if 'best' produces overlap
+    sed_ax.legend(loc='best', fontsize=9)
 
     sed_ax.set_ylabel(r"Flux [ergs s$^{-1}$ cm$^{-2}$ $\AA^{-1}$]")
-    sed_ax.set_yscale("symlog", linthreshy=symlog_linthreshold)
+    sed_ax.set_yscale("symlog", linthresh=symlog_linthreshold)
     sed_ax.grid(True)
 
     sed_ax.text(0.5, -0.07, r"$\lambda$ [$\mu m$]", transform=sed_ax.transAxes, va="top")


### PR DESCRIPTION
An explicitly-specified legend location in the lower right of the individual star fit plot sometimes overlapped the legend with a fit line. `matplotlib.legend` can be asked to choose the best location for minimum overlap. A future update can include a legend location option.

The change in the keyword for symlog was based on a MatplotlibDeprecationWarning received just today:
`MatplotlibDeprecationWarning: The 'linthreshy' parameter of __init__() has been renamed 'linthresh' since Matplotlib 3.3; support for the old name will be dropped two minor releases later.`
The latest Matplotlib minor release - [3.3.3](https://pypi.org/project/matplotlib/#history) - took place recently on Nov. 11, 2020, and I believe this is why we may not have run into this issue yet. (I ran into it when testing the legend location option change).