### PR TITLE
Suppl ast filename

### DIFF
--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -59,7 +59,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
     Nfilters = settings.ast_bands_above_maglimit
 
     # file names for stars and corresponding SED parameters
-    if settings.ast_supplement:
+    if pick_method == "suppl_seds":
         outfile_seds = "./{0}/{0}_inputAST_seds_suppl.txt".format(settings.project)
         outfile_params = "./{0}/{0}_ASTparams_suppl.fits".format(settings.project)
     else:

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -160,7 +160,7 @@ to select additional model SEDs.
 
   .. code-block:: console
 
-     $ python -m beast.tools.run.make_ast_inputs --suppl_seds
+     $ python -m beast.tools.run.make_ast_inputs beast_settings.txt --suppl_seds
 
 How the sources are placed in the image is determined by the ast_source_density_table
 variable in `beast_settings.txt`


### PR DESCRIPTION
Current way of setting the output file names for the supplemented input AST list can cause a problem by making both the BEAST optimized input list and the supplemented input list have the same file names unless you run the 'make_ast_inputs' with 'ast_supplement = False' in the beast_seetings.txt and then run again 'make_ast_inputs' with 'ast_supplement = True'. This is inconvenient for users and might cause unnecessary issue for their ASTs. So I fixed that issue. 

I also update the doc string for the correct usage of the 'make_ast_inputs' with the --suppl_seds option.