### PR TITLE
Allow to indicate the ref image extension number where the WCS info is stored

### DIFF
--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -172,7 +172,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 settings.ast_realization_per_model,
                 outfile=outfile,
                 refimage=settings.ast_reference_image,
-                refimage_hdu=1,
+                refimage_hdu=settings.ast_reference_image_hdu_extension,
                 wcs_origin=1,
                 Nrealize=1,
                 set_coord_boundary=settings.ast_coord_boundary,

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -161,6 +161,11 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
 
         # if we're replicating SEDs across source density or background bins
         if settings.ast_density_table is not None:
+            if hasattr(settings, "ast_reference_image_hdu_extension"):
+                hdu_ext = settings.ast_reference_image_hdu_extension
+            else:
+                hdu_ext = 1
+
             make_ast_xy_list.pick_positions_from_map(
                 obsdata,
                 chosen_seds,
@@ -172,7 +177,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 settings.ast_realization_per_model,
                 outfile=outfile,
                 refimage=settings.ast_reference_image,
-                refimage_hdu=settings.ast_reference_image_hdu_extension,
+                refimage_hdu=hdu_ext,
                 wcs_origin=1,
                 Nrealize=1,
                 set_coord_boundary=settings.ast_coord_boundary,

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -48,6 +48,7 @@ input parameters from beast_settings.txt.
 * ``ast_N_bins``: (optional; int) number of source or background bins that you want ASTs repeated over.
 * ``ast_pixel_distribution``: (optional; float) minimum pixel separation between AST position and catalog star used to determine the AST spatial distribution. Used if ast_with_positions is True.
 * ``ast_reference_image``: (optional; string) name of the reference image used by DOLPHOT when running the measured photometry. Required if ast_with_positions is True and no X,Y information is present in the photometry catalog.
+* ``ast_reference_image_hdu_extension``: (optional; int) extension number of the reference image file where the WCS information is stored. Required if ast_with_positions is True and no X,Y information is present in the photometry catalog.
 * ``ast_coord_boundary``: (optional; list of two arrays) if supplied, these RA/Dec coordinates will be used to limit the region over which ASTs are generated (default = None).
 * ``ast_erode_selection_region``: (optional; float) To avoid placing ASTs near the edge of the image, set this to the number of arcseconds (default=0.5, which is ~10 pixels for WFC3/UVIS) to shrink the allowed AST placement region.  This is applied by doing an erosion to both ast_coord_boundary (if set) and a convex hull around the photometry catalog.
 * ``astfile``:  pathname to the AST files (single camera ASTs).


### PR DESCRIPTION
I encountered a case where my reference image has the WCS information in the 0th extension header of a FITS file. However, the BEAST currently assumes the WCS info is always in the first extension of a given reference image. I modified it to allow to explicitly indicate the extension number where the WCS information is stored. I introduced a new parameter 'ast_reference_image_hdu_extension', which needs to be in 'beast_settings.txt' file. 