### PR TITLE
Cleanup toothpick observation model calculation and fix simulate_obs bug

### DIFF
--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -188,13 +188,6 @@ class MultiFilterASTs(NoiseModel):
             flux_out = flux_out[gvals]
             print("removing NaNs")
 
-        # get the output flux accounting for flagged sources
-        # that mean the source was not recovered
-        flux_out = copy.copy(flux_out)
-        if fluxout_mag is not None:
-            notrecovered = fluxout_mag > 90
-            flux_out[notrecovered] = 0.0
-
         # convert the AST input from magnitudes to fluxes
         # always convert the mag_in to fluxes (the way the ASTs are
         # reported)

--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -272,12 +272,12 @@ class MultiFilterASTs(NoiseModel):
         else:
             return d
 
-    def fit(self, nbins=50, completeness_mag_cut=80, progress=True):
+    def fit(self, nbins=50, progress=True):
         """
         Alias of fit_bins
         """
         return self.fit_bins(
-            nbins=nbins, completeness_mag_cut=completeness_mag_cut, progress=progress
+            nbins=nbins, progress=progress
         )
 
     def fit_bins(

--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -187,8 +187,8 @@ class MultiFilterASTs(NoiseModel):
         # based on input threshold ratio
         if ast_nonrecovered_ratio is not None:
             (indxs,) = np.where(flux_out != 0.0)
-            absdiff = flux_out[indxs] / flux_in[indxs]
-            (indxs2,) = np.where(absdiff > ast_nonrecovered_ratio)
+            flux_ratio = flux_out[indxs] / flux_in[indxs]
+            (indxs2,) = np.where(flux_ratio > ast_nonrecovered_ratio)
             flux_out[indxs[indxs2]] = 0.0
 
         # storage the storage of the results

--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -107,7 +107,7 @@ class MultiFilterASTs(NoiseModel):
         name_prefix=None,
         asarray=False,
         compute_stddev=False,
-        ast_nonrecovered_frac=0.5,
+        ast_nonrecovered_ratio=2.0,
         min_flux=None,
         max_flux=None,
     ):
@@ -142,9 +142,9 @@ class MultiFilterASTs(NoiseModel):
             if True, uses np.mean()+np.std() to estimate avg bias+sigma;
             if False (default), uses np.percentiles
 
-        ast_nonrecovered_frac : float
-            fraction of (flux_in-flux_out)/flux_in to consider an ast not recovered
-            default = 0.5, set to None to disable
+        ast_nonrecovered_ratio : float
+            output/input flux ratio above which to consider an ast not recovered
+            default = 2.0, set to None to disable
 
         min_flux : float
             min flux value in vega normalized fluxes for model bins
@@ -181,14 +181,14 @@ class MultiFilterASTs(NoiseModel):
         flux_in = 10 ** (-0.4 * mag_in)
 
         # set the flux_out to zero for all ASTs recovered with too large
-        # a difference in fluxes.  This removes sources that are below the
+        # a ratio of output/input fluxes.  This removes sources that are below the
         # the faintest detectable flux that are associated with a real nearby
         # source (random chance that happens depending on the source density)
         # based on input threshold ratio
-        if ast_nonrecovered_frac is not None:
+        if ast_nonrecovered_ratio is not None:
             (indxs,) = np.where(flux_out != 0.0)
-            absdiff = np.absolute((flux_in[indxs] - flux_out[indxs]) / flux_in[indxs])
-            (indxs2,) = np.where(absdiff > ast_nonrecovered_frac)
+            absdiff = flux_out[indxs] / flux_in[indxs]
+            (indxs2,) = np.where(absdiff > ast_nonrecovered_ratio)
             flux_out[indxs[indxs2]] = 0.0
 
         # storage the storage of the results
@@ -283,7 +283,7 @@ class MultiFilterASTs(NoiseModel):
     def fit_bins(
         self,
         nbins=50,
-        ast_nonrecovered_frac=0.5,
+        ast_nonrecovered_ratio=2.0,
         min_flux=None,
         max_flux=None,
         progress=True,
@@ -296,8 +296,8 @@ class MultiFilterASTs(NoiseModel):
         nbins : int
             number of bins between the min/max values
 
-        ast_nonrecovered_frac : float
-            mark any ASTs with a fractional difference larger than this value
+        ast_nonrecovered_ratio : float
+            mark any ASTs with a an output/input flux ratio larger than this value
             as nonrecovered
 
         min_flux : float
@@ -347,7 +347,7 @@ class MultiFilterASTs(NoiseModel):
                 mag_in,
                 flux_out,
                 nbins=nbins,
-                ast_nonrecovered_frac=ast_nonrecovered_frac,
+                ast_nonrecovered_ratio=ast_nonrecovered_ratio,
                 min_flux=min_norm_flux,
                 max_flux=max_norm_flux,
             )

--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -1,5 +1,4 @@
 import math
-import copy
 
 import numpy as np
 
@@ -90,28 +89,19 @@ class MultiFilterASTs(NoiseModel):
         for k in self.filters:
             external_in = k.split("_")[-1] + "_" + in_pair[1]
             external_out = k.split("_")[-1] + "_" + out_pair[1]
-            external_out_flag = k.split("_")[-1] + "_flag"
-            external_out_mag = k.split("_")[-1] + "_vega"
             if upcase:
                 external_in = external_in.upper()
                 external_out = external_out.upper()
-                external_out_flag = external_out_flag.upper()
-                external_out_mag = external_out_mag.upper()
             else:
                 external_in = external_in.lower()
                 external_out = external_out.lower()
-                external_out_flag = external_out_flag.lower()
-                external_out_mag = external_out_mag.lower()
             self.filter_aliases[k + "_in"] = external_in
             self.filter_aliases[k + "_out"] = external_out
-            self.filter_aliases[k + "_flag"] = external_out_flag
-            self.filter_aliases[k + "_outmag"] = external_out_mag
 
     def _compute_sigma_bins(
         self,
         mag_in,
         flux_out,
-        fluxout_mag=None,
         nbins=30,
         min_per_bin=10,
         name_prefix=None,
@@ -134,9 +124,6 @@ class MultiFilterASTs(NoiseModel):
 
         flux_out : ndarray
              AST output flux
-
-        fluxout_mag : ndarray
-            AST output mag, if present used to remove sources with mag > 90
 
         nbins : int, optional
             Number of logrithmically spaced bins between the min/max values
@@ -345,10 +332,6 @@ class MultiFilterASTs(NoiseModel):
 
             mag_in = self.data[self.filter_aliases[filterk + "_in"]]
             flux_out = self.data[self.filter_aliases[filterk + "_out"]]
-            if self.filter_aliases[filterk + "_outmag"] in self.data.colnames:
-                fluxout_mag = self.data[self.filter_aliases[filterk + "_outmag"]]
-            else:
-                fluxout_mag = None
 
             # convert min/max fluxes to vega normalized fluxes
             if min_flux is not None:
@@ -363,7 +346,6 @@ class MultiFilterASTs(NoiseModel):
             d = self._compute_sigma_bins(
                 mag_in,
                 flux_out,
-                fluxout_mag=fluxout_mag,
                 nbins=nbins,
                 ast_nonrecovered_frac=ast_nonrecovered_frac,
                 min_flux=min_norm_flux,

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -216,7 +216,7 @@ def gen_SimObs_from_sedgrid(
     sedgrid,
     sedgrid_noisemodel,
     nsim=100,
-    compl_filter="F475W",
+    compl_filter="max",
     complcut=None,
     magcut=None,
     ranseed=None,

--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -295,7 +295,13 @@ def gen_SimObs_from_sedgrid(
 
     # only use models that have non-zero completeness in all filters
     # zero completeness means the observation model is not defined for that filters/flux
-    ast_defined = model_compl > 0.0
+    # if complcut is provided, only use models above that completeness cut
+    if complcut is not None:
+        finalcomplcut = complcut
+    else:
+        finalcomplcut = 0.0
+
+    ast_defined = model_compl > finalcomplcut
     sum_ast_defined = np.sum(ast_defined, axis=1)
     goodobsmod = sum_ast_defined >= n_filters
 
@@ -319,11 +325,6 @@ def gen_SimObs_from_sedgrid(
         filter_k = short_filters.index(compl_filter.upper())
         print("Completeness from %s" % sedgrid.filters[filter_k])
         model_compl = model_compl[:, filter_k]
-
-    # if complcut is provided, only use models above that completeness cut
-    # in addition to the non-zero completeness criterion
-    if complcut is not None:
-        goodobsmod = (goodobsmod) & (model_compl >= complcut)
 
     # if magcut is provided, only use models brighter than the magnitude cut
     # in addition to the non-zero completeness criterion
@@ -376,14 +377,15 @@ def gen_SimObs_from_sedgrid(
 
             # simluate the stars at the current age
             curweights = gridweights[gmods]
-            curweights /= np.sum(curweights)
-            cursim_indx = rangen.choice(
-                model_indx[gmods], size=nsim_curage, p=curweights
-            )
+            if np.sum(curweights) > 0:
+                curweights /= np.sum(curweights)
+                cursim_indx = rangen.choice(
+                    model_indx[gmods], size=nsim_curage, p=curweights
+                )
 
-            totsim_indx = np.concatenate((totsim_indx, cursim_indx))
+                totsim_indx = np.concatenate((totsim_indx, cursim_indx))
 
-            nsim += nsim_curage
+                nsim += nsim_curage
             # totsimcurmass = np.sum(sedgrid["M_ini"][cursim_indx])
             # print(cage, totcurmass / totmass, simmass, totsimcurmass, nsim_curage)
 

--- a/beast/plotting/plot_toothpick_details.py
+++ b/beast/plotting/plot_toothpick_details.py
@@ -40,7 +40,6 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
     ast_nonrecovered_frac = 0.5
     model.fit_bins(
         nbins=50,
-        completeness_mag_cut=-10,
         ast_nonrecovered_frac=ast_nonrecovered_frac,
         # min_flux=1e-22,
         # max_flux=1e-14,

--- a/beast/plotting/plot_toothpick_details.py
+++ b/beast/plotting/plot_toothpick_details.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import copy
 
 from beast.observationmodel.noisemodel import toothpick
 from beast.physicsmodel.grid import SEDGrid
@@ -37,12 +38,10 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
     model.set_data_mappings(upcase=True, in_pair=("in", "in"), out_pair=("out", "rate"))
 
     # compute binned biases, uncertainties, and completeness as a function of band flux
-    ast_nonrecovered_frac = 0.5
+    ast_nonrecovered_ratio = 2.0
     model.fit_bins(
         nbins=50,
-        ast_nonrecovered_frac=ast_nonrecovered_frac,
-        # min_flux=1e-22,
-        # max_flux=1e-14,
+        ast_nonrecovered_ratio=ast_nonrecovered_ratio,
     )
 
     nfilters = len(sedgrid.filters)
@@ -60,7 +59,7 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
 
         ax[i, 0].plot(
             flux_in[gvals],
-            (flux_in[gvals] - flux_out[gvals]) / flux_in[gvals],
+            flux_out[gvals] / flux_in[gvals],
             "ko",
             alpha=0.1,
             markersize=2,
@@ -71,30 +70,26 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
 
         ax[i, 0].plot(
             model._fluxes[0:ngbins, i],
-            model._biases[0:ngbins, i] / model._fluxes[0:ngbins, i],
+            1. + model._biases[0:ngbins, i] / model._fluxes[0:ngbins, i],
             "b-",
         )
 
         ax[i, 0].errorbar(
             model._fluxes[0:ngbins, i],
-            model._biases[0:ngbins, i] / model._fluxes[0:ngbins, i],
+            1. + model._biases[0:ngbins, i] / model._fluxes[0:ngbins, i],
             yerr=model._sigmas[0:ngbins, i] / model._fluxes[0:ngbins, i],
             fmt="bo",
             markersize=2,
             alpha=0.5,
         )
 
-        if ast_nonrecovered_frac is not None:
+        if ast_nonrecovered_ratio is not None:
             ax[i, 0].axhline(
-                ast_nonrecovered_frac, linestyle="--", alpha=0.25, color="k"
-            )
-            ax[i, 0].axhline(
-                -1.0 * ast_nonrecovered_frac, linestyle="--", alpha=0.25, color="k"
+                ast_nonrecovered_ratio, linestyle="--", alpha=0.25, color="k"
             )
 
-        ax[i, 0].set_ylim(-5e0, 5e0)
-        ax[i, 0].set_xscale("log")
-        ax[i, 0].set_ylabel(r"$(F_i - F_o)/F_i$")
+        ax[i, 0].set_ylim(-10, 2.5)
+        ax[i, 0].set_ylabel(r"$F_o/F_i$")
 
         ax[i, 1].plot(
             model._fluxes[0:ngbins, i],
@@ -116,7 +111,7 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
     # do after all the data has been plotted to get the full x range
     pxrange = ax[0, 0].get_xlim()
     for i, cfilter in enumerate(sedgrid.filters):
-        ax[i, 0].plot(pxrange, [0.0, 0.0], "k--", alpha=0.5)
+        ax[i, 0].plot(pxrange, [1.0, 1.0], "k--", alpha=0.5)
 
     # figname
     basename = asts_filename.replace(".fits", "_plot")

--- a/beast/plotting/plot_toothpick_details.py
+++ b/beast/plotting/plot_toothpick_details.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-import copy
 
 from beast.observationmodel.noisemodel import toothpick
 from beast.physicsmodel.grid import SEDGrid

--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -73,13 +73,6 @@ class TestRegressionSuite(unittest.TestCase):
             cls.basename = f"{cls.basesubdir}beast_metal_small"
             cls.obsname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst_samp.fits"
             cls.astname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst.fake.fits"
-            cls.ast_use_rate = True
-        else:
-            cls.basesubdir = "phat_small/"
-            cls.basename = f"{cls.basesubdir}beast_example_phat"
-            cls.obsname = f"{cls.basesubdir}b15_4band_det_27_A.fits"
-            cls.astname = f"{cls.basesubdir}fake_stars_b15_27_all.hd5"
-            cls.ast_use_rate = False
 
         # download the cached version for use and comparision
         # - photometry and ASTs
@@ -277,7 +270,6 @@ class TestRegressionSuite(unittest.TestCase):
             self.asts_fname_cache,
             modelsedgrid,
             absflux_a_matrix=self.settings.absflux_a_matrix,
-            use_rate=self.ast_use_rate,
         )
 
         # compare the new to the cached version
@@ -1026,7 +1018,6 @@ class TestRegressionSuite(unittest.TestCase):
             use_sd=False,
             nsubs=self.settings.n_subgrid,
             nprocs=1,
-            use_rate=False,
         )
 
         # check that files match
@@ -1049,7 +1040,6 @@ class TestRegressionSuite(unittest.TestCase):
             use_sd=False,
             nsubs=self.settings_sg.n_subgrid,
             nprocs=1,
-            use_rate=False,
         )
 
         # check that files match

--- a/beast/tools/run/create_obsmodel.py
+++ b/beast/tools/run/create_obsmodel.py
@@ -17,7 +17,6 @@ def create_obsmodel(
     nsubs=1,
     nprocs=1,
     subset=[None, None],
-    use_rate=True,
 ):
     """
     Create the observation models.  If nsubs > 1, this will find existing
@@ -45,12 +44,6 @@ def create_obsmodel(
     subset : list of two ints (default=[None,None])
         Only process subgrids in the range [start,stop].
         (only relevant if nsubs > 1)
-
-    use_rate : boolean (default=True)
-        Choose whether to use the rate or magnitude when creating the noise
-        model.  This should always be True, but is currently an option to be
-        compatible with the phat_small example (which has no rate info).
-        When that gets fixed, please remove this option!
 
     """
 

--- a/beast/tools/run/create_obsmodel.py
+++ b/beast/tools/run/create_obsmodel.py
@@ -94,7 +94,7 @@ def create_obsmodel(
         # if we're not splitting by source density
         else:
 
-            input_list = [(settings, modelsedgridfile, None, use_rate)]
+            input_list = [(settings, modelsedgridfile, None)]
 
             parallel_wrapper(gen_obsmodel, input_list, nprocs=nprocs)
 
@@ -115,7 +115,7 @@ def create_obsmodel(
         if use_sd:
 
             input_list = [
-                (settings, sedfile, curr_sd, use_rate)
+                (settings, sedfile, curr_sd)
                 for sedfile in modelsedgridfiles
                 for curr_sd in sd_list
             ]
@@ -126,13 +126,13 @@ def create_obsmodel(
         else:
 
             input_list = [
-                (settings, sedfile, None, use_rate) for sedfile in modelsedgridfiles
+                (settings, sedfile, None) for sedfile in modelsedgridfiles
             ]
 
             parallel_wrapper(gen_obsmodel, input_list, nprocs=nprocs)
 
 
-def gen_obsmodel(settings, modelsedgridfile, source_density=None, use_rate=True):
+def gen_obsmodel(settings, modelsedgridfile, source_density=None):
     """
     Code to create filenames and run the toothpick noise model
 
@@ -147,12 +147,6 @@ def gen_obsmodel(settings, modelsedgridfile, source_density=None, use_rate=True)
     source_density : string (default=None)
         set to None if there's no source density info, otherwise set to
         a string of the form "#-#"
-
-    use_rate : boolean (default=True)
-        Choose whether to use the rate or magnitude when creating the noise
-        model.  This should always be True, but is currently an option to be
-        compatible with the phat_small example (which has no rate info).
-        When that gets fixed, please remove this option!
 
     Returns
     -------
@@ -187,7 +181,6 @@ def gen_obsmodel(settings, modelsedgridfile, source_density=None, use_rate=True)
             astfile,
             modelsedgrid,
             absflux_a_matrix=settings.absflux_a_matrix,
-            use_rate=use_rate,
         )
 
     else:

--- a/beast/tools/simulate_obs.py
+++ b/beast/tools/simulate_obs.py
@@ -15,7 +15,7 @@ def simulate_obs(
     output_catalog,
     beastinfo_list=None,
     nsim=100,
-    compl_filter="F475W",
+    compl_filter="max",
     complcut=None,
     magcut=None,
     weight_to_use="weight",
@@ -50,7 +50,7 @@ def simulate_obs(
         nsim/len(physgrid_list) isn't an integer, this will be increased so that
         each grid has the same number of samples.
 
-    compl_filter : str (default=F475W)
+    compl_filter : str (default=max)
         filter to use for completeness (required for toothpick model)
         set to max to use the max value in all filters
 


### PR DESCRIPTION
The removing of faint input AST sources that were erroneously recovered with real, brighter sources has been updated.  The criteria is now to remove any sources with output/input flux ratios above a threshold (default is 2.0).  Previously, sources were removed based on their absolute flux difference/input flux (default = 0.5).  This was incorrect as it removed all output negative sources, did not remove sources symmetrically, and removed sources that were recovered fainter than the input fluxes.  Used the wrong logic basically. 

The toothpick handling of AST outputs has been cleaned up.  Removed the support for ASTs where the returned measurements are in magnitudes and not fluxes.  This was an old format and is not actually correct and should not be used ever.  So removing it to avoid an future issues.

Fixes a bug in the simulation of observations that was caused by an age having zero SFR.
Closes #697.

Updated plot from `plot_toothpick_details` (using the *st* AST results)

![15275_UGCA292 gst fake_plot](https://user-images.githubusercontent.com/1554536/111356427-bbc17e00-865e-11eb-8b2a-c1e1c5b7165d.png)
