### PR TITLE
remove unused Nfilter parameter in toothpick style model selection

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -59,7 +59,6 @@ def mag_limits(seds, faint_cut, Nfilter=1, bright_cut=None):
 def pick_models_toothpick_style(
     sedgrid_fname,
     filters,
-    Nfilter,
     N_fluxes,
     min_N_per_flux,
     outfile=None,
@@ -81,10 +80,6 @@ def pick_models_toothpick_style(
 
     filters: list of string
         Names of the filters, to be used as columns of the output table
-
-    Nfilter: integer
-        In how many filters a fake star needs to be brighter than the
-        mag_cut value
 
     N_fluxes: integer
         The number of flux bins into which the dynamic range of the

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -56,7 +56,6 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
 
     modelsedgrid_filename = "./{0}/{0}_seds.grid.hd5".format(settings.project)
     Nrealize = settings.ast_realization_per_model
-    Nfilters = settings.ast_bands_above_maglimit
 
     # file names for stars and corresponding SED parameters
     if pick_method == "suppl_seds":
@@ -80,7 +79,6 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
             chosen_seds = pick_models_toothpick_style(
                 modelsedgrid_filename,
                 settings.filters,
-                Nfilters,
                 N_fluxes,
                 min_N_per_flux,
                 outfile=outfile_seds,
@@ -91,8 +89,8 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
         if pick_method == "random_pick":
 
             # construct magnitude cuts
-
             mag_cuts = settings.ast_maglimit
+            Nfilters = settings.ast_bands_above_maglimit
 
             if len(mag_cuts) == 1:
                 tmp_cuts = mag_cuts


### PR DESCRIPTION
The 'NFilter' parameter is not used anymore for the toothpick style model selection. I removed that parameter from the relevant functions. Sorry about a typo in my commit message.