### PR TITLE
Adding erosion step to source density map creation

### DIFF
--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -321,7 +321,7 @@ def pick_positions_from_map(
 
                 # - erode_boundary
                 # if you only want to erode the boundary and not impose other
-                # coordinate boundary constraints, still discard SD tiles
+                # coordinate boundary constraints, still discard SD tiles that don't overlap
                 if (set_coord_boundary is None) and (erode_boundary is not None):
                     if catalog_boundary_xy and tile_box_xy:
                         if (

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -319,6 +319,27 @@ def pick_positions_from_map(
 
                 # discard tile if there's no overlap with user-imposed regions
 
+                # - erode_boundary
+                # if you only want to erode the boundary and not impose other
+                # coordinate boundary constraints, still discard SD tiles
+                if (set_coord_boundary is None) and (erode_boundary is not None):
+                    if catalog_boundary_xy and tile_box_xy:
+                        if (
+                            Polygon(catalog_boundary_xy.vertices)
+                            .intersection(tile_box_xy)
+                            .area
+                            == 0
+                        ):
+                            keep_tile[j] = False
+                    elif catalog_boundary_radec and tile_box_radec:
+                        if (
+                            Polygon(catalog_boundary_radec.vertices)
+                            .intersection(tile_box_radec)
+                            .area
+                            == 0
+                        ):
+                            keep_tile[j] = False
+
                 # - set_coord_boundary
                 if set_coord_boundary is not None:
                     # coord boundary is input in RA/Dec, and tiles are RA/Dec,

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -564,8 +564,10 @@ def make_source_dens_map(
             pix_box = geometry.box(i, j, i + 1, j + 1)
             # find fractional overlap area
             frac_area = catalog_boundary.intersection(pix_box).area
-            # stars per unit area
-            npts_map[i, j] = n_indxs / (pix_area * frac_area)
+
+            if frac_area > 0.1:
+                # stars per unit area
+                npts_map[i, j] = n_indxs / (pix_area * frac_area)
 
         # save the source density as an entry for each source
         source_dens[indxs] = npts_map[i, j]

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -26,8 +26,6 @@ import itertools as it
 import os
 from shapely import geometry
 
-from beast.observationmodel.ast.make_ast_xy_list import erode_path
-
 
 def main():  # pragma: no cover
     parser = argparse.ArgumentParser()

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -121,7 +121,7 @@ def main():  # pragma: no cover
         type=str,
         default=None,
         metavar="ERODE_BOUNDARY",
-        help="use same boundary conditions for source density map creation as for AST placment",
+        help="number of arcsec to erode the SD map boundary by",
     )
 
     # options unique to plot command
@@ -499,9 +499,9 @@ def make_source_dens_map(
     erode_boundary : None, or float (default=None)
         If provided, this number of arcseconds will be eroded from the region
         over which SD is estimated.  The purpose is to make sure that the SD
-        bins are the same ones used for placing ASTs (i.e., SD bins will not
-        fall outisde the region used for AST placement, thus ending up un/under-
-        populated).
+        bins are the same ones used for placing ASTs (i.e., so that SD bins will not
+        fall outisde the region used for AST placement, thus ensuring all SD bins
+        are well-populated).
 
     OUTPUT:
     -------


### PR DESCRIPTION
Addressing issue #693, I added an "erode_boundary" parameter to the make_source_dens_map function in create_background_density_map. This (I think) will mean that the source density is computed for the same region that ASTs are placed in... in other words, the RA/Dec grid used for computing source density across each field will be the same (i.e., generated using the full catalog), but the value of the source density in each pixel is based on the sources that overlap with the eroded region. 

Very much looking forward to thoughts from @galaxyumi and @karllark! 