### PR TITLE
Checking sd parameter settings with hasattr

### DIFF
--- a/beast/tools/split_catalog_using_map.py
+++ b/beast/tools/split_catalog_using_map.py
@@ -88,7 +88,7 @@ def split_main(
         )
     else:
         raise RuntimeError(
-            "You need to specify the source density binning parameters in the beast_settings files"
+            "You need to specify all source density binning parameters (sd_binmode, sd_Nbins, sd_binwidth, sd_custom) in the beast_settings file. Unused parameters should be set to 'None'."
         )
 
     print("Splitting catalog")

--- a/beast/tools/split_catalog_using_map.py
+++ b/beast/tools/split_catalog_using_map.py
@@ -74,18 +74,21 @@ def split_main(
     # Create a binned density map, so both the observed and the ast
     # catalog can be split using a consistent grouping (= binning) of
     # the tiles
-    if not settings.sd_Nbins and not settings.sd_binwidth and not settings.sd_custom:
-        raise RuntimeError(
-            "You need to specify the source density binning parameters in beast_settings_info"
-        )
 
-    bdm = BinnedDensityMap.create(
-        mapfile,
-        bin_mode=settings.sd_binmode,
-        N_bins=settings.sd_Nbins,
-        bin_width=settings.sd_binwidth,
-        custom_bins=settings.sd_custom,
-    )
+    if all(
+        hasattr(settings, attr) for attr in ["sd_Nbins", "sd_binwidth", "sd_custom"]
+    ):
+        bdm = BinnedDensityMap.create(
+            mapfile,
+            bin_mode=settings.sd_binmode,
+            N_bins=settings.sd_Nbins,
+            bin_width=settings.sd_binwidth,
+            custom_bins=settings.sd_custom,
+        )
+    else:
+        raise RuntimeError(
+            "You need to specify the source density binning parameters in the beast_settings files"
+        )
 
     print("Splitting catalog")
     split_catalog_using_map(

--- a/beast/tools/split_catalog_using_map.py
+++ b/beast/tools/split_catalog_using_map.py
@@ -76,7 +76,8 @@ def split_main(
     # the tiles
 
     if all(
-        hasattr(settings, attr) for attr in ["sd_Nbins", "sd_binwidth", "sd_custom"]
+        hasattr(settings, attr)
+        for attr in ["sd_binmode", "sd_Nbins", "sd_binwidth", "sd_custom"]
     ):
         bdm = BinnedDensityMap.create(
             mapfile,


### PR DESCRIPTION
Addressing issue #682, and based on Yumi's suggestion from PR #698, when the catalog is split using the source density map, it now checks to see that all the source density parameters have been set. Currently all the source density binning parameters (sd_binmode, sd_binwidth, sd_Nbins, sd_custom) need to be set in the beast_settings file, where unused parameters should be set to "None". The runtime error message thrown directs users to set all parameters in the beast_settings file.

Closes #682.