### PR TITLE
Xy box fix

### DIFF
--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -323,15 +323,7 @@ def pick_positions_from_map(
                 # if you only want to erode the boundary and not impose other
                 # coordinate boundary constraints, still discard SD tiles that don't overlap
                 if (set_coord_boundary is None) and (erode_boundary is not None):
-                    if catalog_boundary_xy and tile_box_xy:
-                        if (
-                            Polygon(catalog_boundary_xy.vertices)
-                            .intersection(tile_box_xy)
-                            .area
-                            == 0
-                        ):
-                            keep_tile[j] = False
-                    elif catalog_boundary_radec and tile_box_radec:
+                    if catalog_boundary_radec and tile_box_radec:
                         if (
                             Polygon(catalog_boundary_radec.vertices)
                             .intersection(tile_box_radec)
@@ -339,7 +331,14 @@ def pick_positions_from_map(
                             == 0
                         ):
                             keep_tile[j] = False
-
+                    elif catalog_boundary_xy and tile_box_xy:
+                        if (
+                            Polygon(catalog_boundary_xy.vertices)
+                            .intersection(tile_box_xy)
+                            .area
+                            == 0
+                        ):
+                            keep_tile[j] = False
                 # - set_coord_boundary
                 if set_coord_boundary is not None:
                     # coord boundary is input in RA/Dec, and tiles are RA/Dec,
@@ -354,18 +353,18 @@ def pick_positions_from_map(
 
                 # - region_from_filters
                 if region_from_filters is not None:
-                    if filt_reg_boundary_xy and tile_box_xy:
-                        if (
-                            Polygon(filt_reg_boundary_xy.vertices)
-                            .intersection(tile_box_xy)
-                            .area
-                            == 0
-                        ):
-                            keep_tile[j] = False
-                    elif filt_reg_boundary_radec and tile_box_radec:
+                    if filt_reg_boundary_radec and tile_box_radec:
                         if (
                             Polygon(filt_reg_boundary_radec.vertices)
                             .intersection(tile_box_radec)
+                            .area
+                            == 0
+                        ):
+                        keep_tile[j] = False
+                    elif filt_reg_boundary_xy and tile_box_xy:
+                        if (
+                            Polygon(filt_reg_boundary_xy.vertices)
+                            .intersection(tile_box_xy)
                             .area
                             == 0
                         ):

--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -360,7 +360,7 @@ def pick_positions_from_map(
                             .area
                             == 0
                         ):
-                        keep_tile[j] = False
+                            keep_tile[j] = False
                     elif filt_reg_boundary_xy and tile_box_xy:
                         if (
                             Polygon(filt_reg_boundary_xy.vertices)


### PR DESCRIPTION
Fixed xy vs ra/dec priority ordering for checking whether a source density tile is within the boundary area or not. This is a short-term fix for Issue #704. Long term we will need to either figure out if shapely allows diagonal boxes or to just phase out xy functionality completely (although I'm personally not in favor of this plan)