### PR TITLE
Add AST cut_flag to toothpick observation model

### DIFF
--- a/beast/tests/test_regresscheck.py
+++ b/beast/tests/test_regresscheck.py
@@ -69,7 +69,7 @@ class TestRegressionSuite(unittest.TestCase):
 
         cls.dset = "metal"
         if cls.dset == "metal":
-            cls.basesubdir = "metal_small_19Mar21/"
+            cls.basesubdir = "metal_small_16Apr21/"
             cls.basename = f"{cls.basesubdir}beast_metal_small"
             cls.obsname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst_samp.fits"
             cls.astname = f"{cls.basesubdir}14675_LMC-13361nw-11112.gst.fake.fits"


### PR DESCRIPTION
The toothpick model needs to be input with the full AST list with a designation of which ones were not recovered.  The non-recovered designation is given by the `CUT_FLAG` that is set by external-to-the-BEAST processing.  Usually, this flag is set based on photometry parameters (e.g., sharpness, crowding, etc.).  This information is specifically needed for computation of the completeness.

If the `CUT_FLAG` is not part of the AST output catalog passed to the BEAST, an exception will be raised causing the BEAST to stop.