### PR TITLE
Added new optional parameter to write_sbatch_file

### DIFF
--- a/beast/tools/tests/test_write_sbatch_file.py
+++ b/beast/tools/tests/test_write_sbatch_file.py
@@ -10,8 +10,8 @@ def test_sbatch_file():
         "/pylon5/as5pi7p/lhagen",
         modules=["module load anaconda3", "source activate bdev"],
         job_name="LMCgrid",
-        egress=True,
-        queue="LM",
+        queue="EM",
+        nodes="24",
         stdout_file="/pylon5/as5pi7p/lhagen/mastergrid_LMC/model_batch_jobs/logs/%A_%a.out",
         run_time="35:00:00",
         mem="570GB",
@@ -26,8 +26,8 @@ def test_sbatch_file():
 
 #SBATCH -J LMCgrid
 #SBATCH -o /pylon5/as5pi7p/lhagen/mastergrid_LMC/model_batch_jobs/logs/%A_%a.out
-#SBATCH -C EGRESS
-#SBATCH -p LM
+#SBATCH -p EM
+#SBATCH -n 24
 #SBATCH -t 35:00:00
 #SBATCH --mem 570GB
 #SBATCH --array=1-9

--- a/beast/tools/write_sbatch_file.py
+++ b/beast/tools/write_sbatch_file.py
@@ -74,10 +74,11 @@ def write_sbatch_file(
         if stdout_file is not None:
             f.write("#SBATCH -o " + stdout_file + "\n")
 
+        f.write("#SBATCH -p " + queue + "\n")
+
         if nodes:
             f.write("#SBATCH -n " + nodes + "\n")
 
-        f.write("#SBATCH -p " + queue + "\n")
         f.write("#SBATCH -t " + run_time + "\n")
         f.write("#SBATCH --mem " + mem + "\n")
 

--- a/beast/tools/write_sbatch_file.py
+++ b/beast/tools/write_sbatch_file.py
@@ -10,7 +10,6 @@ def write_sbatch_file(
     modules=["module load anaconda3", "source activate bdev"],
     job_name="beast",
     stdout_file=None,
-    egress=False,
     queue="EM",
     nodes="24",
     run_time="1:00:00",
@@ -44,10 +43,6 @@ def write_sbatch_file(
     stdout_file : string (default=None)
         If set, any output to the terminal will go into this file
 
-    egress : boolean (default=False)
-        If your job will need connections to external sites (e.g., for downloading
-        stellar tracks), set this to True.
-
     queue : string (default='EM')
         the queue to submit your job to
         'RM' = bridges2 regular
@@ -78,9 +73,6 @@ def write_sbatch_file(
 
         if stdout_file is not None:
             f.write("#SBATCH -o " + stdout_file + "\n")
-
-        if egress:
-            f.write("#SBATCH -C EGRESS\n")
 
         if nodes:
             f.write("#SBATCH -n " + nodes + "\n")
@@ -156,15 +148,9 @@ if __name__ == "__main__":  # pragma: no cover
         help="If set, any output to the terminal will go into this file",
     )
     parser.add_argument(
-        "--egress",
-        type=int,
-        default=0,
-        help="If your job will need connections to external sites, set this to 1 (True)",
-    )
-    parser.add_argument(
         "--queue",
         type=str,
-        default="LM",
+        default="EM",
         help="the queue to submit your job to",
     )
     parser.add_argument(
@@ -200,7 +186,6 @@ if __name__ == "__main__":  # pragma: no cover
         modules=args.modules,
         job_name=args.job_name,
         stdout_file=args.stdout_file,
-        egress=bool(args.egress),
         queue=args.queue,
         run_time=args.run_time,
         mem=args.mem,

--- a/beast/tools/write_sbatch_file.py
+++ b/beast/tools/write_sbatch_file.py
@@ -11,7 +11,8 @@ def write_sbatch_file(
     job_name="beast",
     stdout_file=None,
     egress=False,
-    queue="LM",
+    queue="EM",
+    nodes="24",
     run_time="1:00:00",
     mem="128GB",
     array=None,
@@ -47,10 +48,13 @@ def write_sbatch_file(
         If your job will need connections to external sites (e.g., for downloading
         stellar tracks), set this to True.
 
-    queue : string (default='LM')
+    queue : string (default='EM')
         the queue to submit your job to
-        'RM' = bridges regular
-        'LM' = bridges large
+        'RM' = bridges2 regular
+        'EM' = bridges2 extreme
+
+    nodes : string (default = "24")
+        the number of nodes (min for EM on Bridges2 is 24)
 
     run_time : string (default='1:00:00')
         Maximum run time (hh:mm:ss).  If your job is shorter, it's fine.
@@ -77,6 +81,9 @@ def write_sbatch_file(
 
         if egress:
             f.write("#SBATCH -C EGRESS\n")
+
+        if nodes:
+            f.write("#SBATCH -n " + nodes + "\n")
 
         f.write("#SBATCH -p " + queue + "\n")
         f.write("#SBATCH -t " + run_time + "\n")
@@ -114,7 +121,9 @@ if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "file_name", type=str, help="file in which to save the job submission settings",
+        "file_name",
+        type=str,
+        help="file in which to save the job submission settings",
     )
     parser.add_argument(
         "job_command",
@@ -153,7 +162,10 @@ if __name__ == "__main__":  # pragma: no cover
         help="If your job will need connections to external sites, set this to 1 (True)",
     )
     parser.add_argument(
-        "--queue", type=str, default="LM", help="the queue to submit your job to",
+        "--queue",
+        type=str,
+        default="LM",
+        help="the queue to submit your job to",
     )
     parser.add_argument(
         "--run_time",


### PR DESCRIPTION
New parameter can now be included when writing sbatch files for XSEDE -- the number of nodes to use can now be set (e.g., for the Extreme Memory allocation on Bridges2, the minimum number of nodes to use is 24).