### PR TITLE
Use a beast_settings file instead of loading a sedgrid to figure our a list of filters in plot_toothpick_details

### DIFF
--- a/beast/plotting/plot_toothpick_details.py
+++ b/beast/plotting/plot_toothpick_details.py
@@ -1,13 +1,13 @@
 import matplotlib.pyplot as plt
 
+from beast.tools import beast_settings
 from beast.observationmodel.noisemodel import toothpick
-from beast.physicsmodel.grid import SEDGrid
 from beast.plotting.beastplotlib import set_params
 
 __all__ = ["plot_toothpick_details"]
 
 
-def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
+def plot_toothpick_details(asts_filename, settings_filename, savefig=False):
     """
     Plot the details of the toothpick noisemodel creation for each filter.
     These plots show the individual AST results as points as
@@ -22,16 +22,16 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
     asts_filename : str
         filename with the AST results
 
-    seds_filename : str
+    settings_filename : str
         filename with the SED grid (used just for the filter information)
 
     savefig : str (default=False)
         to save the figure, set this to the file extension (e.g., 'png', 'pdf')
     """
-    sedgrid = SEDGrid(seds_filename, backend="cache")
+    settings = beast_settings.beast_settings(settings_filename)
 
     # read in AST results
-    model = toothpick.MultiFilterASTs(asts_filename, sedgrid.filters)
+    model = toothpick.MultiFilterASTs(asts_filename, settings.filters)
 
     # set the column mappings as the external file is BAND_VEGA or BAND_IN
     model.set_data_mappings(upcase=True, in_pair=("in", "in"), out_pair=("out", "rate"))
@@ -43,12 +43,12 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
         ast_nonrecovered_ratio=ast_nonrecovered_ratio,
     )
 
-    nfilters = len(sedgrid.filters)
+    nfilters = len(settings.filters)
     figsize_y = nfilters * 3
     fig, ax = plt.subplots(nrows=nfilters, ncols=2, figsize=(14, figsize_y), sharex=True)
     set_params()
 
-    for i, cfilter in enumerate(sedgrid.filters):
+    for i, cfilter in enumerate(settings.filters):
         mag_in = model.data[model.filter_aliases[cfilter + "_in"]]
         flux_out = model.data[model.filter_aliases[cfilter + "_out"]]
 
@@ -110,7 +110,7 @@ def plot_toothpick_details(asts_filename, seds_filename, savefig=False):
     # add in the zero line
     # do after all the data has been plotted to get the full x range
     pxrange = ax[0, 0].get_xlim()
-    for i, cfilter in enumerate(sedgrid.filters):
+    for i, cfilter in enumerate(settings.filters):
         ax[i, 0].plot(pxrange, [1.0, 1.0], "k--", alpha=0.5)
 
     # figname


### PR DESCRIPTION
I saw another PR by @christinawlindberg including the same changes (#710). Mine is just for the plot_toothpick_details.py, while #710 seems to include changes in other files. @karllark Please feel free to reject or accept this PR.  