### PR TITLE
Set hdu extention

### DIFF
--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -3,6 +3,7 @@ import os
 import argparse
 import time
 import pickle
+import glob
 
 
 # BEAST imports
@@ -110,7 +111,18 @@ def run_fitting(
     if pdf2d_param_list is None:
         pdf2d_files = [None for i in range(len(pdf2d_files))]
     lnp_files = file_dict["lnp_files"]
-
+    
+    # check to see that output files actual exist
+    for i in np.arange(len(stats_files)):
+        if not glob.glob(stats_files[i]):
+            stats_files[i] = None
+            
+        if not glob.glob(pdf_files[i]):
+            pdf_files[i] = None
+            
+        if not glob.glob(pdf2d_files[i]):
+            pdf2d_files[i] = None
+            
     # total number of files
     n_files = len(photometry_files)
 

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -3,8 +3,6 @@ import os
 import argparse
 import time
 import pickle
-import glob
-
 
 # BEAST imports
 from beast.fitting import fit
@@ -111,18 +109,7 @@ def run_fitting(
     if pdf2d_param_list is None:
         pdf2d_files = [None for i in range(len(pdf2d_files))]
     lnp_files = file_dict["lnp_files"]
-    
-    # check to see that output files actual exist
-    for i in np.arange(len(stats_files)):
-        if not glob.glob(stats_files[i]):
-            stats_files[i] = None
-            
-        if not glob.glob(pdf_files[i]):
-            pdf_files[i] = None
-            
-        if not glob.glob(pdf2d_files[i]):
-            pdf2d_files[i] = None
-            
+               
     # total number of files
     n_files = len(photometry_files)
 

--- a/beast/tools/run/run_fitting.py
+++ b/beast/tools/run/run_fitting.py
@@ -109,7 +109,7 @@ def run_fitting(
     if pdf2d_param_list is None:
         pdf2d_files = [None for i in range(len(pdf2d_files))]
     lnp_files = file_dict["lnp_files"]
-               
+
     # total number of files
     n_files = len(photometry_files)
 

--- a/beast/tools/setup_batch_beast_fit.py
+++ b/beast/tools/setup_batch_beast_fit.py
@@ -189,7 +189,7 @@ def setup_batch_beast_fit(
             obs = Table.read(phot_file)
 
             # get the fit results catalog
-            t = Table.read(stats_files[i])
+            t = Table.read(stats_files[i], hdu=1)
             # get the number of stars that have been fit
             (indxs,) = np.where(t["Pmax"] != 0.0)
 


### PR DESCRIPTION
For XSEDE runs, the lack of an hdu extension being set will throw a warning which halts the process.

This is for the fitting step for the Scylla runs.