### PR TITLE
Increased the precision of the IAU name generating function

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -868,11 +868,11 @@ def IAU_names_and_extra_info(obsdata, surveyname="PHAT", extraInfo=False):
                 + c.ra.to_string(
                     unit=ap_units.hourangle,
                     sep="",
-                    precision=2,
+                    precision=4,
                     alwayssign=False,
                     pad=True,
                 )
-                + c.dec.to_string(sep="", precision=2, alwayssign=True, pad=True)
+                + c.dec.to_string(sep="", precision=3, alwayssign=True, pad=True)
             )
             r["Name"] = _tnames
 


### PR DESCRIPTION
This change increases the precision of the IAU names generated for each star in the BEAST stats files. The previous level of precision generated duplicate names (see issue #716). 

The RA has a higher precision than DEC based on the official [IAU specifications](http://cdsweb.u-strasbg.fr/Dic/iau-spec.html) which state,

> When sexagesimal coordinates are used, the right ascension portion must have one significant digit more than the declination portion.

Closes #716 