### PR TITLE
Extend correctly extinction curves below 912A

### DIFF
--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -517,7 +517,7 @@ class Gordon16_RvFALaw(ExtinctionLaw):
 
         Rv: float
             R(V) of mixture law (default to 3.1)
-       
+
         Alambda: bool
             if set returns +2.5*1./log(10.)*tau, tau otherwise
 

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -503,7 +503,7 @@ class Gordon16_RvFALaw(ExtinctionLaw):
             np.min([self.ALaw.x_range[1], self.BLaw.x_range[1]]),
         ]
 
-    def function(self, lamb, Av=1, Rv=3.1, Alambda=True, f_A=0.5, **kwargs):
+    def function(self, lamb, Av=1, Rv=3.1, Alambda=True, f_A=0.5, draine_extend=True, **kwargs):
         """
         Gordon16_RvFALaw
 
@@ -515,14 +515,18 @@ class Gordon16_RvFALaw(ExtinctionLaw):
         Av: float
             desired A(V) (default 1.0)
 
+        Rv: float
+            R(V) of mixture law (default to 3.1)
+       
         Alambda: bool
             if set returns +2.5*1./log(10.)*tau, tau otherwise
 
         f_A: float
             set the mixture ratio between the two laws (default 0.5)
 
-        Rv: float
-            R(V) of mixture law (default to 3.1)
+        draine_extend: bool
+            if set correctly extends the extinction curve to below 912 A
+            based on theoretical curves (Weingartner&Draine 2001; Draine 2003)
 
         Returns
         -------
@@ -537,8 +541,8 @@ class Gordon16_RvFALaw(ExtinctionLaw):
         Rv_A = self.get_Rv_A(Rv, f_A)
 
         # compute the two components
-        k_A = self.ALaw.function(_lamb, Av=Av, Rv=Rv_A, Alambda=Alambda)
-        k_B = self.BLaw.function(_lamb, Av=Av, Alambda=Alambda)
+        k_A = self.ALaw.function(_lamb, Av=Av, Rv=Rv_A, Alambda=Alambda, draine_extend=draine_extend)
+        k_B = self.BLaw.function(_lamb, Av=Av, Alambda=Alambda, draine_extend=draine_extend)
 
         # return the mixture
         return f_A * k_A + (1.0 - f_A) * k_B

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -106,6 +106,9 @@ Choices:
    * ``extinction.Gordon16_RvFALaw()``: Mixture model of MW (Type A;
      Fitzpatrick 99) and SMC (Type B; Gordon+03) extinction curves.
    * Adjustable parameters include: A_V, R_V, and f_A.
+   * By default, the curve is extended below 912A to correctly apply
+     extinction in short wavelength by merging the observed curves with
+     theoretical curves (see `Choi et al. 2020 <https://ui.adsabs.harvard.edu/abs/2020ApJ...902...54C/abstract>`_ for the details)
 
 * Fitzpatrick 99
    * ``extinction.Fitzpatrick99()``: Default Milky Way extinction curve model.

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -108,7 +108,7 @@ Choices:
    * Adjustable parameters include: A_V, R_V, and f_A.
    * By default, the curve is extended below 912A to correctly apply
      extinction in short wavelength by merging the observed curves with
-     theoretical curves (see `Choi et al. 2020 <https://ui.adsabs.harvard.edu/abs/2020ApJ...902...54C/abstract>`_ for the details)
+     theoretical curves (see `Choi et al. 2020 <https://ui.adsabs.harvard.edu/abs/2020ApJ...902...54C/abstract>`_ for the details).
 
 * Fitzpatrick 99
    * ``extinction.Fitzpatrick99()``: Default Milky Way extinction curve model.


### PR DESCRIPTION
To correctly apply dust extinction below 912A, there is need to merge the observed and theoretical extinction curves because the observed ones are not available (or valid) at these short wavelengths. The necessary lines of code were available, but the functionality was off by default. This PR will make the extended extinction curves available for the Gordon16_RvFALaw() by default. 

To make this PR work properly, we need to add MW_Rv*.txt files back to the beast library package. @karllark 