### PR TITLE
trimmed cut mask to remove potential nans

### DIFF
--- a/beast/observationmodel/noisemodel/toothpick.py
+++ b/beast/observationmodel/noisemodel/toothpick.py
@@ -171,6 +171,12 @@ class MultiFilterASTs(NoiseModel):
             if name_prefix[-1] != "_":
                 name_prefix += "_"
 
+        # set the fluxes to zero for all sources with CUT_FLAG > 0
+        #   these are the sources that are not recovered
+        # user determined flag
+        #   often this flag is set by sharpness, roundness, non-measured bands
+        cmask = cut_flag > 0
+
         # check if any NaNs are present, remove if they are
         # NaNs can be present due to the AST pipeline or in cases where
         # there is missing data (e.g., chip gaps)
@@ -178,6 +184,7 @@ class MultiFilterASTs(NoiseModel):
             gvals = np.isfinite(mag_in) & np.isfinite(flux_out)
             mag_in = mag_in[gvals]
             flux_out = flux_out[gvals]
+            cmask = cmask[gvals]
             print("removing NaNs")
 
         # convert the AST input from magnitudes to fluxes
@@ -185,11 +192,6 @@ class MultiFilterASTs(NoiseModel):
         # reported)
         flux_in = 10 ** (-0.4 * mag_in)
 
-        # set the fluxes to zero for all sources with CUT_FLAG > 0
-        #   these are the sources that are not recovered
-        # user determined flag
-        #   often this flag is set by sharpness, roundness, non-measured bands
-        cmask = cut_flag > 0
         flux_out[cmask] = 0.0
 
         # set the flux_out to zero for all ASTs recovered with too large


### PR DESCRIPTION
I ran into an issue on XSEDE where the length of the cmask (setting any flux_out with CUT_FLAG>0 to 0.0) didn't match the length of the ASTs if any NaNs were present in one of the filters. The issue was caused by the fact that the flux_out list was trimmed for NaNs but the cmask wasn't. I've moved the line generating the cmask up in the function so that the cmask can also be trimmed for NaNs if needed. 

This is an example of the error generated:
```
Traceback (most recent call last):
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/runpy.py", line 194, in _run_module_as_main
  return _run_code(code, main_globals, None,
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/runpy.py", line 87, in _run_code
  exec(code, run_globals)
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/tools/run/create_obsmodel.py", line 228, in <module>
  create_obsmodel(
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/tools/run/create_obsmodel.py", line 123, in create_obsmodel
  parallel_wrapper(gen_obsmodel, input_list, nprocs=nprocs)
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/tools/run/helper_functions.py", line 61, in parallel_wrapper
  r = function(*a)
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/tools/run/create_obsmodel.py", line 179, in gen_obsmodel
  noisemodel.make_toothpick_noise_model(
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/observationmodel/noisemodel/generic_noisemodel.py", line 68, in make_toothpick_noise_model
  model.fit_bins(nbins=nfluxbins)
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/observationmodel/noisemodel/toothpick.py", line 363, in fit_bins
  d = self._compute_sigma_bins(
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/beast/observationmodel/noisemodel/toothpick.py", line 193, in _compute_sigma_bins
  flux_out[cmask] = 0.0
 File "/jet/home/clindber/.conda/envs/beast_prod/lib/python3.8/site-packages/astropy/table/column.py", line 1125, in __setitem__
  self.data[index] = value
IndexError: boolean index did not match indexed array along dimension 0; dimension is 3327 but corresponding boolean dimension is 3341
```