### PR TITLE
Allowing the users to append their filters into the existing BEAST filter library

### DIFF
--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -767,10 +767,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.filter_throughput_curve:
-        lamb, throughput = numpy.loadtxt(args.filter_throughput_curve, usecols=(0,1), unpack=True)
-        append_filter(lamb, throughput, args.tablename, args.observatory, args.instrument,
-            args.filtername
-        )
+        lamb, throughput = numpy.loadtxt(args.filter_throughput_curve, usecols=(0, 1), unpack=True)
+        append_filter(lamb, throughput, args.tablename, args.observatory, args.instrument, 
+                args.filtername
+                     )
 
     if not any(vars(args).values()):
         parser.print_help()

--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -768,9 +768,9 @@ if __name__ == "__main__":
 
     if args.filter_throughput_curve:
         lamb, throughput = numpy.loadtxt(args.filter_throughput_curve, usecols=(0, 1),
-                unpack=True)
+                                         unpack=True)
         append_filter(lamb, throughput, args.tablename, args.observatory, args.instrument,
-                     args.filtername)
+                      args.filtername)
 
     if not any(vars(args).values()):
         parser.print_help()

--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -767,10 +767,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.filter_throughput_curve:
-        lamb, throughput = numpy.loadtxt(args.filter_throughput_curve, usecols=(0, 1), unpack=True)
-        append_filter(lamb, throughput, args.tablename, args.observatory, args.instrument, 
-                args.filtername
-                     )
+        lamb, throughput = numpy.loadtxt(args.filter_throughput_curve, usecols=(0, 1),
+                unpack=True)
+        append_filter(lamb, throughput, args.tablename, args.observatory, args.instrument,
+                     args.filtername)
 
     if not any(vars(args).values()):
         parser.print_help()

--- a/docs/append_filters.rst
+++ b/docs/append_filters.rst
@@ -1,0 +1,22 @@
+##############
+Append filters
+##############
+
+Users can add any filters into their local ``beast/libs/filters.hd5``. 
+The list of default filters in the BEAST filter library can be found `<here https://beast.readthedocs.io/en/latest/beast_setup.html#beast-filters>`_.
+
+If you need to include fluxes in particular bands in your SED fitting or BEAST
+predictions but those particular bands do not exist in the BEAST filter library,
+you should append those filters to the BEAST filter library before generating 
+your physics model grid. To do this, you need an ascii file that has two columns:
+wavelegnth in angstrom and thoughput. The BEAST filter library requires basic information
+about the filter. This includes the tablename for the filter information (e.g., HST_WFC3_F275W), 
+observatorty associated with the filter (e.g., HST), instrument of the filter (e.g., WFC3), 
+and name of the filter (e.g., F275W). 
+
+Command to add a filter to the BEAST filter library.
+
+  .. code-block:: console
+
+     $ python -m beast.observationmodel.phot filter_curve_file --tablename tablename
+       --observatory observatory --instrument instrument --filtername filtername

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,12 +33,13 @@ Basics:
    Photometry files <photometry_files.rst>
    Output files <outputs.rst>
 
-Detals:
+Details:
 
 .. toctree::
    :maxdepth: 1
 
    Graphical Models <beast_graphical_model.rst>
+   Appending additional filters <append_filters.rst>
    Stellar/Extinction Priors <beast_priors.rst>
    Generating AST inputs <generating_asts.rst>
    Simulating observations <simulations.rst>


### PR DESCRIPTION
This PR is to allow the users to add any filters that are not in the default BEAST filter library into the filter library from command line. An input ascii file for a filter throughput curve should have two columns: wavelength in angstrom and throughput. 