### PR TITLE
Fix verifying beast setting

### DIFF
--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -141,7 +141,7 @@ def verify_input_format(settings):
         "list_float_grid",
     ]
     parameters_limits = [
-        [0.0, 0.1],
+        [-4.0, 0.5],
         None,
         None,
         [-inf, 10.15],

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -74,7 +74,7 @@ For more on setting up priors, see :ref:`BEAST priors <beast_priors>`.
   - ``logt``: age grid range parameters (min, max, step).
   - ``age_prior_model``: specify a prior for age parameter.
   - ``mass_prior_model``: specify a stellar IMF.
-  - ``z``: metallicity grid points.
+  - ``z``: metallicity grid points. For PARSEC, 1e-4<=z<=0.02; For MIST, -4.0<=[Z/H]<=0.5
   - ``met_prior_model``: specify a prior for metallicity parameter.
   - ``oiso``: isochrone model grid. Current choices: Padova or MIST. Default: PARSEC+CALIBRI: ``oiso = isochrone.PadovaWeb()``
   - ``osl``: stellar library definition. Options include Kurucz, Tlusty, BTSettl, Munari, Elodie and BaSel. You can also generate an object from the union of multiple individual libraries: ``osl = stellib.Tlusty() + stellib.Kurucz()``


### PR DESCRIPTION
The current limiting range for Z in the verifying beast setting process is only valid for the PARSEC model. The PARSEC webform takes Z (1e-4<=Z<=0.02) whereas the MIST webform takes [Z/H] (-4.0<=[Z/H]<=0.5). So when using the MIST model, having negative Z values in the settings file return an error. This PR fixs that error.