### PR TITLE
Extinction curves that extend below 912 A

### DIFF
--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -650,9 +650,9 @@ class Generalized_DustExt(ExtinctionLaw):
             self.extcurve_class = getattr(dustext_extend, curve)
             if hasattr(self.extcurve_class, "Rv_range"):
                 self.hasRvParam = True
-                self.Rv = self.extcurve_class.Rv
             else:
                 self.hasRvParam = False
+                self.Rv = self.extcurve_class.Rv
         else:
             raise ValueError(
                 curve

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -11,6 +11,7 @@ import dust_extinction.averages as dustext_avg
 from dust_extinction.helpers import _test_valid_x_range
 
 from beast.config import __ROOT__
+import beast.physicsmodel.dust.extinction_extension as dustext_extend
 
 __all__ = [
     "ExtinctionLaw",
@@ -645,6 +646,13 @@ class Generalized_DustExt(ExtinctionLaw):
             self.extcurve_class = getattr(dustext_avg, curve)
             self.hasRvParam = False
             self.Rv = self.extcurve_class.Rv
+        elif curve in dustext_extend.__all__:
+            self.extcurve_class = getattr(dustext_extend, curve)
+            if hasattr(self.extcurve_class, "Rv_range"):
+                self.hasRvParam = True
+                self.Rv = self.extcurve_class.Rv
+            else:
+                self.hasRvParam = False
         else:
             raise ValueError(
                 curve

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -192,7 +192,7 @@ class Fitzpatrick99(ExtinctionLaw):
         self.name = "Fitzpatrick99"
         self.x_range = [0.3, 10.0]
 
-    def function(self, lamb, Av=1, Rv=3.1, Alambda=True, draine_extend=False, **kwargs):
+    def function(self, lamb, Av=1, Rv=3.1, Alambda=True, **kwargs):
         """
         Fitzpatrick99 extinction Law
 
@@ -209,9 +209,6 @@ class Fitzpatrick99(ExtinctionLaw):
 
         Alambda: bool
             if set returns +2.5*1./log(10.)*tau, tau otherwise
-
-        draine_extend: bool
-            if set extends the extinction curve to below 912 A
 
         Returns
         -------
@@ -265,12 +262,11 @@ class Fitzpatrick99(ExtinctionLaw):
             )
 
             # FUV portion
-            if not draine_extend:
-                fuvind = np.where(x >= 5.9)
-                k[fuvind] += c4 * (
-                    0.5392 * ((x[fuvind] - 5.9) ** 2)
-                    + 0.05644 * ((x[fuvind] - 5.9) ** 3)
-                )
+            fuvind = np.where(x >= 5.9)
+            k[fuvind] += c4 * (
+                0.5392 * ((x[fuvind] - 5.9) ** 2)
+                + 0.05644 * ((x[fuvind] - 5.9) ** 3)
+            )
 
             k[ind] += Rv
             yspluv += Rv
@@ -309,30 +305,6 @@ class Fitzpatrick99(ExtinctionLaw):
         # convert from A(lambda)/E(B-V) to A(lambda)/A(V)
         k /= Rv
 
-        # FUV portion from Draine curves
-        if draine_extend:
-            fuvind = np.where(x >= 5.9)
-            tmprvs = np.arange(2.0, 6.1, 0.1)
-            diffRv = Rv - tmprvs
-            if min(abs(diffRv)) < 1e-8:
-                dfname = libdir + "MW_Rv%s_ext.txt" % ("{0:.1f}".format(Rv))
-                l_draine, k_draine = np.loadtxt(dfname, usecols=(0, 1), unpack=True)
-            else:
-                add, = np.where(diffRv < 0.0)
-                Rv1 = tmprvs[add[0] - 1]
-                Rv2 = tmprvs[add[0]]
-                dfname = libdir + "MW_Rv%s_ext.txt" % ("{0:.1f}".format(Rv1))
-                l_draine, k_draine1 = np.loadtxt(dfname, usecols=(0, 1), unpack=True)
-                dfname = libdir + "MW_Rv%s_ext.txt" % ("{0:.1f}".format(Rv2))
-                l_draine, k_draine2 = np.loadtxt(dfname, usecols=(0, 1), unpack=True)
-                frac = diffRv[add[0] - 1] / (Rv2 - Rv1)
-                k_draine = (1.0 - frac) * k_draine1 + frac * k_draine2
-
-            dind = np.where((1.0 / l_draine) >= 5.9)
-            k[fuvind] = interp(
-                x[fuvind], 1.0 / l_draine[dind][::-1], k_draine[dind][::-1]
-            )
-
         # setup the output
         if Alambda:
             return k * Av
@@ -358,7 +330,7 @@ class Gordon03_SMCBar(ExtinctionLaw):
         self.x_range = [0.3, 10.0]
 
     def function(
-        self, lamb, Av=1, Rv=2.74, Alambda=True, draine_extend=False, **kwargs
+        self, lamb, Av=1, Rv=2.74, Alambda=True, **kwargs
     ):
         """
         Gordon03_SMCBar extinction law
@@ -435,17 +407,9 @@ class Gordon03_SMCBar(ExtinctionLaw):
         # FUV portion
         ind = np.where(x >= 5.9)
         if np.size(ind) > 0:
-            if draine_extend:
-                dfname = libdir + "SMC_Rv2.74_norm.txt"
-                l_draine, k_draine = np.loadtxt(dfname, usecols=(0, 1), unpack=True)
-                dind = np.where((1.0 / l_draine) >= 5.9)
-                k[ind] = interp(
-                    x[ind], 1.0 / l_draine[dind][::-1], k_draine[dind][::-1]
-                )
-            else:
-                k[ind] += c4 * (
-                    0.5392 * ((x[ind] - 5.9) ** 2) + 0.05644 * ((x[ind] - 5.9) ** 3)
-                )
+            k[ind] += c4 * (
+                0.5392 * ((x[ind] - 5.9) ** 2) + 0.05644 * ((x[ind] - 5.9) ** 3)
+            )
 
         # Opt/NIR part
         ind = np.where(x < xcutuv)

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -2,7 +2,7 @@
 Extinction Curves
 """
 import numpy as np
-from scipy import interpolate, interp
+from scipy import interpolate
 
 from astropy import units
 

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -1,0 +1,237 @@
+import copy
+import numpy as np
+
+from dust_extinction.helpers import _get_x_in_wavenumbers, _test_valid_x_range
+from dust_extinction.parameter_averages import F19
+from dust_extinction.averages import G03_SMCBar
+from dust_extinction.grain_models import D03, WD01
+
+__all__ = ["F19_D03_extension", "G03_SMCBar_WD01_extension"]
+
+
+class F19_D03_extension(F19):
+    r"""
+    dust_extinction.parameter_averages.F19 model extended to shorter
+    wavelengths using the dust_extinction.grain_models.D03 models.
+
+    Parameters
+    ----------
+    None
+
+    Raises
+    ------
+    InputParameterError
+       Input Rv values outside of defined range
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+        import astropy.units as u
+
+        from beast.physicsmodel.dust.extinction_extension import F19_D03_extension
+        from dust_extinction.grain_models import D03
+
+        fig, ax = plt.subplots()
+
+        # temp model to get the correct x range
+        text_model = F19_D03_extension()
+
+        # generate the curves and plot them
+        x = np.arange(text_model.x_range[0], text_model.x_range[1], 0.1) / u.micron
+
+        Rvs = [2.0, 3.0, 4.0, 5.0, 6.0]
+        for cur_Rv in Rvs:
+            ext_model = F19_D03_extension(Rv=cur_Rv)
+            ax.plot(1.0 / x, ext_model(x), label="F19_D03_ext R(V) = " + str(cur_Rv))
+
+        pmods = ["MWRV31", "MWRV40", "MWRV55"]
+        for cmod in pmods:
+            dmod = D03(modelname=cmod)
+            ax.plot(1.0 / x, dmod(x), label=f"D03 {cmod}", linestyle="dashed", color="black")
+
+        ax.set_xlabel(r"$\lambda$ [$\mu m$]")
+        ax.set_ylabel(r"$A(x)/A(V)$")
+
+        ax.set_xscale("log")
+
+        ax.legend(loc="best")
+        plt.show()
+    """
+
+    # update the wavelength range (in micron^-1)
+    x_range = [0.3, 1.0 / 0.0250]
+
+    def evaluate(self, in_x, Rv):
+        """
+        F19_D03_extension function
+
+        Parameters
+        ----------
+        in_x: float
+           expects either x in units of wavelengths or frequency
+           or assumes wavelengths in wavenumbers [1/micron]
+
+           internally wavenumbers are used
+
+        Returns
+        -------
+        axav: np array (float)
+            A(x)/A(V) extinction curve [mag]
+
+        Raises
+        ------
+        ValueError
+           Input x values outside of defined range
+        """
+        # convert to wavenumbers (1/micron) if x input in units
+        # otherwise, assume x in appropriate wavenumber units
+        x = _get_x_in_wavenumbers(in_x)
+
+        # check that the wavenumbers are within the defined range
+        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
+
+        # just in case someone calls evaluate explicitly
+        Rv = np.atleast_1d(Rv)
+
+        # ensure Rv is a single element, not numpy array
+        Rv = Rv[0]
+
+        # determine the dust grain models to use for the input Rv
+        if Rv < 4.0:
+            d1rv = 3.1
+            d2rv = 4.0
+            d1mod = D03(modelname="MWRV31")
+            d2mod = D03(modelname="MWRV40")
+        else:
+            d1rv = 4.0
+            d2rv = 5.5
+            d1mod = D03(modelname="MWRV40")
+            d2mod = D03(modelname="MWRV55")
+
+        # interpolate to get the model extinction for the input Rv value
+        dslope = (d2mod(in_x) - d1mod(in_x)) / (d2rv - d1rv)
+        dmod = d1mod(in_x) + dslope * (Rv - d1rv)
+
+        # compute the F19 curve for the input Rv over the F19 defined wavelength range
+        gvals_f19 = (x > super().x_range[0]) & (x < super().x_range[1])
+        fmod = super().evaluate(x[gvals_f19], Rv)
+
+        # now merge the two smoothly
+        outmod = copy.copy(dmod)
+        outmod[gvals_f19] = fmod
+
+        merge_range = np.array([1.0 / 0.1675, super().x_range[1]])
+        gvals_merge = (x > merge_range[0]) & (x < merge_range[1])
+        # have weights be zero at the min merge and 1 at the max merge
+        weights = (x[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
+        outmod[gvals_merge] = (1.0 - weights) * outmod[gvals_merge] + weights * dmod[
+            gvals_merge
+        ]
+
+        return outmod
+
+
+class G03_SMCBar_WD01_extension(G03_SMCBar):
+    r"""
+    dust_extinction.averages.G03_SMCBar model extended to shorter
+    wavelengths using the dust_extinction.grain_models.WD01 SMCBar model.
+
+    Parameters
+    ----------
+    Rv: float
+        R(V) = A(V)/E(B-V) = total-to-selective extinction
+
+    Raises
+    ------
+    InputParameterError
+       Input Rv values outside of defined range
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+        import astropy.units as u
+
+        from beast.physicsmodel.dust.extinction_extension import G03_SMCBar_WD01_extension
+        from dust_extinction.grain_models import WD01
+
+        fig, ax = plt.subplots()
+
+        # define the extinction model
+        ext_model = G03_SMCBar_WD01_extension()
+
+        # generate the curves and plot them
+        x = np.arange(ext_model.x_range[0], ext_model.x_range[1], 0.1) / u.micron
+
+        ax.plot(1.0 / x, ext_model(x), label="G03 SMCBar WD01 ext")
+
+        dmod = WD01(modelname="SMCBar")
+        ax.plot(
+            1.0 / x, dmod(x), label="WD01 SMCBar", linestyle="dashed", color="black"
+        )
+
+        ax.set_xlabel(r"$\lambda$ [$\mu m$]")
+        ax.set_ylabel(r"$A(x)/A(V)$")
+
+        ax.set_xscale("log")
+
+        ax.legend(loc="best")
+        plt.show()
+    """
+
+    # update the wavelength range (in micron^-1)
+    x_range = [0.3, 1.0 / 0.0250]
+
+    def evaluate(self, in_x):
+        """
+        G03_SMCBar_WD01_extension function
+
+        Parameters
+        ----------
+        in_x: float
+           expects either x in units of wavelengths or frequency
+           or assumes wavelengths in wavenumbers [1/micron]
+
+           internally wavenumbers are used
+
+        Returns
+        -------
+        axav: np array (float)
+            A(x)/A(V) extinction curve [mag]
+
+        Raises
+        ------
+        ValueError
+           Input x values outside of defined range
+        """
+        # convert to wavenumbers (1/micron) if x input in units
+        # otherwise, assume x in appropriate wavenumber units
+        x = _get_x_in_wavenumbers(in_x)
+
+        # check that the wavenumbers are within the defined range
+        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
+
+        # compute the dust grain model
+        dmodel = WD01(modelname="SMCBar")
+        dmod = dmodel(in_x)
+
+        # compute the F19 curve for the input Rv over the F19 defined wavelength range
+        gvals_g03 = (x > super().x_range[0]) & (x < super().x_range[1])
+        fmod = super().evaluate(x[gvals_g03])
+
+        # now merge the two smoothly
+        outmod = copy.copy(dmod)
+        outmod[gvals_g03] = fmod
+
+        merge_range = np.array([1.0 / 0.1675, super().x_range[1]])
+        gvals_merge = (x > merge_range[0]) & (x < merge_range[1])
+        # have weights be zero at the min merge and 1 at the max merge
+        weights = (x[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
+        outmod[gvals_merge] = (1.0 - weights) * outmod[gvals_merge] + weights * dmod[
+            gvals_merge
+        ]
+
+        return outmod

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -116,7 +116,7 @@ class F19_D03_extension(F19):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_f19 = (x > super().x_range[0]) & (x < super().x_range[1])
-        fmod = super().evaluate(x[gvals_f19], Rv)
+        fmod = super().evaluate(in_x[gvals_f19], Rv)
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)
@@ -220,7 +220,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_g03 = (x > super().x_range[0]) & (x < super().x_range[1])
-        fmod = super().evaluate(x[gvals_g03])
+        fmod = super().evaluate(in_x[gvals_g03])
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -61,7 +61,7 @@ class F19_D03_extension(F19):
     """
 
     # update the wavelength range (in micron^-1)
-    x_range = [0.3, 1.0 / 0.0250]
+    x_range = [0.3, 1.0 / 0.01]
 
     def evaluate(self, in_x, Rv):
         """
@@ -183,7 +183,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
     """
 
     # update the wavelength range (in micron^-1)
-    x_range = [0.3, 1.0 / 0.0250]
+    x_range = [0.3, 1.0 / 0.01]
 
     def evaluate(self, in_x):
         """

--- a/beast/physicsmodel/dust/tests/test_extinction_extension.py
+++ b/beast/physicsmodel/dust/tests/test_extinction_extension.py
@@ -5,8 +5,10 @@ from dust_extinction.parameter_averages import F19
 from dust_extinction.averages import G03_SMCBar
 from dust_extinction.grain_models import WD01, D03
 
-from beast.physicsmodel.dust.extinction_extension import (F19_D03_extension,
-    G03_SMCBar_WD01_extension)
+from beast.physicsmodel.dust.extinction_extension import (
+    F19_D03_extension,
+    G03_SMCBar_WD01_extension,
+)
 
 
 def test_F19_D03_ext():

--- a/beast/physicsmodel/dust/tests/test_extinction_extension.py
+++ b/beast/physicsmodel/dust/tests/test_extinction_extension.py
@@ -1,0 +1,59 @@
+import numpy as np
+import astropy.units as u
+
+from dust_extinction.parameter_averages import F19
+from dust_extinction.averages import G03_SMCBar
+from dust_extinction.grain_models import WD01, D03
+
+from beast.physicsmodel.dust.extinction_extension import (F19_D03_extension,
+    G03_SMCBar_WD01_extension)
+
+
+def test_F19_D03_ext():
+    emod = F19(Rv=3.1)
+    dmod = D03(modelname="MWRV31")
+    cmod = F19_D03_extension(Rv=3.1)
+
+    x = np.arange(cmod.x_range[0], cmod.x_range[1], 0.1) / u.micron
+
+    cmod_vals = cmod(x)
+    dmod_vals = dmod(x)
+
+    gvals_f19 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
+    emod_vals = emod(x[gvals_f19])
+
+    # test that the combined model as the grain model values below 912 A
+    # below the merge wavelengths
+    gvals_ion = x > 1.0 / 0.0912 / u.micron
+    np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
+
+    # test that the combine dmodel has the F19 values above 1700 A
+    # above the merge wavelengths
+    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
+    gvals_amerge_f19 = x[gvals_f19] < 1.0 / 0.1700 / u.micron
+    np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_f19])
+
+
+def test_G03_SMCBar_WD01_ext():
+    emod = G03_SMCBar()
+    dmod = WD01(modelname="SMCBar")
+    cmod = G03_SMCBar_WD01_extension()
+
+    x = np.arange(cmod.x_range[0], cmod.x_range[1], 0.1) / u.micron
+
+    cmod_vals = cmod(x)
+    dmod_vals = dmod(x)
+
+    gvals_g03 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
+    emod_vals = emod(x[gvals_g03])
+
+    # test that the combined model as the grain model values below 912 A
+    # below the merge wavelengths
+    gvals_ion = x > 1.0 / 0.0912 / u.micron
+    np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
+
+    # test that the combine dmodel has the F19 values above 1700 A
+    # above the merge wavelengths
+    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
+    gvals_amerge_g03 = x[gvals_g03] < 1.0 / 0.1700 / u.micron
+    np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_g03])

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -120,10 +120,10 @@ Choices:
 * `beast.physicsmodel.dust.extinction_extension` (recommended of sub 912 A extinction needed)
    * all the observation based models stop at or before 912 A as hydrogen dominates extinction below this wavelength
    * For work that interested in sub 912 A information (e.g., ionizing photon measurements), these models extend the
-     dust extinction to shorter than 912 A wavelengths by smoothly merging dust grain models with an observed extinction model
+     dust extinction to 100 A by smoothly merging dust grain models with an observed extinction model
      starting at 1675 A.  Thus, the extinction between around 1150 A and 1675 A is a combination of the observed extinction curve and
      the dust grain model extinction curve.  Most observational based extinction curves do not go all the way to 912 A due to lack
-     of measurements. 
+     of measurements.
    * `F19_D03_extension`: Extension of Fitzpatrick+19 Milky Way Rv dependent model with Draine03 grain models.
    * `G03_SMCBar_WD01_extension`: Extension of Gordon+03 SMCBar average with the Weingarter & Draine01 SMCBar grain model.
 

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -102,35 +102,46 @@ providing fully self-consistent treatment of reddening.
 
 Choices:
 
-* Gordon+16
+* Generalized_RvFaLaw (recommended)
+   * allows for any choice of the extinction curve model for the A and B components
+   * recommended
+      * A: F19 - based on spectroscopy in UV and optical and does a bit better than F99 in the optical
+      * B: G03_SMCBar - best average for the SMC "bumpless" extinction curve
+      * In beast_settings file:
+        extLaw = extinction.Generalized_RvFALaw(ALaw=extinction.Generalized_DustExt(curve='F19'), BLaw=extinction.Generalized_DustExt(curve='G03_SMCBar'))
+
+* `dust_extinction`_ Package Extinction Curves (recommended)
+   * ``extinction.Generalized_DustExt()``: Wrapper for any extinction curve
+     class available via dust_extinction python package.
+   * Select curve class via string parameter: `curve`
+   * Example call, for Fitzpatrick+19: ``extinction.Generalized_DustExt('F19')``
+   * For the most possible models, see `dust_extinction docs <https://dust-extinction.readthedocs.io/en/stable/>`_
+
+* `beast.physicsmodel.dust.extinction_extension` (recommended of sub 912 A extinction needed)
+   * all the observation based models stop at or before 912 A as hydrogen dominates extinction below this wavelength
+   * for work that interested in sub 912 A information (e.g., ionizing photon measurements), these models extend the
+     dust extinction to shorter than 912 A wavelengths by smoothly merging dust grain models with an observed extinction model
+   * `F19_D03_extension`: Extension of Fitzpatrick+19 Milky Way Rv dependent model with Draine03 grain models.
+   * `G03_SMCBar_WD01_extension`: Extension of Gordon+03 SMCBar average with the Weingarter & Draine01 SMCBar grain model.
+
+* Gordon+16 (original mixture dust extinction model)
    * ``extinction.Gordon16_RvFALaw()``: Mixture model of MW (Type A;
      Fitzpatrick 99) and SMC (Type B; Gordon+03) extinction curves.
    * Adjustable parameters include: A_V, R_V, and f_A.
 
-* Fitzpatrick 99
+* Fitzpatrick 99 (may be deprecated, superceded by dust_extinction package)
    * ``extinction.Fitzpatrick99()``: Default Milky Way extinction curve model.
    * Adjustable parameters: R_V
 
-* Gordon+03
+* Gordon+03 (may be deprecated, superceded by dust_extinction package)
    * ``extinction.Gordon03_SMCBar()``: Empirically-derived SMC Bar dust
      extinction curve.
    * Adjustable A_V, R_V fixed at 2.74
 
-* Cardelli, Clayton, and Mathis 89
+* Cardelli, Clayton, and Mathis 89 (may be deprecated, superceded by dust_extinction package)
    * ``extinction.Cardelli89()``: Well-known Milky Way extinction curve model,
-     but advise use of ``Fitzpatrick99()`` model instead.
+     but advise use of ``dust_extinction F19`` model instead.
    * Adjustable parameters: R_V
-
-* `dust_extinction`_ Package Extinction Curves
-   * ``extinction.Generalized_DustExt()``: Wrapper for any extinction curve
-     class available via dust_extinction python package.
-   * Select curve class via string parameter: `curve`
-   * Example call, for Fitzpatrick 04: ``extinction.Generalized_DustExt('F04')``
-   * R_V-dependent models available: Cardelli+89=CCM89, O'Donnell94=O94,
-     Fitzpatrick99=F99, Fitzpatrick04=F04, MaizApellaniz+14=M14
-   * Average model available: Gordon+03's SMC Bar Avg = G03_SMCBar; Gordon+03's
-     LMC Avg = G03_LMCAvg; Gordon+03's LMC2 Supershell Avg = G03_LMC2;
-     Gordon, Cartledge, & Clayton 09's MW Avg = GCC09_MWAvg
 
  .. _TLusty: http://tlusty.oca.eu/
  .. _Munari: https://vizier.u-strasbg.fr/viz-bin/VizieR-3?-source=J/A%2bA/442/1127

--- a/docs/beast_grid_inputs.rst
+++ b/docs/beast_grid_inputs.rst
@@ -119,8 +119,11 @@ Choices:
 
 * `beast.physicsmodel.dust.extinction_extension` (recommended of sub 912 A extinction needed)
    * all the observation based models stop at or before 912 A as hydrogen dominates extinction below this wavelength
-   * for work that interested in sub 912 A information (e.g., ionizing photon measurements), these models extend the
+   * For work that interested in sub 912 A information (e.g., ionizing photon measurements), these models extend the
      dust extinction to shorter than 912 A wavelengths by smoothly merging dust grain models with an observed extinction model
+     starting at 1675 A.  Thus, the extinction between around 1150 A and 1675 A is a combination of the observed extinction curve and
+     the dust grain model extinction curve.  Most observational based extinction curves do not go all the way to 912 A due to lack
+     of measurements. 
    * `F19_D03_extension`: Extension of Fitzpatrick+19 Milky Way Rv dependent model with Draine03 grain models.
    * `G03_SMCBar_WD01_extension`: Extension of Gordon+03 SMCBar average with the Weingarter & Draine01 SMCBar grain model.
 

--- a/docs/physicsmodel_api.rst
+++ b/docs/physicsmodel_api.rst
@@ -14,6 +14,8 @@ Dust
 
 .. automodapi:: beast.physicsmodel.dust.extinction
 
+.. automodapi:: beast.physicsmodel.dust.extinction_extension
+
 Weights
 =======
 


### PR DESCRIPTION
BEAST runs interested in providing predictions of ionizing photons need dust extinction curves that extend below 912 A.  This PR provides two new dust extinction models that merge observation based extinction curves with dust grain models to provide this capability.

This is done using the `Generalized_DustExt` capabilities and models available in the `dust_extinction` package.  Previously this capability was provide directly inside of the `Gordon16_RvFALaw` using static data files.

In the beast_settings.txt file, these new extinction models can be used by declaring the extinction mixture model to be:

`extlaw = extinction.Generalized_RvFALaw(ALaw=extinction.Generalized_DustExt(curve=’F19_D03_extension’), BLaw=extinction.Generalized_DustExt(curve=’G03_SMCBar_WD01_extension’))`

Replaces #749.