### PR TITLE
add proper param verification for MIST

### DIFF
--- a/beast/tools/tests/test_verify_beast_settings.py
+++ b/beast/tools/tests/test_verify_beast_settings.py
@@ -21,6 +21,7 @@ class settings_mock:
     fA_prior_model = {"name": "flat"}
     oiso = isochrone.MISTWeb()
 
+
 class settings_mock_nofA(settings_mock):
     """Mock beast_settings w/ fAs=None"""
 

--- a/beast/tools/tests/test_verify_beast_settings.py
+++ b/beast/tools/tests/test_verify_beast_settings.py
@@ -1,4 +1,5 @@
 import pytest
+from beast.physicsmodel.stars import isochrone
 from beast.tools import verify_beast_settings
 
 
@@ -18,7 +19,7 @@ class settings_mock:
     rv_prior_model = {"name": "flat"}
     fAs = [0.0, 1.0, 0.25]
     fA_prior_model = {"name": "flat"}
-
+    oiso = isochrone.MISTWeb()
 
 class settings_mock_nofA(settings_mock):
     """Mock beast_settings w/ fAs=None"""

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -8,6 +8,7 @@ from os.path import exists
 from numpy import inf
 import warnings
 
+from beast.physicsmodel.stars import isochrone
 
 def verify_range(param, param_name, param_lim):
     # check if input param limits make sense
@@ -140,15 +141,30 @@ def verify_input_format(settings):
         "list_float_grid",
         "list_float_grid",
     ]
-    parameters_limits = [
-        [-4.0, 0.5],
-        None,
-        None,
-        [-inf, 10.15],
-        [0.0, inf],
-        [1.0, 7.0],
-        [0.0, 1.0],
-    ]
+
+    print(settings.oiso.name)
+    if settings.oiso.name == "MESA/MIST isochrones":
+        print('Working on the MIST isochrone')
+        parameters_limits = [
+            [0.0142E-4, 0.0142*10**(0.5)],
+            None,
+            None,
+            [5, 10.3],
+            [0.0, inf],
+            [1.0, 7.0],
+            [0.0, 1.0],
+        ]
+    if settings.oiso.name == "Padova CMD isochrones":
+        print('Working on the PARSEC isochrone')
+        parameters_limits = [
+            [1E-4, 0.06],
+            None,
+            None,
+            [-inf, 10.15],
+            [0.0, inf],
+            [1.0, 7.0],
+            [0.0, 1.0],
+        ]
 
     for i, param_ in enumerate(parameters):
         verify_one_input_format(

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -8,7 +8,6 @@ from os.path import exists
 from numpy import inf
 import warnings
 
-from beast.physicsmodel.stars import isochrone
 
 def verify_range(param, param_name, param_lim):
     # check if input param limits make sense
@@ -146,7 +145,7 @@ def verify_input_format(settings):
     if settings.oiso.name == "MESA/MIST isochrones":
         print('Working on the MIST isochrone')
         parameters_limits = [
-            [0.0142E-4, 0.0142*10**(0.5)],
+            [0.0142E-4, 0.0142 * 10**(0.5)],
             None,
             None,
             [5, 10.3],


### PR DESCRIPTION
Although available metallicity range for the MIST models is different from the PARSEC models, the current version of parameter verification is optimized for the PARSEC models. This PR should fix the problem.