### PR TITLE
Adding --diffSpike option when computing source density maps

### DIFF
--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -169,8 +169,8 @@ def main_make_map(args):
 
     # if diffSpike is set, remove entries with DiffSpike_FLAG==True
     if args.diffSpike:
-        diffSpike_flag = args.diffSpike.upper()
-        keep = cat[diffSpike_flag] == 0
+        diffspike_flag = args.diffSpike.upper()
+        keep = cat[diffspike_flag] == 0
         cat = cat[keep]
 
     ra = cat["RA"]

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -35,7 +35,10 @@ def main():  # pragma: no cover
     # common options for both types of map
     commonparser = argparse.ArgumentParser(add_help=False)
     commonparser.add_argument(
-        "-catfile", type=str, required=True, help="catalog FITS file"
+        "-catfile",
+        type=str,
+        required=True,
+        help="catalog FITS file"
     )
     commonparser.add_argument(
         "-erode_boundary",
@@ -122,6 +125,13 @@ def main():  # pragma: no cover
         metavar="FILTER_FLAG",
         help="if set, ignore sources with flag >= 99",
     )
+    sourceden_parser.add_argument(
+        "--diffSpike",
+        type=str,
+        default=None,
+        metavar="DiffractionSpike_FLAG",
+        help="if set, ignore sources with flag == True",
+    )
 
     # options unique to plot command
     plot_parser.add_argument(
@@ -156,6 +166,11 @@ def main_make_map(args):
     cat = Table.read(args.catfile)
     for name in cat.colnames:
         cat.rename_column(name, name.upper())
+
+    # if diffSpike is set, remove entries with DiffSpike_FLAG==True
+    if args.diffSpike:
+        keep = cat[args.diffSpike] == False
+        cat = cat[keep]
 
     ra = cat["RA"]
     dec = cat["DEC"]

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -169,7 +169,8 @@ def main_make_map(args):
 
     # if diffSpike is set, remove entries with DiffSpike_FLAG==True
     if args.diffSpike:
-        keep = cat[args.diffSpike] == False
+        diffSpike_flag = args.diffSpike.upper()
+        keep = cat[diffSpike_flag] == False
         cat = cat[keep]
 
     ra = cat["RA"]

--- a/beast/tools/create_background_density_map.py
+++ b/beast/tools/create_background_density_map.py
@@ -170,7 +170,7 @@ def main_make_map(args):
     # if diffSpike is set, remove entries with DiffSpike_FLAG==True
     if args.diffSpike:
         diffSpike_flag = args.diffSpike.upper()
-        keep = cat[diffSpike_flag] == False
+        keep = cat[diffSpike_flag] == 0
         cat = cat[keep]
 
     ra = cat["RA"]

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -40,11 +40,12 @@ Adding source density to observations
 =====================================
 
 Create a new version of the observations that includes a column with the
-source density.  The user chooses one band to use as the reference, and chooses
-the magnitude range of sources to use for calculating the source density
-(generally, this would be the range over which the catalog is complete).  The
-user can also choose a band for which sources that have '[band]_FLAG == 99' are
-ignored.
+source density.  The user chooses one band to use as the reference
+(F475W is default), and chooses (generally, this would be the range over
+which the catalog is complete). The user can also choose a band for which
+sources that have '[band]_FLAG == 99' are ignored. If the observation catalog
+has a column to indicate diffraction spike artifacts, the --diffSpike option
+can be set to exclude those sources from source density calculation.
 
 Three files are created.  The prefix is derived from the name of the input
 photometry catalog.
@@ -55,14 +56,23 @@ photometry catalog.
 * [prefix]_sourceden_map.hd5: contains information about the map grid
 
 Command to create the observed catalog with source density column with
-a pixel scale of 5 arcsec using the 'phot_catalog.fits' catalog.
+a pixel scale of 5 arcsec over a given magnitude range (20--26) with 100%
+in F475W (by default) using the 'phot_catalog.fits' catalog.
 
   .. code-block:: console
 
      $ python -m beast.tools.create_background_density_map sourceden \
-       -catfile phot_catalog.fits --pixsize 5.
+       -catfile phot_catalog.fits --pixsize 5.0 --mag_cut 20 26
 
+Set --diffSpike to the column name for a diffraction spike flag in the
+observation catalog to compute source density after diffraction spike artifact
+removal.
 
+  .. code-block:: console
+
+     $ python -m beast.tools.create_background_density_map sourceden \
+       -catfile phot_catalog.fits --pixsize 5.0 --mag_cut 20 26 \
+       --diffSpike DiffSpike_FLAG
 
 Adding background to observations
 =================================


### PR DESCRIPTION
This might be specific to the LUVIT project at the moment, but will be useful for any observations suffering from diffraction spike artifacts due to bright foreground stars. If a column for the diffraction spike artifact flag ('DiffSpike_FLAG' in the example below) exists in any provided observation catalogs to the BEAST, the users can set --diffSpike option when creating source density maps. 

python -m beast.tools.create_background_density_map sourceden \
       -catfile phot_catalog.fits --pixsize 5.0 --mag_cut 20 26 \
       --diffSpike DiffSpike_FLAG