### PR TITLE
Clean up the usage of make_ast_xy_list

### DIFF
--- a/beast/observationmodel/ast/make_ast_xy_list.py
+++ b/beast/observationmodel/ast/make_ast_xy_list.py
@@ -20,12 +20,11 @@ def pick_positions_from_map(
     N_bins,
     bin_width,
     custom_bins,
-    Npermodel,
+    Nrealize,
     outfile=None,
     refimage=None,
     refimage_hdu=1,
     wcs_origin=1,
-    Nrealize=1,
     set_coord_boundary=None,
     region_from_filters=None,
     erode_boundary=None,
@@ -86,6 +85,14 @@ def pick_positions_from_map(
         Each tile will be put into a bin, so that a set of tiles of the
         map is obtained for each range of source density/background values.
 
+    Nrealize: integer
+        The number of times each model should be repeated for each
+        background regime. This is to sample the variance due to
+        variations within each region, for each individual model.
+
+    outfile: str
+        Path to an output file to store input AST information.
+
     refimage: str
         Path to fits image that is used for the positions. If none is
         given, the ra and dec will be put in the x and y output columns
@@ -99,11 +106,6 @@ def pick_positions_from_map(
         As described in the WCS documentation: "the coordinate in the upper
         left corner of the image. In FITS and Fortran standards, this is 1.
         In Numpy and C standards this is 0."
-
-    Nrealize: integer
-        The number of times each model should be repeated for each
-        background regime. This is to sample the variance due to
-        variations within each region, for each individual model.
 
     set_coord_boundary : None, or list of 2 numpy arrays
         If provided, these RA/Dec coordinates will be used to limit the
@@ -266,7 +268,7 @@ def pick_positions_from_map(
             )
 
     # Load the background map
-    print(Npermodel, " repeats of each model in each map bin")
+    print(Nrealize, " repeats of each model in each map bin")
 
     bdm = density_map.BinnedDensityMap.create(
         input_map,
@@ -405,7 +407,7 @@ def pick_positions_from_map(
     for bin_index, tile_set in enumerate(
         tqdm(
             tile_sets,
-            desc="{:.2f} models per map bin".format(Nseds_per_region / Npermodel),
+            desc="{:.2f} models per map bin".format(Nseds_per_region / Nrealize),
         )
     ):
         start = bin_index * Nseds_per_region

--- a/beast/tools/cut_catalogs.py
+++ b/beast/tools/cut_catalogs.py
@@ -49,8 +49,7 @@ def cut_catalogs(
         the source will not be removed.
 
     flagged : boolean (default=False)
-        if True, remove sources with flag=99 in flag_filter.  Note that this
-        will only be applied to sources with RATE>0 in flag_filter.
+        if True, remove sources with RATE=0 in flag_filter.
 
     flag_filter : string or list of strings (default=None)
         if flagged is True, set this to the filter(s) to use
@@ -158,7 +157,7 @@ def make_cuts(cat_file, partial_overlap=False, flagged=False, flag_filter=None):
 
     # read in the catalog
     cat = Table.read(cat_file)
-    filters = [c[0:-5] for c in cat.colnames if "RATE" in c and "RATERR" not in c]
+    filters = [c[0:-5] for c in cat.colnames if "VEGA" in c]
     n_stars = len(cat)
 
     # array to keep track of which ones are good
@@ -175,7 +174,7 @@ def make_cuts(cat_file, partial_overlap=False, flagged=False, flag_filter=None):
     # flagged sources
     if flagged is True:
         for fl in np.atleast_1d(flag_filter):
-            good_stars[(cat[fl + "_FLAG"] >= 99) & (cat[fl + "_RATE"] > 0)] = 0
+            good_stars[(cat[fl + "_RATE"] > 0)] = 0
 
     # return results
     return cat, good_stars

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -177,7 +177,6 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 refimage=settings.ast_reference_image,
                 refimage_hdu=hdu_ext,
                 wcs_origin=1,
-                Nrealize=1,
                 set_coord_boundary=settings.ast_coord_boundary,
                 region_from_filters="all",
                 erode_boundary=settings.ast_erode_selection_region,

--- a/beast/tools/run/make_ast_inputs.py
+++ b/beast/tools/run/make_ast_inputs.py
@@ -164,6 +164,11 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
             else:
                 hdu_ext = 1
 
+            if hasattr(settings, "region_from_filters"):
+                region_from_filters = settings.region_from_filters
+            else:
+                region_from_filters = 'all'
+
             make_ast_xy_list.pick_positions_from_map(
                 obsdata,
                 chosen_seds,
@@ -178,7 +183,7 @@ def make_ast_inputs(beast_settings_info, pick_method="flux_bin_method"):
                 refimage_hdu=hdu_ext,
                 wcs_origin=1,
                 set_coord_boundary=settings.ast_coord_boundary,
-                region_from_filters="all",
+                region_from_filters=region_from_filters,
                 erode_boundary=settings.ast_erode_selection_region,
             )
         # if we're not using SD/background maps, SEDs will be distributed


### PR DESCRIPTION
Although there is an option for placing input ASTs over a region based on a customized filter combination, the make_ast_xy_list.py always place input ASTs in the full filter coverage area. I made the customized filter combination option effective. I also modified a few associated files to make codes cleaner by removing redundant argument/keyword in a function and by removing the part where magnitude information is used. The BEAST uses 'RATE' in the rest of its work flow.