### PR TITLE
adding commas for tox passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ indexserver =
 setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
Fix to error in tox setup.  Simple solution - add commas as instructed.