### PR TITLE
switch fully to numpy.trapz and fix numpy version

### DIFF
--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -18,7 +18,6 @@ import sys
 import numpy
 
 import tables
-from scipy.integrate import trapz
 
 from beast.config import __ROOT__
 
@@ -133,9 +132,9 @@ Filter object information:
         self.name = name
         self.wavelength = wavelength
         self.transmit = transmit
-        self.norm = trapz(transmit, wavelength)
-        self.lT = trapz(wavelength * transmit, wavelength)
-        self.lpivot = numpy.sqrt(self.lT / trapz(transmit / wavelength, wavelength))
+        self.norm = numpy.trapz(transmit, wavelength)
+        self.lT = numpy.trapz(wavelength * transmit, wavelength)
+        self.lpivot = numpy.sqrt(self.lT / numpy.trapz(transmit / wavelength, wavelength))
         self.cl = self.lT / self.norm
 
 
@@ -230,9 +229,9 @@ class IntegrationFilter(object):
         self.name = name
         self.wavelength = wavelength
         self.transmit = transmit
-        self.norm = trapz(transmit, wavelength)
-        self.lT = trapz(transmit * wavelength, wavelength)
-        self.lpivot = numpy.sqrt(self.lT / trapz(1.0 / wavelength, wavelength))
+        self.norm = numpy.trapz(transmit, wavelength)
+        self.lT = numpy.trapz(transmit * wavelength, wavelength)
+        self.lpivot = numpy.sqrt(self.lT / numpy.trapz(1.0 / wavelength, wavelength))
         self.cl = self.lT / self.norm
 
 
@@ -396,7 +395,7 @@ def extractPhotometry(lamb, spec, flist, absFlux=True):
         # apply absolute flux conversion if requested
         if absFlux:
             s0 /= distc
-        a = trapz(tmp[None, :] * s0, lamb[xl], axis=1)
+        a = numpy.trapz(tmp[None, :] * s0, lamb[xl], axis=1)
         seds[e] = a / k.lT  # divide by integral (lambda T dlambda)
         cls[e] = k.cl
 
@@ -438,7 +437,7 @@ def extractSEDs(g0, flist, absFlux=True):
         # apply absolute flux conversion if requested
         if absFlux:
             s0 /= distc
-        a = trapz(tmp[None, :] * s0, lamb[xl], axis=1)
+        a = numpy.trapz(tmp[None, :] * s0, lamb[xl], axis=1)
         seds[:, e] = a / k.lT
         cls[e] = k.cl
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
+    numpy==1.26.4
     astropy
     Cython
     scipy


### PR DESCRIPTION
Fixes two different test errors.

Numpy version fixed to 1.26.4 to avoid issues with upstream packages being compiled to different libraries (mismatch of variable sizes).

Remove last use of scipy.trapz by switching to numpy.trapz.  Scipy seems to have renamed their function to trapezoid.