### PR TITLE
modifications to support megabeast simulations

### DIFF
--- a/beast/observationmodel/ast/make_ast_input_list.py
+++ b/beast/observationmodel/ast/make_ast_input_list.py
@@ -185,7 +185,7 @@ def pick_models_toothpick_style(
             else:
                 # ... do not include this model again, since we will reject it
                 # anyway.
-                include_mask[idxs == rand_idx] = False
+                include_mask[idxs == rand_idx[r]] = False
 
         # Add the approved models
         chosen_idxs.extend(rand_idx[add_these])

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -94,7 +94,7 @@ def compute_distance_age_mass_metallicity_weights(
         dist_prior_weights /= np.sum(dist_prior_weights)
         dist_weights = dist_grid_weights * dist_prior_weights
 
-        # correct for any non-unformity in the number size of the
+        # correct for any non-uniformity in the number size of the
         # age-mass grids between metallicity points
         total_dist_grid_weight /= np.sum(total_dist_grid_weight)
         total_dist_prior_weight /= np.sum(total_dist_prior_weight)
@@ -180,6 +180,10 @@ def compute_age_mass_metallicity_weights(
                     mass_prior = mass_prior_model
 
                 # deal with repeat masses - happens for MegaBEAST
+                # and have discovred this can happen even for a standard BEAST run
+                # as sometimes two masses in an isochrone are exactly the same
+                #   new code for MegaBEAST is more correct as then the grid weight
+                #   will be correctly set for any repeated masses
                 cur_masses = np.unique(_tgrid_single_age["M_ini"])
                 n_masses = len(_tgrid_single_age["M_ini"])
                 if len(cur_masses) < n_masses:

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -12,6 +12,8 @@ Basically, we want the maginalization using these grid weights to provide
 flat priors on all the fit parameters.  Non-flat priors will be implemented
 with prior weights.
 """
+
+from inspect import signature
 import numpy as np
 
 from beast.physicsmodel.grid_weights_stars import compute_distance_grid_weights
@@ -24,11 +26,13 @@ from beast.physicsmodel.priormodel import (
     PriorMassModel,
     PriorMetallicityModel,
     PriorDistanceModel,
+    PriorDustModel,
 )
 
 __all__ = [
     "compute_age_mass_metallicity_weights",
     "compute_distance_age_mass_metallicity_weights",
+    "compute_av_rv_fA_weights",
 ]
 
 
@@ -155,7 +159,10 @@ def compute_age_mass_metallicity_weights(
 
         # compute the age weights
         age_grid_weights = compute_age_grid_weights(uniq_ages)
-        age_prior = PriorAgeModel(age_prior_model)
+        if isinstance(age_prior_model, dict):
+            age_prior = PriorAgeModel(age_prior_model)
+        else:
+            age_prior = age_prior_model
         age_prior_weights = age_prior(uniq_ages)
 
         for ak, age_val in enumerate(uniq_ages):
@@ -168,10 +175,26 @@ def compute_age_mass_metallicity_weights(
 
             # compute the mass weights
             if len(aindxs) > 1:
-                cur_masses = _tgrid_single_age["M_ini"]
-                mass_grid_weights = compute_mass_grid_weights(cur_masses)
-                mass_prior = PriorMassModel(mass_prior_model)
-                mass_prior_weights = mass_prior(cur_masses)
+                # cur_masses = _tgrid_single_age["M_ini"]
+                # deal with repeat masses - happens for MegaBEAST
+                cur_masses = np.unique(_tgrid_single_age["M_ini"])
+                umass_grid_weights = compute_mass_grid_weights(cur_masses)
+                if isinstance(mass_prior_model, dict):
+                    mass_prior = PriorMassModel(mass_prior_model)
+                else:
+                    mass_prior = mass_prior_model
+                umass_prior_weights = mass_prior(cur_masses)
+                n_masses = len(_tgrid_single_age["M_ini"])
+                if len(cur_masses) < n_masses:
+                    mass_grid_weights = np.zeros(n_masses, dtype=float)
+                    mass_prior_weights = np.zeros(n_masses, dtype=float)
+                    for k, cmass in enumerate(cur_masses):
+                        gvals = _tgrid_single_age["M_ini"] == cmass
+                        mass_grid_weights[gvals] = umass_grid_weights[k]
+                        mass_prior_weights[gvals] = umass_prior_weights[k]
+                else:
+                    mass_grid_weights = umass_grid_weights
+                    mass_prior_weights = umass_prior_weights
             else:
                 # must be a single mass for this age,z combination
                 # set mass weight to zero to remove this point from the grid
@@ -218,3 +241,59 @@ def compute_age_mass_metallicity_weights(
                 met_prior_weights[i] * total_z_prior_weight[i]
             )
             _tgrid[zindxs]["weight"] *= met_weights[i] * total_z_weight[i]
+
+
+def compute_av_rv_fA_prior_weights(
+    Av,
+    Rv,
+    f_A,
+    dists,
+    av_prior_model={"name": "flat"},
+    rv_prior_model={"name": "flat"},
+    fA_prior_model={"name": "flat"},
+):
+    """
+    Computes the av, rv, f_A grid and prior weights
+    on the BEAST model spectra grid
+    Grid and prior weight columns updated by multiplying by the
+    existing weights
+
+    Parameters
+    ----------
+    Av : vector
+        A(V) values
+    Rv : vector
+        R(V) values
+    f_A : vector
+        f_A values
+    dists : vector
+        distance values
+    av_prior_model : dict
+        dict including prior model name and parameters
+    rv_prior_model : dict
+        dict including prior model name and parameters
+    fA_prior_model :dict
+        dict including prior model name and parameters
+    """
+    av_prior = PriorDustModel(av_prior_model)
+    rv_prior = PriorDustModel(rv_prior_model)
+    fA_prior = PriorDustModel(fA_prior_model)
+    if av_prior_model["name"] == "step":
+        av_weights = av_prior(np.full((len(dists)), Av), y=dists)
+    else:
+        av_weights = av_prior(Av)
+    if rv_prior_model["name"] == "step":
+        rv_weights = rv_prior(np.full((len(dists)), Rv), y=dists)
+    else:
+        rv_weights = rv_prior(Rv)
+    if fA_prior_model["name"] == "step":
+        f_A_weights = fA_prior(np.full((len(dists)), f_A), y=dists)
+    else:
+        f_A_weights = fA_prior(f_A)
+
+    dust_prior = av_weights * rv_weights * f_A_weights
+
+    # normalize to control for numerical issues
+    dust_prior /= np.max(dust_prior)
+
+    return dust_prior

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -195,6 +195,7 @@ def compute_age_mass_metallicity_weights(
                     cur_masses = _tgrid_single_age["M_ini"]
                     mass_grid_weights = compute_mass_grid_weights(cur_masses)
                     mass_prior_weights = mass_prior(cur_masses)
+
             else:
                 # must be a single mass for this age,z combination
                 # set mass weight to zero to remove this point from the grid

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -174,17 +174,17 @@ def compute_age_mass_metallicity_weights(
 
             # compute the mass weights
             if len(aindxs) > 1:
-                # cur_masses = _tgrid_single_age["M_ini"]
-                # deal with repeat masses - happens for MegaBEAST
-                cur_masses = np.unique(_tgrid_single_age["M_ini"])
-                umass_grid_weights = compute_mass_grid_weights(cur_masses)
                 if isinstance(mass_prior_model, dict):
                     mass_prior = PriorMassModel(mass_prior_model)
                 else:
                     mass_prior = mass_prior_model
-                umass_prior_weights = mass_prior(cur_masses)
+
+                # deal with repeat masses - happens for MegaBEAST
+                cur_masses = np.unique(_tgrid_single_age["M_ini"])
                 n_masses = len(_tgrid_single_age["M_ini"])
                 if len(cur_masses) < n_masses:
+                    umass_grid_weights = compute_mass_grid_weights(cur_masses)
+                    umass_prior_weights = mass_prior(cur_masses)
                     mass_grid_weights = np.zeros(n_masses, dtype=float)
                     mass_prior_weights = np.zeros(n_masses, dtype=float)
                     for k, cmass in enumerate(cur_masses):
@@ -192,8 +192,9 @@ def compute_age_mass_metallicity_weights(
                         mass_grid_weights[gvals] = umass_grid_weights[k]
                         mass_prior_weights[gvals] = umass_prior_weights[k]
                 else:
-                    mass_grid_weights = umass_grid_weights
-                    mass_prior_weights = umass_prior_weights
+                    cur_masses = _tgrid_single_age["M_ini"]
+                    mass_grid_weights = compute_mass_grid_weights(cur_masses)
+                    mass_prior_weights = mass_prior(cur_masses)
             else:
                 # must be a single mass for this age,z combination
                 # set mass weight to zero to remove this point from the grid

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -13,7 +13,6 @@ flat priors on all the fit parameters.  Non-flat priors will be implemented
 with prior weights.
 """
 
-from inspect import signature
 import numpy as np
 
 from beast.physicsmodel.grid_weights_stars import compute_distance_grid_weights
@@ -32,7 +31,7 @@ from beast.physicsmodel.priormodel import (
 __all__ = [
     "compute_age_mass_metallicity_weights",
     "compute_distance_age_mass_metallicity_weights",
-    "compute_av_rv_fA_weights",
+    "compute_av_rv_fA_prior_weights",
 ]
 
 
@@ -294,6 +293,6 @@ def compute_av_rv_fA_prior_weights(
     dust_prior = av_weights * rv_weights * f_A_weights
 
     # normalize to control for numerical issues
-    dust_prior /= np.max(dust_prior)
+    # dust_prior /= np.max(dust_prior)
 
     return dust_prior

--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -71,7 +71,7 @@ def plot_cmd(
     fig = plt.figure(figsize=(9, 9))
 
     # sets up plots to have larger fonts, wider lines, etc.
-    #set_params()
+    set_params()
 
     plt.plot(col, mag, "ko", ms=0.5)
 

--- a/beast/plotting/plot_cmd.py
+++ b/beast/plotting/plot_cmd.py
@@ -71,9 +71,9 @@ def plot_cmd(
     fig = plt.figure(figsize=(9, 9))
 
     # sets up plots to have larger fonts, wider lines, etc.
-    set_params()
+    #set_params()
 
-    plt.plot(col, mag, "k.", ms=0.1)
+    plt.plot(col, mag, "ko", ms=0.5)
 
     plt.gca().invert_yaxis()
 

--- a/beast/tests/helpers.py
+++ b/beast/tests/helpers.py
@@ -30,7 +30,7 @@ def download_rename(filename, tmpdir=""):
     return fname
 
 
-def compare_tables(table_cache, table_new, rtol=1e-7, otag=""):
+def compare_tables(table_cache, table_new, rtol=1e-6, otag=""):
     """
     Compare two tables using astropy tables routines.
 


### PR DESCRIPTION
The megabeast simulations are based on recomputing the prior weights using the megabeast ensemble model.  This requires computing the prior weights on the full sedgrid at once.   In the beast, the stellar priors are computed on the spectral grid (not sed grid) and this allows for some simplifications.  Code to address computing the stellar priors on the spectral or sed grid is added.  In addition, the dust priors are moved to a function so that the same function can be used in the beast and megabeast.

As part of this work, a new check is added to determine if there are repeat masses in the single age isochrone.  This is the easiest way to tell if stellar prior and grid weights are being computed on the spec or sed grids (spec has no dust and is where it is done for the BEAST).  Surprisingly, there is at least one case where there is a repeated mass in the spec grid - e.g., directly computed from the stellar isochrones.  Thus, the new code produces slightly different results than the previous code as now the repeated masses get the *correct* grid weight whereas before they were not.

In addition, a bug in `make_ast_input_list.py` was found on line 188 when regenerating the regression test files.  There must have been an upstream behavior that allowed this line to work.  It logically should not have worked.  @drvdputt: any insights on this?  This was your code from a few years back.  No worries if it doesn't spark anything.  Just being comprehensive and tagging you.