### PR TITLE
replace http with https

### DIFF
--- a/beast/physicsmodel/stars/ezpadova/parsec.py
+++ b/beast/physicsmodel/stars/ezpadova/parsec.py
@@ -243,7 +243,7 @@ class __CMD_Error_Parser(parser.HTMLParser):
 
 def __query_website(d):
     """ Communicate with the CMD website """
-    webserver = "http://stev.oapd.inaf.it"
+    webserver = "https://stev.oapd.inaf.it"
     print("Interrogating {0}...".format(webserver))
 
     # OPTION: Use fixed version for stability (CURRENT CHOICE)


### PR DESCRIPTION
Querying PARSEC CMD isochrones stops working. This is a quick fix for it by replacing "http" with "https" in its url.