### PR TITLE
removing numpy pinning to a specific version

### DIFF
--- a/beast/observationmodel/observations.py
+++ b/beast/observationmodel/observations.py
@@ -345,8 +345,8 @@ def gen_SimObs_from_sedgrid(
         masspts = np.logspace(np.log10(mass_range[0]), np.log10(mass_range[1]), nmass)
         mass_prior = PriorMassModel(mass_prior_model)
         massprior = mass_prior(masspts)
-        totmass = np.trapz(massprior, masspts)
-        avemass = np.trapz(masspts * massprior, masspts) / totmass
+        totmass = np.trapezoid(massprior, masspts)
+        avemass = np.trapezoid(masspts * massprior, masspts) / totmass
 
         # compute the mass of the remaining stars at each age and
         # simulate the stars assuming everything is complete
@@ -368,7 +368,7 @@ def gen_SimObs_from_sedgrid(
             gmass = (masspts >= cur_mass_range[0]) & (masspts <= cur_mass_range[1])
             curmasspts = masspts[gmass]
             curmassprior = massprior[gmass]
-            totcurmass = np.trapz(curmassprior, curmasspts)
+            totcurmass = np.trapezoid(curmassprior, curmasspts)
 
             # compute the mass remaining at each age -> this is the mass to simulate
             simmass = cprior * cwidth * totcurmass / totmass

--- a/beast/observationmodel/phot.py
+++ b/beast/observationmodel/phot.py
@@ -97,8 +97,8 @@ Filter object information:
         ifT = numpy.interp(slamb, self.wavelength, self.transmit, left=0.0, right=0.0)
         if True in (ifT > 0.0):
             ind = numpy.where(ifT > 0.0)
-            a = numpy.trapz(slamb[ind] * ifT[ind] * sflux[ind], slamb[ind])
-            b = numpy.trapz(slamb[ind] * ifT[ind], slamb[ind])
+            a = numpy.trapezoid(slamb[ind] * ifT[ind] * sflux[ind], slamb[ind])
+            b = numpy.trapezoid(slamb[ind] * ifT[ind], slamb[ind])
             if numpy.isinf(a) | numpy.isinf(b):
                 print(self.name, "Warn for inf value")
             return a / b
@@ -133,10 +133,10 @@ Filter object information:
         self.name = name
         self.wavelength = wavelength
         self.transmit = transmit
-        self.norm = numpy.trapz(transmit, wavelength)
-        self.lT = numpy.trapz(wavelength * transmit, wavelength)
+        self.norm = numpy.trapezoid(transmit, wavelength)
+        self.lT = numpy.trapezoid(wavelength * transmit, wavelength)
         self.lpivot = numpy.sqrt(
-            self.lT / numpy.trapz(transmit / wavelength, wavelength)
+            self.lT / numpy.trapezoid(transmit / wavelength, wavelength)
         )
         self.cl = self.lT / self.norm
 
@@ -194,8 +194,8 @@ class IntegrationFilter(object):
 
         if True in ind:
             _slamb = slamb[ind]
-            a = numpy.trapz(_slamb * sflux[ind], _slamb)
-            b = numpy.trapz(numpy.ones(_slamb.shape, dtype=float) * _slamb, _slamb)
+            a = numpy.trapezoid(_slamb * sflux[ind], _slamb)
+            b = numpy.trapezoid(numpy.ones(_slamb.shape, dtype=float) * _slamb, _slamb)
 
             if numpy.isinf(a) | numpy.isinf(b):
                 print(self.name, "Warn for inf value")
@@ -232,9 +232,9 @@ class IntegrationFilter(object):
         self.name = name
         self.wavelength = wavelength
         self.transmit = transmit
-        self.norm = numpy.trapz(transmit, wavelength)
-        self.lT = numpy.trapz(transmit * wavelength, wavelength)
-        self.lpivot = numpy.sqrt(self.lT / numpy.trapz(1.0 / wavelength, wavelength))
+        self.norm = numpy.trapezoid(transmit, wavelength)
+        self.lT = numpy.trapezoid(transmit * wavelength, wavelength)
+        self.lpivot = numpy.sqrt(self.lT / numpy.trapezoid(1.0 / wavelength, wavelength))
         self.cl = self.lT / self.norm
 
 
@@ -398,7 +398,7 @@ def extractPhotometry(lamb, spec, flist, absFlux=True):
         # apply absolute flux conversion if requested
         if absFlux:
             s0 /= distc
-        a = numpy.trapz(tmp[None, :] * s0, lamb[xl], axis=1)
+        a = numpy.trapezoid(tmp[None, :] * s0, lamb[xl], axis=1)
         seds[e] = a / k.lT  # divide by integral (lambda T dlambda)
         cls[e] = k.cl
 
@@ -440,7 +440,7 @@ def extractSEDs(g0, flist, absFlux=True):
         # apply absolute flux conversion if requested
         if absFlux:
             s0 /= distc
-        a = numpy.trapz(tmp[None, :] * s0, lamb[xl], axis=1)
+        a = numpy.trapezoid(tmp[None, :] * s0, lamb[xl], axis=1)
         seds[:, e] = a / k.lT
         cls[e] = k.cl
 

--- a/beast/physicsmodel/dust/extinction.py
+++ b/beast/physicsmodel/dust/extinction.py
@@ -99,7 +99,7 @@ class Cardelli89(ExtinctionLaw):
         # ensure the units are in angstrom
         _lamb = units.Quantity(lamb, units.angstrom).value
 
-        if isinstance(_lamb, float) or isinstance(_lamb, np.float_):
+        if isinstance(_lamb, float) or isinstance(_lamb, np.float64):
             _lamb = np.asarray([lamb])
         else:
             _lamb = lamb[:]
@@ -219,7 +219,7 @@ class Fitzpatrick99(ExtinctionLaw):
         # ensure the units are in angstrom
         _lamb = units.Quantity(lamb, units.angstrom).value
 
-        if isinstance(_lamb, float) or isinstance(_lamb, np.float_):
+        if isinstance(_lamb, float) or isinstance(_lamb, np.float64):
             _lamb = np.asarray([lamb])
         else:
             _lamb = lamb[:]
@@ -358,7 +358,7 @@ class Gordon03_SMCBar(ExtinctionLaw):
         # ensure the units are in angstrom
         _lamb = units.Quantity(lamb, units.angstrom).value
 
-        if isinstance(_lamb, float) or isinstance(_lamb, np.float_):
+        if isinstance(_lamb, float) or isinstance(_lamb, np.float64):
             _lamb = np.asarray([lamb])
         else:
             _lamb = lamb[:]
@@ -655,7 +655,7 @@ class Generalized_DustExt(ExtinctionLaw):
         # ensure the units are in angstrom
         _lamb = units.Quantity(lamb, units.angstrom).value
 
-        if isinstance(_lamb, float) or isinstance(_lamb, np.float_):
+        if isinstance(_lamb, float) or isinstance(_lamb, np.float64):
             _lamb = np.asarray([lamb])
         else:
             _lamb = lamb[:]

--- a/beast/physicsmodel/priormodel_functions.py
+++ b/beast/physicsmodel/priormodel_functions.py
@@ -87,7 +87,7 @@ def _two_lognorm(xs, max_pos1, max_pos2, sigma1=0.5, sigma2=0.5, N1=1.0, N2=1.0)
     pointwise = _lognorm(xs, max_pos1, sigma=sigma1, N=N1) + _lognorm(
         xs, max_pos2, sigma=sigma2, N=N2
     )
-    normalization = np.trapz(pointwise, x=xs)
+    normalization = np.trapezoid(pointwise, x=xs)
     return pointwise / normalization
 
 

--- a/beast/physicsmodel/stars/simpletable.py
+++ b/beast/physicsmodel/stars/simpletable.py
@@ -1492,7 +1492,7 @@ class SimpleTable(object):
                 )
                 kwargs.setdefault("names", names)
                 kwargs.setdefault("skip_header", n)
-                self.data = np.recfromtxt(fname, *args, **kwargs)
+                self.data = np.genfromtxt(fname, *args, **kwargs)
                 self.header = header
                 self._units.update(**units)
                 self._desc.update(**comments)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    numpy==1.26.4
+    numpy
     astropy
     Cython
     scipy


### PR DESCRIPTION
Closes #828

Also updates to np.trapezoid from np.trapz (another deprecation).
Also updates to np.genfromtext from np.recfromtext (another deprecation).