### PR TITLE
Fixed physicsmodel failure: Padova isochrones now acquired via ezpadova package, and handled as astropy tables

### DIFF
--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -78,10 +78,10 @@ def make_iso_table(
             oiso = isochrone.PadovaWeb()
 
         t = oiso._get_t_isochrones(max(5.0, logtmin), min(10.13, logtmax), dlogt, z)
+        t.header = {} # Spoofing for astropy table
         t.header["NAME"] = "{0} Isochrones".format("_".join(iso_fname.split("_")[:-1]))
         print("{0} Isochrones".format("_".join(iso_fname.split("_")[:-1])))
-
-        t.write(iso_fname)
+        t.write(iso_fname, overwrite=True)
 
     # save info to the beast info file
     info = {"project": project, "logt_input": [logtmin, logtmax, dlogt], "z_input": z}

--- a/beast/physicsmodel/stars/ezpadova/parsec.py
+++ b/beast/physicsmodel/stars/ezpadova/parsec.py
@@ -17,6 +17,8 @@ from io import BytesIO
 import zlib
 import re
 import json
+import ezpadova
+import astropy.table
 from beast.physicsmodel.stars.simpletable import SimpleTable as Table
 
 py3k = True
@@ -144,6 +146,88 @@ def file_type(filename, stream=False):
     return None
 
 
+
+def get_ezpadova_args(
+    model=None,
+    carbon=None,
+    interp=None,
+    Mstars=None,
+    Cstars=None,
+    dust=None,
+    phot=None,
+    **kwargs
+    ):
+    """
+    Function to ingest standard set of arguments for
+    queries to padova CMD service, for passing to the
+    ezpadova package. (This function is basically equivalent
+    to the old __get_url_args function)
+
+    Parameters
+    ----------
+
+    model: str
+        select the type of model :func:`help_models`
+
+    carbon: str
+        carbon stars model :func:`help_carbon_stars`
+
+    interp: str
+        interpolation scheme
+
+    dust: str
+        circumstellar dust prescription :func:`help_circumdust`
+
+    Mstars: str
+        dust on M stars :func:`help_circumdust`
+
+    Cstars: str
+        dust on C stars :func:`help_circumdust`
+
+    phot: str
+        photometric set for photometry values :func:`help_phot`
+
+    Returns
+    -------
+    d: dict
+        cgi arguments
+    """
+    d = __def_args__.copy()
+
+    # overwrite some parameters
+    if model is not None:
+        d["isoc_kind"] = map_models["%s" % model][0]
+        if "parsec" in model.lower():
+            d["output_evstage"] = 1
+        else:
+            d["output_evstage"] = 0
+
+    if carbon is not None:
+        d["kind_cspecmag"] = map_carbon_stars[carbon][0]
+
+    if interp is not None:
+        d["kind_interp"] = map_interp[interp]
+
+    if dust is not None:
+        d["dust_source"] = map_circum_Mstars[dust]
+
+    if Cstars is not None:
+        d["dust_sourceC"] = map_circum_Cstars[Cstars]
+
+    if Mstars is not None:
+        d["dust_sourceM"] = map_circum_Mstars[Mstars]
+
+    if phot is not None:
+        d["photsys_file"] = "tab_mag_odfnew/tab_mag_{0}.dat".format(phot)
+
+    for k, v in list(kwargs.items()):
+        if k in d:
+            d[k] = v
+    return d
+
+
+
+
 # Build up URL request
 # --------------------
 
@@ -220,8 +304,10 @@ def __get_url_args(
     for k, v in list(kwargs.items()):
         if k in d:
             d[k] = v
-
     return d
+
+
+
 
 
 class __CMD_Error_Parser(parser.HTMLParser):
@@ -428,7 +514,7 @@ def get_Z_isochrones(z0, z1, dz, age, ret_table=True, **kwargs):
 
 
 def get_t_isochrones(logt0, logt1, dlogt, metal, ret_table=True, **kwargs):
-    """ get a sequence of isochrones at constant Z
+    """ get a sequence of isochrones at constant Z, via ezpadova
 
     Parameters
     ----------
@@ -474,18 +560,21 @@ def get_t_isochrones(logt0, logt1, dlogt, metal, ret_table=True, **kwargs):
         if ret_table is set, return a eztable.Table object of the data
         else return the string content of the data
     """
-    d = __get_url_args(**kwargs)
-    d["isoc_val"] = 1
-    d["isoc_zeta0"] = metal
-    d["isoc_lage0"] = logt0
-    d["isoc_lage1"] = logt1
-    d["isoc_dlage"] = dlogt
 
-    r = __query_website(d)
+    # Prepare dictionary of parameters (and ranges) for padova query
+    d = get_ezpadova_args(**kwargs)
+
+    # Use ezpadava to... query padova! Eee-zed!
+    r = ezpadova.get_isochrones(logage=(logt0, logt1, dlogt),
+                                Z=(metal, metal, metal),
+                                kwargs=d)
+
+    # Convert pandas frame to astropy table, and return
     if ret_table is True:
-        return __convert_to_Table(r, d)
-    else:
+        r = astropy.table.Table.from_pandas(r)
         return r
+    else:
+        raise Exception('Currently only supports astropy table output')
 
 
 # Auto-update photometry list

--- a/beast/physicsmodel/stars/isochrone.py
+++ b/beast/physicsmodel/stars/isochrone.py
@@ -9,7 +9,9 @@ from numpy import interp
 from numpy import log10
 from scipy import interpolate
 from astropy import units
+import copy
 import tables
+import astropy.table
 from astropy.table import Table
 from numpy.lib import recfunctions
 
@@ -508,29 +510,29 @@ class PadovaWeb(Isochrone):
 
     def _clean_cols(self, iso_table):
         """clean column names, remove unnecessary columns"""
-        # Rename Columns
+
+        # If this is an astropy table, clean it using a different function
+        if not isinstance(iso_table, astropy.table.table.Table):
+            raise Exception('This now expects astropy tables, not simpletables')
+
+        # Rename Columns appropriately for parsec
         if self.modeltype == "parsec12s_r14":
+
             # PARSEC+COLIBRI Column Names
-            iso_table.add_column("logA", np.log10(iso_table["Age"][:]))
-            iso_table.add_column("logT", iso_table["logTe"][:])
-            iso_table.add_column("M_ini", iso_table["Mini"][:])
-            iso_table.add_column("M_act", iso_table["Mass"][:])
-            iso_table.add_column("stage", iso_table["label"][:])
-            iso_table.remove_columns(["Age", "logTe", "Mini", "Mass", "label"])
+            old_colnanes = ["logAge", "logTe", "Mini", "Mass", "label"]
+            new_colnames = ["logA", "logT", "M_ini", "M_act", "stage"]
+            iso_table.rename_columns(old_colnanes, new_colnames)
+
             # Remove age-specific Z, rename Zini as Z
             iso_table.remove_columns(["Z"])
-            iso_table.add_column("Z", iso_table["Zini"][:])
-            iso_table.remove_columns(["Zini"])
+            iso_table.rename_columns(["Zini"], ["Z"])
 
+        # Padova (Girardi10, Marigo08, etc), Old PARSEC Column Names
         else:
-            # Padova (Girardi10, Marigo08, etc), Old PARSEC Column Names
-            iso_table.add_column("logA", iso_table["logageyr"][:])
-            iso_table.add_column("logL", iso_table["logLLo"][:])
-            iso_table.add_column("logT", iso_table["logTe"][:])
-            iso_table.add_column("logg", iso_table["logG"][:])
-            iso_table.remove_columns(["logageyr", "logLLo", "logTe", "logG"])
+            old_colnanes = ["logageyr", "logLLo", "logTe", "logG"]
+            new_colnames = ["logA", "logL", "logT", "logg"]
 
-        # Remove phot columns and unnecessary properties
+        # List unwanted phot columns ,and unnecessary properties
         filternames = "U UX B BX V R I J H K L M".split()
         theorycols = [
             "C/O",
@@ -543,34 +545,17 @@ class PadovaWeb(Isochrone):
             "period0",
             "period1",
             "McoreTP",
-            "tau1m",
-        ]
-        # removing mass loss outputs
+            "tau1m"]
         theorycols += ["logMdot", "Mloss"]
         abundcols = "X Y Xc Xn Xo Cexcess".split()
-        drop = theorycols + abundcols + filternames + [s + "mag" for s in filternames]
-        # make sure columns exist
-        iso_table.remove_columns([x for x in drop if x in iso_table])
+        dropcols = theorycols + abundcols + filternames + [s + "mag" for s in filternames]
 
-        # polish the header
-        iso_table.setUnit("logA", "yr")
-        iso_table.setComment("logA", "Age")
-        iso_table.setUnit("logT", "K")
-        iso_table.setComment("logT", "Effective temperature")
-        iso_table.setUnit("logL", "Lsun")
-        iso_table.setComment("logL", "Luminosity")
-        iso_table.setUnit("M_ini", "Msun")
-        iso_table.setComment("M_ini", "Initial Mass")
-        iso_table.setUnit("M_act", "Msun")
-        iso_table.setComment("M_act", "Current Mass, M(t)")
-        iso_table.setUnit("logg", "cm/s**2")
-        iso_table.setComment("logg", "Surface gravity")
-        iso_table.setComment("stage", "Evolutionary Stage")
-        iso_table.setComment("Z", "Metallicity")
-        # iso_table.setUnit('logMdot', 'Msun/yr')
-        # iso_table.setComment('logMdot', 'Mass loss')
+        # make sure columns exist; if so, delete
+        iso_table.remove_columns([dropcol for dropcol in dropcols if dropcol in iso_table.colnames])
 
         return iso_table
+
+
 
     def _filter_iso_points(self, iso_table, filterPMS=False, filterBad=False):
         """ Filter bad points and PMS points
@@ -614,12 +599,14 @@ class PadovaWeb(Isochrone):
         tab: eztable.Table
             the table of isochrones
         """
+        # Handle Z if it's a single number
         if not hasattr(Z, "__iter__"):
             iso_table = parsec.get_t_isochrones(
                 max(6.0, logtmin), min(10.13, logtmax), dlogt, Z, model=self.modeltype
             )
+            iso_table.header = {}
             iso_table.header["NAME"] = "PadovaCMD Isochrones: " + self.modeltype
-            if "Z" not in iso_table:
+            if "Z" not in iso_table.colnames:
                 iso_table.add_column("Z", np.ones(iso_table.nrows) * Z)
 
             # rename cols, remove phot and other unnecessary cols
@@ -630,19 +617,19 @@ class PadovaWeb(Isochrone):
                 iso_table, filterPMS=self.filterPMS, filterBad=self.filterBad
             )
 
+        # Handle Z if it's a list of numbers, getting isochrones for each
+        # With ~~~#~~~ RECURSIVE RECURSION ~~~#~~~
         else:
             iso_table = self._get_t_isochrones(logtmin, logtmax, dlogt, Z[0])
+            iso_table.header = {}
             iso_table.header["NAME"] = "PadovaCMD Isochrones: " + self.modeltype
-
             if len(Z) > 1:
-                more = [
-                    self._get_t_isochrones(logtmin, logtmax, dlogt, Zk).data
-                    for Zk in Z[1:]
-                ]
-                iso_table.data = recfunctions.stack_arrays(
-                    [iso_table.data] + more, usemask=False, asrecarray=True
-                )
-
+                for Zk in Z[1:]:
+                    iso_table = astropy.table.vstack([iso_table,
+                                                      self._get_t_isochrones(logtmin,
+                                                                             logtmax,
+                                                                             dlogt,
+                                                                             Zk)])
         return iso_table
 
 


### PR DESCRIPTION
Padova CMD isochrones now acquired using the [ezpadova](https://github.com/mfouesneau/ezpadova) package of @mfouesneau, and passed as astropy tables to physicsmodel grid generation(not simpletables).

This fixes issue #833, in which we were no longer able to reliably create physicsmodels, due to the Padova CMD service usually returning empty table files. Whereas before isochrones were acquired via URL query to v3.1 of Padova CMD, now we use the [ezpadova](https://github.com/mfouesneau/ezpadova) package of @mfouesneau to query the newest version of CMD (currently v3.8). This A) works, and B) means there is one less independently-reinvented wheel in the BEAST for us to fix!