### PR TITLE
modified exec/eval commands in beast_settings.py for python 3.13 compatibility

### DIFF
--- a/beast/tools/beast_settings.py
+++ b/beast/tools/beast_settings.py
@@ -59,19 +59,20 @@ class beast_settings:
                 del input_data[i]
 
         # parse it into a dictionary
+        temp_dict = {}
         beast_params = {}
 
         for i in range(len(input_data)):
-            # execute imports
-            if "import " in input_data[i]:
-                exec(input_data[i])
+            line = input_data[i]
 
-            # extract parameter and value (as strings)
+            # execute imports
+            if "import " in line:
+                exec(line, temp_dict)
+
             else:
-                param = input_data[i].split("=")[0].strip()
-                # exec the string to get parameter values accessible
-                exec(input_data[i])
-                beast_params[param] = eval(param)
+                param = line.split("=")[0].strip()
+                exec(line, temp_dict)
+                beast_params[param] = temp_dict[param]
 
         # turn dictionary into attributes
         for key in beast_params:


### PR DESCRIPTION
The problem was in beast.tools.beast_settings.py, line 74, the bottom line of the pasted code:

    # parse it into a dictionary
    beast_params = {}

    for i in range(len(input_data)):
        # execute imports
        if "import " in input_data[i]:
            exec(input_data[i])

        # extract parameter and value (as strings)
        else:
            param = input_data[i].split("=")[0].strip()
            # exec the string to get parameter values accessible
            exec(input_data[i])
            beast_params[param] = eval(param)
            
exec/eval statements can't modify local variables anymore, so you have to read/write them into specific variables.

An updated version of the code:

    # parse it into a dictionary
    temp_dict = {} # empty dict for exec to write into
    beast_params = {}

    for i in range(len(input_data)):
        line = input_data[i]

        # execute imports
        if "import " in line:
            exec(line, temp_dict)

        else:
            param = line.split("=")[0].strip()
            exec(line, temp_dict)
            beast_params[param] = temp_dict[param]


Closes #837