### PR TITLE
vectorized IAU name generation in beast.fitting.fit.py. Process sped up by factor of 15.

### DIFF
--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -636,7 +636,7 @@ def Q_all_memory(
     )
     for e, obj in it:
         # calculate the full nD posterior
-        (sed) = obj
+        sed = obj
 
         cur_mask = sed == 0
         # need an alternate way to generate the mask as zeros can be
@@ -645,7 +645,7 @@ def Q_all_memory(
         cur_mask[:] = False
 
         if full_cov_mat:
-            (lnp, chi2) = N_covar_logLikelihood(
+            lnp, chi2 = N_covar_logLikelihood(
                 sed,
                 model_seds_with_bias,
                 ast_q_norm,
@@ -654,7 +654,7 @@ def Q_all_memory(
                 lnp_threshold=abs(threshold),
             )
         else:
-            (lnp, chi2) = N_logLikelihood_NM(
+            lnp, chi2 = N_logLikelihood_NM(
                 sed,
                 model_seds_with_bias,
                 ast_ivar,
@@ -868,29 +868,29 @@ def IAU_names_and_extra_info(obsdata, surveyname="PHAT", extraInfo=False):
     if go_name:
         # generate the IAU names
 
-	coords = ap_SkyCoord(
-	    obsdata.data[ra_str], 
-	    obsdata.data[dec_str], 
-	    unit=ap_units.degree, 
-	    frame="icrs",
-	    )
+        coords = ap_SkyCoord(
+            obsdata.data[ra_str],
+            obsdata.data[dec_str],
+            unit=ap_units.degree,
+            frame="icrs",
+        )
 
-	ra_string = coords.ra.to_string(
-	    unit=ap_units.hourangle, 
-	    sep="", 
-	    precision=4, 
-	    alwayssign=False, 
-	    pad=True,
-	    )
+        ra_string = coords.ra.to_string(
+            unit=ap_units.hourangle,
+            sep="",
+            precision=4,
+            alwayssign=False,
+            pad=True,
+        )
 
-	dec_string = coords.dec.to_string(
-	    sep="", 
-	    precision=3, 
-	    alwayssign=True, 
-	    pad=True,
-	    )
+        dec_string = coords.dec.to_string(
+            sep="",
+            precision=3,
+            alwayssign=True,
+            pad=True,
+        )
 
-	r["Name"] = surveyname + " J" + ra_string + dec_string
+        r["Name"] = surveyname + " J" + ra_string + dec_string
 
         # other useful information
         r["RA"] = obsdata.data[ra_str]
@@ -899,7 +899,7 @@ def IAU_names_and_extra_info(obsdata, surveyname="PHAT", extraInfo=False):
             r["field"] = obsdata.data["field"]
             r["inside_brick"] = obsdata.data["inside_brick"]
             r["inside_chipgap"] = obsdata.data["inside_chipgap"]
-    
+
     else:
         r["Name"] = ["noname" for x in range(len(obsdata))]
 

--- a/beast/fitting/fit.py
+++ b/beast/fitting/fit.py
@@ -867,34 +867,39 @@ def IAU_names_and_extra_info(obsdata, surveyname="PHAT", extraInfo=False):
 
     if go_name:
         # generate the IAU names
-        _tnames = []
-        for i in range(len(obsdata)):
-            c = ap_SkyCoord(
-                ra=obsdata.data[ra_str][i] * ap_units.degree,
-                dec=obsdata.data[dec_str][i] * ap_units.degree,
-                frame="icrs",
-            )
-            _tnames.append(
-                surveyname
-                + " J"
-                + c.ra.to_string(
-                    unit=ap_units.hourangle,
-                    sep="",
-                    precision=4,
-                    alwayssign=False,
-                    pad=True,
-                )
-                + c.dec.to_string(sep="", precision=3, alwayssign=True, pad=True)
-            )
-            r["Name"] = _tnames
 
-            # other useful information
-            r["RA"] = obsdata.data[ra_str]
-            r["DEC"] = obsdata.data[dec_str]
-            if extraInfo:
-                r["field"] = obsdata.data["field"]
-                r["inside_brick"] = obsdata.data["inside_brick"]
-                r["inside_chipgap"] = obsdata.data["inside_chipgap"]
+	coords = ap_SkyCoord(
+	    obsdata.data[ra_str], 
+	    obsdata.data[dec_str], 
+	    unit=ap_units.degree, 
+	    frame="icrs",
+	    )
+
+	ra_string = coords.ra.to_string(
+	    unit=ap_units.hourangle, 
+	    sep="", 
+	    precision=4, 
+	    alwayssign=False, 
+	    pad=True,
+	    )
+
+	dec_string = coords.dec.to_string(
+	    sep="", 
+	    precision=3, 
+	    alwayssign=True, 
+	    pad=True,
+	    )
+
+	r["Name"] = surveyname + " J" + ra_string + dec_string
+
+        # other useful information
+        r["RA"] = obsdata.data[ra_str]
+        r["DEC"] = obsdata.data[dec_str]
+        if extraInfo:
+            r["field"] = obsdata.data["field"]
+            r["inside_brick"] = obsdata.data["inside_brick"]
+            r["inside_chipgap"] = obsdata.data["inside_chipgap"]
+    
     else:
         r["Name"] = ["noname" for x in range(len(obsdata))]
 


### PR DESCRIPTION
I was working on some custom functions to merge catalogs and noticed a small bug in beast.fitting.fit.IAU_names_and_extra_info():

    if go_name:
        # generate the IAU names
        _tnames = []
        for i in range(len(obsdata)):
            c = ap_SkyCoord(
                ra=obsdata.data[ra_str][i] * ap_units.degree,
                dec=obsdata.data[dec_str][i] * ap_units.degree,
                frame="icrs",
            )
            _tnames.append(
                surveyname
                + " J"
                + c.ra.to_string(
                    unit=ap_units.hourangle,
                    sep="",
                    precision=4,
                    alwayssign=False,
                    pad=True,
                )
                + c.dec.to_string(sep="", precision=3, alwayssign=True, pad=True)
            )
            r["Name"] = _tnames

            # other useful information
            r["RA"] = obsdata.data[ra_str]
            r["DEC"] = obsdata.data[dec_str]
            if extraInfo:
                r["field"] = obsdata.data["field"]
                r["inside_brick"] = obsdata.data["inside_brick"]
                r["inside_chipgap"] = obsdata.data["inside_chipgap"]
    else:
        r["Name"] = ["noname" for x in range(len(obsdata))]

The bottom nine lines in the if statement are indented one too many times, so the dictionary called r is written to at each iteration in this for loop.

This could be fixed by just back-indenting these lines so that they'd only be written at the end. However, vectorizing this is straightforward, so the new version looks like:

    if go_name:
        # generate the IAU names

	coords = ap_SkyCoord(
	    obsdata.data[ra_str], 
	    obsdata.data[dec_str], 
	    unit=ap_units.degree, 
	    frame="icrs",
	    )

	ra_string = coords.ra.to_string(
	    unit=ap_units.hourangle, 
	    sep="", 
	    precision=4, 
	    alwayssign=False, 
	    pad=True,
	    )

	dec_string = coords.dec.to_string(
	    sep="", 
	    precision=3, 
	    alwayssign=True, 
	    pad=True,
	    )

	r["Name"] = surveyname + " J" + ra_string + dec_string

        # other useful information
        r["RA"] = obsdata.data[ra_str]
        r["DEC"] = obsdata.data[dec_str]
        if extraInfo:
            r["field"] = obsdata.data["field"]
            r["inside_brick"] = obsdata.data["inside_brick"]
            r["inside_chipgap"] = obsdata.data["inside_chipgap"]
    
    else:
        r["Name"] = ["noname" for x in range(len(obsdata))]


I checked this with a catalog of ~470,000 stars. The original version took ~75 seconds. The new version took less than 5. Not a huge difference in the grand scheme of things, but theres one less for loop in the BEAST now.