### PR TITLE
Fix mixed unit error between angstroms and wavenumbers in `extinction_extension.py`

### DIFF
--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -85,6 +85,9 @@ class F19_D03_extension(F19):
         ValueError
            Input x values outside of defined range
         """
+        # Ensure x has units; if it's a raw array, default it to Angstroms
+        if not hasattr(x, "unit"):
+            x = x * u.Angstrom
         # If it's already inverse microns, use it directly; otherwise, convert it
         if x.unit == u.micron**-1:
             x_um_inv = x
@@ -206,6 +209,9 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         ValueError
            Input x values outside of defined range
         """
+        # Ensure x has units; if it's a raw array, default it to Angstroms
+        if not hasattr(x, "unit"):
+            x = x * u.Angstrom
         # If it's already inverse microns, use it directly; otherwise, convert it
         if x.unit == u.micron**-1:
             x_um_inv = x

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -73,7 +73,7 @@ class F19_D03_extension(F19):
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
-           internally wavelengths in angstrom are used
+           internally wavenubmers in inverse micron are used
 
         Returns
         -------
@@ -85,7 +85,7 @@ class F19_D03_extension(F19):
         ValueError
            Input x values outside of defined range
         """
-        # Ensure x has units; if it's a raw array, default it to Angstroms
+        # Ensure x has units; if it's a raw array, default it to inverse microns
         if not hasattr(x, "unit"):
             x = x * u.micron**-1
         # If it's already inverse microns, use it directly; otherwise, convert it
@@ -93,7 +93,7 @@ class F19_D03_extension(F19):
             x_um_inv = x
         elif x.unit == u.Angstrom:
             x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
-
+        
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 
@@ -118,7 +118,7 @@ class F19_D03_extension(F19):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_f19 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
-        fmod = super().evaluate(x.value[gvals_f19], Rv)
+        fmod = super().evaluate(x_um_inv.value[gvals_f19], Rv)
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)
@@ -197,7 +197,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
-           internally wavelengths in angstrom are used
+           internally wavenumbers in inverse micron are used
 
         Returns
         -------
@@ -209,7 +209,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         ValueError
            Input x values outside of defined range
         """
-        # Ensure x has units; if it's a raw array, default it to Angstroms
+        # Ensure x has units; if it's a raw array, default it to inverse microns
         if not hasattr(x, "unit"):
             x = x * u.micron**-1
         # If it's already inverse microns, use it directly; otherwise, convert it
@@ -224,7 +224,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_g03 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
-        fmod = super().evaluate(x.value[gvals_g03])
+        fmod = super().evaluate(x_um_inv.value[gvals_g03])
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -88,11 +88,7 @@ class F19_D03_extension(F19):
         # Ensure x has units; if it's a raw array, default it to inverse microns
         if not hasattr(x, "unit"):
             x = x * u.micron**-1
-        # If it's already inverse microns, use it directly; otherwise, convert it
-        if x.unit == u.micron**-1:
-            x_um_inv = x
-        elif x.unit == u.Angstrom:
-            x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
 
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
@@ -212,11 +208,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         # Ensure x has units; if it's a raw array, default it to inverse microns
         if not hasattr(x, "unit"):
             x = x * u.micron**-1
-        # If it's already inverse microns, use it directly; otherwise, convert it
-        if x.unit == u.micron**-1:
-            x_um_inv = x
-        elif x.unit == u.Angstrom:
-            x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
 
         # compute the dust grain model
         dmodel = WD01(modelname="SMCBar")

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -73,7 +73,7 @@ class F19_D03_extension(F19):
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
-           internally wavenubmers in inverse micron are used
+           internally wavenumbers in inverse micron are used
 
         Returns
         -------

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -87,7 +87,7 @@ class F19_D03_extension(F19):
         """
         # Ensure x has units; if it's a raw array, default it to Angstroms
         if not hasattr(x, "unit"):
-            x = x * u.Angstrom
+            x = x * u.micron**-1
         # If it's already inverse microns, use it directly; otherwise, convert it
         if x.unit == u.micron**-1:
             x_um_inv = x
@@ -211,7 +211,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         """
         # Ensure x has units; if it's a raw array, default it to Angstroms
         if not hasattr(x, "unit"):
-            x = x * u.Angstrom
+            x = x * u.micron**-1
         # If it's already inverse microns, use it directly; otherwise, convert it
         if x.unit == u.micron**-1:
             x_um_inv = x

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -1,5 +1,6 @@
 import copy
 import numpy as np
+import astropy.units as u
 
 from dust_extinction.parameter_averages import F19
 from dust_extinction.averages import G03_SMCBar
@@ -61,7 +62,7 @@ class F19_D03_extension(F19):
 
     # update the wavelength range (in micron^-1)
     x_range = [0.3, 1.0 / 0.01]
-
+    
     def evaluate(self, x, Rv):
         """
         F19_D03_extension function
@@ -72,7 +73,7 @@ class F19_D03_extension(F19):
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
-           internally wavenumbers are used
+           internally wavelengths in angstrom are used
 
         Returns
         -------
@@ -84,6 +85,9 @@ class F19_D03_extension(F19):
         ValueError
            Input x values outside of defined range
         """
+        # convert wavelength to wavenumber
+        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 
@@ -103,11 +107,11 @@ class F19_D03_extension(F19):
             d2mod = D03(modelname="MWRV55")
 
         # interpolate to get the model extinction for the input Rv value
-        dslope = (d2mod(x) - d1mod(x)) / (d2rv - d1rv)
-        dmod = d1mod(x) + dslope * (Rv - d1rv)
+        dslope = (d2mod(x_um_inv) - d1mod(x_um_inv)) / (d2rv - d1rv)
+        dmod = d1mod(x_um_inv) + dslope * (Rv - d1rv)
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
-        gvals_f19 = (x > super().x_range[0]) & (x < super().x_range[1])
+        gvals_f19 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
         fmod = super().evaluate(x[gvals_f19], Rv)
 
         # now merge the two smoothly
@@ -115,9 +119,9 @@ class F19_D03_extension(F19):
         outmod[gvals_f19] = fmod
 
         merge_range = np.array([1.0 / 0.1675, super().x_range[1]])
-        gvals_merge = (x > merge_range[0]) & (x < merge_range[1])
+        gvals_merge = (x_um_inv.value > merge_range[0]) & (x_um_inv.value < merge_range[1])
         # have weights be zero at the min merge and 1 at the max merge
-        weights = (x[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
+        weights = (x_um_inv.value[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
         outmod[gvals_merge] = (1.0 - weights) * outmod[gvals_merge] + weights * dmod[
             gvals_merge
         ]
@@ -187,7 +191,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
-           internally wavenumbers are used
+           internally wavelengths in angstrom are used
 
         Returns
         -------
@@ -199,12 +203,15 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         ValueError
            Input x values outside of defined range
         """
+        # convert wavelength to wavenumber
+        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+
         # compute the dust grain model
         dmodel = WD01(modelname="SMCBar")
-        dmod = dmodel(x)
+        dmod = dmodel(x_um_inv)
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
-        gvals_g03 = (x > super().x_range[0]) & (x < super().x_range[1])
+        gvals_g03 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
         fmod = super().evaluate(x[gvals_g03])
 
         # now merge the two smoothly
@@ -212,9 +219,9 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         outmod[gvals_g03] = fmod
 
         merge_range = np.array([1.0 / 0.1675, super().x_range[1]])
-        gvals_merge = (x > merge_range[0]) & (x < merge_range[1])
+        gvals_merge = (x_um_inv.value > merge_range[0]) & (x_um_inv.value < merge_range[1])
         # have weights be zero at the min merge and 1 at the max merge
-        weights = (x[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
+        weights = (x_um_inv.value[gvals_merge] - merge_range[0]) / (merge_range[1] - merge_range[0])
         outmod[gvals_merge] = (1.0 - weights) * outmod[gvals_merge] + weights * dmod[
             gvals_merge
         ]

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -62,7 +62,7 @@ class F19_D03_extension(F19):
 
     # update the wavelength range (in micron^-1)
     x_range = [0.3, 1.0 / 0.01]
-    
+
     def evaluate(self, x, Rv):
         """
         F19_D03_extension function
@@ -85,8 +85,11 @@ class F19_D03_extension(F19):
         ValueError
            Input x values outside of defined range
         """
-        # convert wavelength to wavenumber
-        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+        # If it's already inverse microns, use it directly; otherwise, convert it
+        if x.unit == u.micron**-1:
+            x_um_inv = x
+        elif x.unit == u.Angstrom:
+            x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
 
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
@@ -203,8 +206,11 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
         ValueError
            Input x values outside of defined range
         """
-        # convert wavelength to wavenumber
-        x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
+        # If it's already inverse microns, use it directly; otherwise, convert it
+        if x.unit == u.micron**-1:
+            x_um_inv = x
+        elif x.unit == u.Angstrom:
+            x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
 
         # compute the dust grain model
         dmodel = WD01(modelname="SMCBar")

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -118,7 +118,7 @@ class F19_D03_extension(F19):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_f19 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
-        fmod = super().evaluate(x[gvals_f19], Rv)
+        fmod = super().evaluate(x.value[gvals_f19], Rv)
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)
@@ -224,7 +224,7 @@ class G03_SMCBar_WD01_extension(G03_SMCBar):
 
         # compute the F19 curve for the input Rv over the F19 defined wavelength range
         gvals_g03 = (x_um_inv.value > super().x_range[0]) & (x_um_inv.value < super().x_range[1])
-        fmod = super().evaluate(x[gvals_g03])
+        fmod = super().evaluate(x.value[gvals_g03])
 
         # now merge the two smoothly
         outmod = copy.copy(dmod)

--- a/beast/physicsmodel/dust/extinction_extension.py
+++ b/beast/physicsmodel/dust/extinction_extension.py
@@ -93,7 +93,7 @@ class F19_D03_extension(F19):
             x_um_inv = x
         elif x.unit == u.Angstrom:
             x_um_inv = x.to(u.micron**-1, equivalencies=u.spectral())
-        
+
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 

--- a/beast/physicsmodel/dust/tests/test_extinction_extension.py
+++ b/beast/physicsmodel/dust/tests/test_extinction_extension.py
@@ -26,7 +26,7 @@ def test_F19_D03_ext():
         cmod_vals = cmod(x)
         dmod_vals = dmod(x)
 
-    gvals_f19 = (x.value > emod.x_range[0]) & (x.value < emod.x_range[1])
+    gvals_f19 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SpectralUnitsWarning)
@@ -34,13 +34,13 @@ def test_F19_D03_ext():
 
     # test that the combined model as the grain model values below 912 A
     # below the merge wavelengths
-    gvals_ion = x.value > 1.0 / 0.0912
+    gvals_ion = x > 1.0 / 0.0912 / u.micron
     np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
 
     # test that the combine dmodel has the F19 values above 1700 A
     # above the merge wavelengths
-    gvals_amerge = (x.value < 1.0 / 0.1700) & (x.value > emod.x_range[0])
-    gvals_amerge_f19 = x.value[gvals_f19] < 1.0 / 0.1700
+    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
+    gvals_amerge_f19 = x[gvals_f19] < 1.0 / 0.1700 / u.micron
     np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_f19])
 
 
@@ -56,7 +56,7 @@ def test_G03_SMCBar_WD01_ext():
         cmod_vals = cmod(x)
         dmod_vals = dmod(x)
 
-    gvals_g03 = (x.value > emod.x_range[0]) & (x.value < emod.x_range[1])
+    gvals_g03 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SpectralUnitsWarning)
@@ -64,11 +64,11 @@ def test_G03_SMCBar_WD01_ext():
 
     # test that the combined model as the grain model values below 912 A
     # below the merge wavelengths
-    gvals_ion = x.value > 1.0 / 0.0912
+    gvals_ion = x > 1.0 / 0.0912 / u.micron
     np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
 
     # test that the combine dmodel has the F19 values above 1700 A
     # above the merge wavelengths
-    gvals_amerge = (x.value < 1.0 / 0.1700) & (x.value > emod.x_range[0])
-    gvals_amerge_g03 = x.value[gvals_g03] < 1.0 / 0.1700
+    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
+    gvals_amerge_g03 = x[gvals_g03] < 1.0 / 0.1700 / u.micron
     np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_g03])

--- a/beast/physicsmodel/dust/tests/test_extinction_extension.py
+++ b/beast/physicsmodel/dust/tests/test_extinction_extension.py
@@ -26,7 +26,7 @@ def test_F19_D03_ext():
         cmod_vals = cmod(x)
         dmod_vals = dmod(x)
 
-    gvals_f19 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
+    gvals_f19 = (x.value > emod.x_range[0]) & (x.value < emod.x_range[1])
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SpectralUnitsWarning)
@@ -34,13 +34,13 @@ def test_F19_D03_ext():
 
     # test that the combined model as the grain model values below 912 A
     # below the merge wavelengths
-    gvals_ion = x > 1.0 / 0.0912 / u.micron
+    gvals_ion = x.value > 1.0 / 0.0912
     np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
 
     # test that the combine dmodel has the F19 values above 1700 A
     # above the merge wavelengths
-    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
-    gvals_amerge_f19 = x[gvals_f19] < 1.0 / 0.1700 / u.micron
+    gvals_amerge = (x.value < 1.0 / 0.1700) & (x.value > emod.x_range[0])
+    gvals_amerge_f19 = x.value[gvals_f19] < 1.0 / 0.1700
     np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_f19])
 
 
@@ -56,7 +56,7 @@ def test_G03_SMCBar_WD01_ext():
         cmod_vals = cmod(x)
         dmod_vals = dmod(x)
 
-    gvals_g03 = (x > emod.x_range[0] / u.micron) & (x < emod.x_range[1] / u.micron)
+    gvals_g03 = (x.value > emod.x_range[0]) & (x.value < emod.x_range[1])
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SpectralUnitsWarning)
@@ -64,11 +64,11 @@ def test_G03_SMCBar_WD01_ext():
 
     # test that the combined model as the grain model values below 912 A
     # below the merge wavelengths
-    gvals_ion = x > 1.0 / 0.0912 / u.micron
+    gvals_ion = x.value > 1.0 / 0.0912
     np.testing.assert_allclose(cmod_vals[gvals_ion], dmod_vals[gvals_ion])
 
     # test that the combine dmodel has the F19 values above 1700 A
     # above the merge wavelengths
-    gvals_amerge = (x < 1.0 / 0.1700 / u.micron) & (x > emod.x_range[0] / u.micron)
-    gvals_amerge_g03 = x[gvals_g03] < 1.0 / 0.1700 / u.micron
+    gvals_amerge = (x.value < 1.0 / 0.1700) & (x.value > emod.x_range[0])
+    gvals_amerge_g03 = x.value[gvals_g03] < 1.0 / 0.1700
     np.testing.assert_allclose(cmod_vals[gvals_amerge], emod_vals[gvals_amerge_g03])


### PR DESCRIPTION
The bug was caused by two main issues within the `extinction_extension.py`: (1) a mixed usage of angstroms and wavenumbers, and (2) inconsistent input formatting requirements, where certain steps expected raw numerical values while others required values paired with Astropy units. I am opening this PR to resolve these mismatches. This PR addresses the issue #863. 