### PR TITLE
Support generalized extinction models (`G23`) by decoupling legacy fAs grid constraints

### DIFF
--- a/beast/physicsmodel/creategrid.py
+++ b/beast/physicsmodel/creategrid.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 
 from beast.physicsmodel.stars import stellib
 from beast.physicsmodel.grid import SpectralGrid, SEDGrid
-from beast.physicsmodel.grid_and_prior_weights import compute_av_rv_fA_prior_weights
+from beast.physicsmodel.grid_and_prior_weights import compute_av_rv_fA_prior_weights, compute_av_rv_prior_weights
 
 from beast.physicsmodel.grid_weights import compute_grid_weights
 
@@ -318,7 +318,8 @@ def make_extinguished_grid(
     # get the min/max R(V) values necessary for the grid point definition
     min_Rv = min(rvs)
     max_Rv = max(rvs)
-    Rv_B = extLaw.BLaw.Rv  # R(V) for the SMC-like extinction curve
+    if hasattr(extLaw, "BLaw"):
+        Rv_B = extLaw.BLaw.Rv  # R(V) for the SMC-like extinction curve
 
     # Create the sampling mesh
     # ========================
@@ -411,6 +412,16 @@ def make_extinguished_grid(
                 cols["f_A"][N0 * count : N0 * (count + 1)] = f_A
                 cols["Rv_A"][N0 * count : N0 * (count + 1)] = Rv_MW
 
+                # compute the dust weights
+                dust_prior_weight = compute_av_rv_fA_prior_weights(
+                    Av,
+                    Rv,
+                    f_A,
+                    g0.grid["distance"].data,
+                    av_prior_model=av_prior_model,
+                    rv_prior_model=rv_prior_model,
+                    fA_prior_model=fA_prior_model,
+                )
             else:
                 Av, Rv = pt
                 r = g0.applyExtinctionLaw(extLaw, Av=Av, Rv=Rv, inplace=False)
@@ -427,16 +438,14 @@ def make_extinguished_grid(
                 cols["Av"][N0 * count : N0 * (count + 1)] = Av
                 cols["Rv"][N0 * count : N0 * (count + 1)] = Rv
 
-            # compute the dust weights
-            dust_prior_weight = compute_av_rv_fA_prior_weights(
-                Av,
-                Rv,
-                f_A,
-                g0.grid["distance"].data,
-                av_prior_model=av_prior_model,
-                rv_prior_model=rv_prior_model,
-                fA_prior_model=fA_prior_model,
-            )
+                # compute the dust weights
+                dust_prior_weight = compute_av_rv_prior_weights(
+                    Av,
+                    Rv,
+                    g0.grid["distance"].data,
+                    av_prior_model=av_prior_model,
+                    rv_prior_model=rv_prior_model,
+                )
 
             # get new attributes if exist
             for key in list(temp_results.grid.keys()):

--- a/beast/physicsmodel/creategrid.py
+++ b/beast/physicsmodel/creategrid.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 
 from beast.physicsmodel.stars import stellib
 from beast.physicsmodel.grid import SpectralGrid, SEDGrid
-from beast.physicsmodel.grid_and_prior_weights import compute_av_rv_fA_prior_weights, compute_av_rv_prior_weights
+from beast.physicsmodel.grid_and_prior_weights import compute_av_rv_fA_prior_weights
 
 from beast.physicsmodel.grid_weights import compute_grid_weights
 
@@ -411,18 +411,8 @@ def make_extinguished_grid(
                 cols["Rv"][N0 * count : N0 * (count + 1)] = Rv
                 cols["f_A"][N0 * count : N0 * (count + 1)] = f_A
                 cols["Rv_A"][N0 * count : N0 * (count + 1)] = Rv_MW
-
-                # compute the dust weights
-                dust_prior_weight = compute_av_rv_fA_prior_weights(
-                    Av,
-                    Rv,
-                    f_A,
-                    g0.grid["distance"].data,
-                    av_prior_model=av_prior_model,
-                    rv_prior_model=rv_prior_model,
-                    fA_prior_model=fA_prior_model,
-                )
             else:
+                f_A = fAs
                 Av, Rv = pt
                 r = g0.applyExtinctionLaw(extLaw, Av=Av, Rv=Rv, inplace=False)
 
@@ -438,14 +428,16 @@ def make_extinguished_grid(
                 cols["Av"][N0 * count : N0 * (count + 1)] = Av
                 cols["Rv"][N0 * count : N0 * (count + 1)] = Rv
 
-                # compute the dust weights
-                dust_prior_weight = compute_av_rv_prior_weights(
-                    Av,
-                    Rv,
-                    g0.grid["distance"].data,
-                    av_prior_model=av_prior_model,
-                    rv_prior_model=rv_prior_model,
-                )
+            # compute the dust weights
+            dust_prior_weight = compute_av_rv_fA_prior_weights(
+                Av,
+                Rv,
+                f_A,
+                g0.grid["distance"].data,
+                av_prior_model=av_prior_model,
+                rv_prior_model=rv_prior_model,
+                fA_prior_model=fA_prior_model,
+            )
 
             # get new attributes if exist
             for key in list(temp_results.grid.keys()):

--- a/beast/physicsmodel/creategrid.py
+++ b/beast/physicsmodel/creategrid.py
@@ -493,11 +493,12 @@ def make_extinguished_grid(
             cols["weight"][gvals] *= rav_gweight
             cols["grid_weight"][gvals] *= rav_gweight
 
-        fA_grid_weights = compute_grid_weights(fAs)
-        for cfA, cfA_gweight in zip(fAs, fA_grid_weights):
-            gvals = cols["f_A"] == cfA
-            cols["weight"][gvals] *= cfA_gweight
-            cols["grid_weight"][gvals] *= cfA_gweight
+        if with_fA:
+            fA_grid_weights = compute_grid_weights(fAs)
+            for cfA, cfA_gweight in zip(fAs, fA_grid_weights):
+                gvals = cols["f_A"] == cfA
+                cols["weight"][gvals] *= cfA_gweight
+                cols["grid_weight"][gvals] *= cfA_gweight
 
         # free the memory of temp_results
         # del temp_results

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -29,7 +29,6 @@ __all__ = [
     "compute_age_mass_metallicity_weights",
     "compute_distance_age_mass_metallicity_weights",
     "compute_av_rv_fA_prior_weights",
-    "compute_av_rv_prior_weights",
 ]
 
 
@@ -349,51 +348,6 @@ def compute_av_rv_fA_prior_weights(
             f_A_weights = fA_prior(f_A)
 
     dust_prior = av_weights * rv_weights * f_A_weights
-
-    # normalize to control for numerical issues
-    # dust_prior /= np.max(dust_prior)
-
-    return dust_prior
-
-
-def compute_av_rv_prior_weights(
-    Av,
-    Rv,
-    dists,
-    av_prior_model={"name": "flat"},
-    rv_prior_model={"name": "flat"},
-):
-    """
-    Computes the av and rv grid and prior weights
-    on the BEAST model spectra grid
-    Grid and prior weight columns updated by multiplying by the
-    existing weights
-
-    Parameters
-    ----------
-    Av : vector
-        A(V) values
-    Rv : vector
-        R(V) values
-    dists : vector
-        distance values
-    av_prior_model : dict
-        dict including prior model name and parameters
-    rv_prior_model : dict
-        dict including prior model name and parameters
-    """
-    av_prior = PriorDustModel(av_prior_model)
-    rv_prior = PriorDustModel(rv_prior_model)
-    if av_prior_model["name"] == "step":
-        av_weights = av_prior(np.full((len(dists)), Av), y=dists)
-    else:
-        av_weights = av_prior(Av)
-    if rv_prior_model["name"] == "step":
-        rv_weights = rv_prior(np.full((len(dists)), Rv), y=dists)
-    else:
-        rv_weights = rv_prior(Rv)
-
-    dust_prior = av_weights * rv_weights
 
     # normalize to control for numerical issues
     # dust_prior /= np.max(dust_prior)

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -29,6 +29,7 @@ __all__ = [
     "compute_age_mass_metallicity_weights",
     "compute_distance_age_mass_metallicity_weights",
     "compute_av_rv_fA_prior_weights",
+    "compute_av_rv_prior_weights",
 ]
 
 
@@ -345,6 +346,51 @@ def compute_av_rv_fA_prior_weights(
         f_A_weights = fA_prior(f_A)
 
     dust_prior = av_weights * rv_weights * f_A_weights
+
+    # normalize to control for numerical issues
+    # dust_prior /= np.max(dust_prior)
+
+    return dust_prior
+
+
+def compute_av_rv_prior_weights(
+    Av,
+    Rv,
+    dists,
+    av_prior_model={"name": "flat"},
+    rv_prior_model={"name": "flat"},
+):
+    """
+    Computes the av and rv grid and prior weights
+    on the BEAST model spectra grid
+    Grid and prior weight columns updated by multiplying by the
+    existing weights
+
+    Parameters
+    ----------
+    Av : vector
+        A(V) values
+    Rv : vector
+        R(V) values
+    dists : vector
+        distance values
+    av_prior_model : dict
+        dict including prior model name and parameters
+    rv_prior_model : dict
+        dict including prior model name and parameters
+    """
+    av_prior = PriorDustModel(av_prior_model)
+    rv_prior = PriorDustModel(rv_prior_model)
+    if av_prior_model["name"] == "step":
+        av_weights = av_prior(np.full((len(dists)), Av), y=dists)
+    else:
+        av_weights = av_prior(Av)
+    if rv_prior_model["name"] == "step":
+        rv_weights = rv_prior(np.full((len(dists)), Rv), y=dists)
+    else:
+        rv_weights = rv_prior(Rv)
+
+    dust_prior = av_weights * rv_weights
 
     # normalize to control for numerical issues
     # dust_prior /= np.max(dust_prior)

--- a/beast/physicsmodel/grid_and_prior_weights.py
+++ b/beast/physicsmodel/grid_and_prior_weights.py
@@ -304,7 +304,7 @@ def compute_av_rv_fA_prior_weights(
     dists,
     av_prior_model={"name": "flat"},
     rv_prior_model={"name": "flat"},
-    fA_prior_model={"name": "flat"},
+    fA_prior_model=None,
 ):
     """
     Computes the av, rv, f_A grid and prior weights
@@ -318,20 +318,19 @@ def compute_av_rv_fA_prior_weights(
         A(V) values
     Rv : vector
         R(V) values
-    f_A : vector
-        f_A values
+    f_A : vector or None
+        f_A values (None for monolithic models like G23)
     dists : vector
         distance values
     av_prior_model : dict
         dict including prior model name and parameters
     rv_prior_model : dict
         dict including prior model name and parameters
-    fA_prior_model :dict
+    fA_prior_model : dict or None, optional
         dict including prior model name and parameters
     """
     av_prior = PriorDustModel(av_prior_model)
     rv_prior = PriorDustModel(rv_prior_model)
-    fA_prior = PriorDustModel(fA_prior_model)
     if av_prior_model["name"] == "step":
         av_weights = av_prior(np.full((len(dists)), Av), y=dists)
     else:
@@ -340,10 +339,14 @@ def compute_av_rv_fA_prior_weights(
         rv_weights = rv_prior(np.full((len(dists)), Rv), y=dists)
     else:
         rv_weights = rv_prior(Rv)
-    if fA_prior_model["name"] == "step":
-        f_A_weights = fA_prior(np.full((len(dists)), f_A), y=dists)
+    if f_A is None or fA_prior_model is None:
+        f_A_weights = 1.0
     else:
-        f_A_weights = fA_prior(f_A)
+        fA_prior = PriorDustModel(fA_prior_model)
+        if fA_prior_model["name"] == "step":
+            f_A_weights = fA_prior(np.full((len(dists)), f_A), y=dists)
+        else:
+            f_A_weights = fA_prior(f_A)
 
     dust_prior = av_weights * rv_weights * f_A_weights
 

--- a/beast/tools/tests/test_verify_beast_settings.py
+++ b/beast/tools/tests/test_verify_beast_settings.py
@@ -27,6 +27,7 @@ class settings_mock_nofA(settings_mock):
     """Mock beast_settings w/ fAs=None"""
 
     fAs = None
+    fA_prior_model = None
 
 
 class settings_mock_allowwarn(settings_mock_nofA):

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -205,13 +205,17 @@ def verify_input_format(settings):
     param_format = param_format + params_extra_format
     parameters_limits = parameters_base_limits + params_extra_limits
 
+    dust_model = settings.extLaw.name
     for i, param_ in enumerate(parameters):
-        verify_one_input_format(
-            param_,
-            parameters_names[i],
-            param_format[i],
-            parameters_limits[i],
-        )
+        if parameters_names[i] == "fAs" and "G23" in dust_model:
+            pass
+        else:   
+            verify_one_input_format(
+                param_,
+                parameters_names[i],
+                param_format[i],
+                parameters_limits[i],
+            )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -205,11 +205,10 @@ def verify_input_format(settings):
     param_format = param_format + params_extra_format
     parameters_limits = parameters_base_limits + params_extra_limits
 
-    dust_model = settings.extLaw.name
     for i, param_ in enumerate(parameters):
-        if parameters_names[i] == "fAs" and "G23" in dust_model:
+        if parameters_names[i] == "fAs" and param_ == None:
             pass
-        else:   
+        else:
             verify_one_input_format(
                 param_,
                 parameters_names[i],

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -206,8 +206,11 @@ def verify_input_format(settings):
     parameters_limits = parameters_base_limits + params_extra_limits
 
     for i, param_ in enumerate(parameters):
-        if parameters_names[i] == "fAs" and param_ is None:
-            pass
+        if parameters_names[i] == "fAs":
+            ext_law = getattr(settings, "extLaw", "") or ""
+            law_name = getattr(ext_law, "name", ext_law)
+            if isinstance(law_name, str) and "G23" in law_name:
+                continue
         else:
             verify_one_input_format(
                 param_,

--- a/beast/tools/verify_beast_settings.py
+++ b/beast/tools/verify_beast_settings.py
@@ -206,7 +206,7 @@ def verify_input_format(settings):
     parameters_limits = parameters_base_limits + params_extra_limits
 
     for i, param_ in enumerate(parameters):
-        if parameters_names[i] == "fAs" and param_ == None:
+        if parameters_names[i] == "fAs" and param_ is None:
             pass
         else:
             verify_one_input_format(


### PR DESCRIPTION
This PR updates the BEAST parameter verification and physics model generation pipeline to accommodate generalized monolithic dust extinction frameworks, specifically `G23` model, which are critical for stretching extinction curves reliably into the JWST/NIRCam Long-Wavelength (LW) regimes (>3.33μm).

Historically, the codebase tightly coupled all grid validation and matrix calculations to legacy two-component mixture models (which rigidly require an fAs parameter grid triplet and separate ALaw/BLaw sub-classes). This PR breaks those hardcoded assumptions, introducing defensive programming practices that allow the BEAST to dynamically scale between classic mixture models and monolithic/generalized dust laws.

This PR addresses the second part of the Issue #866.