### PR TITLE
Accept explicit distance grids in `make_spectral_grid`

### DIFF
--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -226,14 +226,24 @@ def make_spectral_grid(
 
         # Construct the distances array. Turn single value into
         # 1-element list if single distance is given.
+        # A list of >3 values is used as an explicit (possibly non-uniform)
+        # distance grid, e.g. for variable-resolution distance sampling.
+        # NOTE: an explicit grid of exactly 3 values cannot be expressed
+        # (3 values are always interpreted as min, max, step) -- pad with a
+        # duplicate-free 4th value in that case.
         _distance = np.atleast_1d(distance)
         if len(_distance) == 3:
             mindist, maxdist, stepdist = _distance
             distances = np.arange(mindist, maxdist + stepdist, stepdist)
         elif len(_distance) == 1:
             distances = np.array(_distance)
+        elif len(_distance) > 3:
+            distances = np.sort(np.array(_distance, dtype=float))
         else:
-            raise ValueError("distance needs to be (min, max, step) or single number")
+            raise ValueError(
+                "distance needs to be (min, max, step), a single number, "
+                "or an explicit list of >3 values"
+            )
 
         # calculate the distances in pc
         if distance_unit == units.mag:

--- a/beast/physicsmodel/model_grid.py
+++ b/beast/physicsmodel/model_grid.py
@@ -165,7 +165,10 @@ def make_spectral_grid(
 
     distance: float or list of float
         distances at which models should be shifted, specified as a
-        single number or as [min, max, step]
+        single number, as [min, max, step], or as an explicit list of
+        more than three values giving a (possibly non-uniform) grid.
+        An explicit grid of exactly three values cannot be expressed,
+        since three values are always read as [min, max, step].
 
         0 means absolute magnitude.
 

--- a/docs/beast_setup.rst
+++ b/docs/beast_setup.rst
@@ -51,7 +51,10 @@ General Parameters
 * ``n_subgrid``: number of sub-grids to use (1 means no subgrids), useful for when
   the physics model grid is too large to read into memory.
 * ``velocity`` : heliocentric velocity of a galaxy (e.g., -300 km/s for M31).
-* ``distances``: distance grid range parameters. ``[min, max, step]``, or ``[fixed number]``.
+* ``distances``: distance grid range parameters. ``[min, max, step]``, ``[fixed number]``,
+  or an explicit list of more than three values for a non-uniform grid (e.g. sampling
+  concentrated near the target distance). A list of exactly three values is always
+  interpreted as ``[min, max, step]``.
 * ``distance_unit``: specify magnitude (``units.mag``) or a length unit.
 * ``distance_prior_model``: specify a prior for distance parameter.
 


### PR DESCRIPTION
Closes #868

### What this does

Allows `distance` to be given as an explicit list of more than three values,
which is then used directly (sorted) as the distance grid. This enables
non-uniform, variable-resolution distance sampling — for example a grid whose
density follows the expected line-of-sight distribution of a galaxy.

### Backward compatibility

Unchanged for every currently valid input:

| input | behaviour |
|---|---|
| `60000` (scalar) | single distance, as before |
| `[min, max, step]` (3 values) | uniform `np.arange` grid, as before |
| `>3 values` | **new** — used as the explicit grid, sorted |
| `2 values` | `ValueError`, as before (message expanded) |

A three-element list is still always read as `[min, max, step]`, so an explicit
grid of exactly three distances cannot be expressed. That ambiguity is inherent
in the existing API; it is called out in the docstring and the docs rather than
resolved, to avoid changing what existing settings files mean.

### Also included

- `make_spectral_grid` docstring updated for the new form
- `docs/beast_setup.rst` entry for `distances` updated to match

### Context

Came out of building a shared physics-model grid for two SMC fields, where a
Gaussian-density distance grid gave the same effective resolution in 47 planes
instead of 66.
